### PR TITLE
feat(theme): added textcolor options in table.row theme

### DIFF
--- a/packages/core/src/components/Table/Body/Row/Row.styled.tsx
+++ b/packages/core/src/components/Table/Body/Row/Row.styled.tsx
@@ -13,6 +13,8 @@ const cardStyle = css<StyledProps>`
     & > * {
         background-color: ${({ theme, isSelected, disabled }) =>
             theme.table.row.bgColor[disabled ? 'disabled' : isSelected ? 'selected' : 'even']};
+        color: ${({ theme, isSelected, disabled }) =>
+            theme.table.row.textColor[disabled ? 'disabled' : isSelected ? 'selected' : 'even']};;
     }
 
     &&& > * {
@@ -62,6 +64,8 @@ const normalStyle = css<StyledProps>`
         & > * {
             background-color: ${({ theme, isSelected, disabled }) =>
                 theme.table.row.bgColor[disabled ? 'disabled' : isSelected ? 'selected' : 'odd']};
+            color: ${({ theme, isSelected, disabled }) =>
+                theme.table.row.textColor[disabled ? 'disabled' : isSelected ? 'selected' : 'odd']};;
         }
     }
 
@@ -70,6 +74,8 @@ const normalStyle = css<StyledProps>`
         & > * {
             background-color: ${({ theme, isSelected, disabled }) =>
                 theme.table.row.bgColor[disabled ? 'disabled' : isSelected ? 'selected' : 'even']};
+            color: ${({ theme, isSelected, disabled }) =>
+                theme.table.row.textColor[disabled ? 'disabled' : isSelected ? 'selected' : 'even']};;
         }
     }
 

--- a/packages/core/src/components/Table/Body/Row/__snapshots__/Row.test.tsx.snap
+++ b/packages/core/src/components/Table/Body/Row/__snapshots__/Row.test.tsx.snap
@@ -29,11 +29,13 @@ exports[`Row should render NoResult properly 1`] = `
 .c0:nth-child(odd),
 .c0:nth-child(odd) > * {
   background-color: #F7F8F9;
+  color: #13181D;
 }
 
 .c0:nth-child(even),
 .c0:nth-child(even) > * {
   background-color: #ffffff;
+  color: #13181D;
 }
 
 .c0:not(:last-child) {
@@ -88,6 +90,7 @@ exports[`Row should render NoResult with Card design also 1`] = `
 .c0,
 .c0 > * {
   background-color: #ffffff;
+  color: #13181D;
 }
 
 .c0.c0.c0 > *:first-child,
@@ -156,11 +159,13 @@ exports[`Row should render row properly 1`] = `
 .c0:nth-child(odd),
 .c0:nth-child(odd) > * {
   background-color: #F7F8F9;
+  color: #13181D;
 }
 
 .c0:nth-child(even),
 .c0:nth-child(even) > * {
   background-color: #ffffff;
+  color: #13181D;
 }
 
 .c0:not(:last-child) {

--- a/packages/core/src/components/Table/docs/Table.stories.mdx
+++ b/packages/core/src/components/Table/docs/Table.stories.mdx
@@ -46,6 +46,7 @@ Simple `Table` component to show set of data.
                         isRowSelectable={boolean('Is row selectable', true)}
                         isRowExpandable={boolean('Is row expandable', true)}
                         rowSelectionDisableKey="disabled"
+                        rowClickDisableKey="disabled"
                         size={select('Size', ['S', 'M', 'L'], 'M')}
                         showRowWithCardStyle={boolean('Show Row With Card Style', false)}
                         expandedRowComponent={ExpandedRowComponent}

--- a/packages/theme/src/core/table/index.ts
+++ b/packages/theme/src/core/table/index.ts
@@ -12,7 +12,13 @@ const table: TableTheme = {
             selected: colors.blue[200],
             disabled: colors.grey[100]
         },
-        selectedBorderColor: colors.blue[500]
+        selectedBorderColor: colors.blue[500],
+        textColor: {
+            odd: colors.black,
+            even: colors.black,
+            selected: colors.black,
+            disabled: colors.black
+        }
     },
     titleRow: {
         bgColor: {

--- a/packages/theme/src/core/table/types.ts
+++ b/packages/theme/src/core/table/types.ts
@@ -10,6 +10,12 @@ export interface TableTheme {
             selected: string;
         };
         selectedBorderColor: string;
+        textColor: {
+            odd: string;
+            even: string;
+            disabled: string;
+            selected: string;
+        };
     };
     titleRow: {
         bgColor: {


### PR DESCRIPTION
affects: @medly-components/core, @medly-components/theme

ISSUES CLOSED: #157

### PR Checklist

Please check if your PR fulfills the following requirements:

-   [ ] Tests for the changes have been added (for bug fixes / features)
-   [ ] Docs have been added / updated (for bug fixes / features)

### PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

-   [ ] Bugfix
-   [x] Feature
-   [ ] Code style update (formatting, local variables)
-   [ ] Refactoring (no functional changes, no api changes)
-   [ ] Build related changes
-   [ ] CI related changes
-   [ ] Performance improves
-   [ ] Adding missing tests
-   [ ] Documentation content changes
-   [ ] Other... Please describe:

### What is the current behavior?

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

## Fixes #157 

### What is the new behavior?
Added textColor in Table.Row theme

### Does this PR introduce a breaking change?

-   [ ] Yes
-   [X] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

### Additional context

Add any other context or screenshots about the feature pr here.
