### PR TITLE
Fix(core): add props and WithStyle type to Modal Header and Content

### DIFF
--- a/packages/core/src/components/Modal/types.ts
+++ b/packages/core/src/components/Modal/types.ts
@@ -1,7 +1,5 @@
 import { HTMLProps, WithStyle, WithThemeProp } from '@medly-components/utils';
 import { ModalActionUserProps } from './Actions/types';
-import { Props as ModalContentProps } from './Content/types';
-import { Props as ModalHeaderProps } from './Header/types';
 import { Props as ModalPopupProps } from './Popup/types';
 
 export interface Props extends HTMLProps<HTMLDivElement>, WithThemeProp {
@@ -19,7 +17,7 @@ export interface Props extends HTMLProps<HTMLDivElement>, WithThemeProp {
 
 export interface ModalStaticProps {
     Popup?: React.FC<ModalPopupProps> & WithStyle;
-    Header?: React.FC<ModalHeaderProps> & WithStyle;
-    Content?: React.FC<ModalContentProps> & WithStyle;
+    Header?: React.FC & WithStyle;
+    Content?: React.FC & WithStyle;
     Actions?: React.FC<ModalActionUserProps> & WithStyle;
 }

--- a/packages/core/src/components/Modal/types.ts
+++ b/packages/core/src/components/Modal/types.ts
@@ -1,5 +1,7 @@
 import { HTMLProps, WithStyle, WithThemeProp } from '@medly-components/utils';
 import { ModalActionUserProps } from './Actions/types';
+import { Props as ModalContentProps } from './Content/types';
+import { Props as ModalHeaderProps } from './Header/types';
 import { Props as ModalPopupProps } from './Popup/types';
 
 export interface Props extends HTMLProps<HTMLDivElement>, WithThemeProp {
@@ -17,7 +19,7 @@ export interface Props extends HTMLProps<HTMLDivElement>, WithThemeProp {
 
 export interface ModalStaticProps {
     Popup?: React.FC<ModalPopupProps> & WithStyle;
-    Header?: React.FC;
-    Content?: React.FC;
-    Actions?: React.FC<ModalActionUserProps>;
+    Header?: React.FC<ModalHeaderProps> & WithStyle;
+    Content?: React.FC<ModalContentProps> & WithStyle;
+    Actions?: React.FC<ModalActionUserProps> & WithStyle;
 }


### PR DESCRIPTION
affects: @medly-components/core

### PR Checklist

Please check if your PR fulfills the following requirements:

-   [x] Tests for the changes have been added (for bug fixes / features)
-   [x] Docs have been added / updated (for bug fixes / features)

### PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

-   [x] Bugfix
-   [ ] Feature
-   [ ] Code style update (formatting, local variables)
-   [ ] Refactoring (no functional changes, no api changes)
-   [ ] Build related changes
-   [ ] CI related changes
-   [ ] Performance improves
-   [ ] Adding missing tests
-   [ ] Documentation content changes
-   [ ] Other... Please describe:

### What is the current behavior?
`Modal.Actions`, `Modal.Content`, and `Modal.Header` aren't defined `WithStyle` in the main `Modal` file where they are declared as static props. This prevents users of the library from passing style rules into the components.

## Fixes # (issue)
Added `WithStyle` to their type definitions.

### What is the new behavior?
Users will be able to pass style rules to these static components

### Does this PR introduce a breaking change?

-   [ ] Yes
-   [x] No
