### PR TITLE
fix(core): set width to 100% for Custom components in table cells to …

### DIFF
--- a/packages/core/src/components/Table/Body/Cell/Styled/CustomComponentWrapper.styled.tsx
+++ b/packages/core/src/components/Table/Body/Cell/Styled/CustomComponentWrapper.styled.tsx
@@ -1,3 +1,5 @@
 import { styled } from '@medly-components/utils';
 
-export const CustomComponentWrapper = styled('div')``;
+export const CustomComponentWrapper = styled('div')`
+    width: 100%;
+`;


### PR DESCRIPTION
…show ellipsis correctly

affects: @medly-components/core

set width to 100% for Custom components in table cells to show ellipsis correctly

### PR Checklist

Please check if your PR fulfills the following requirements:

-   [ ] Tests for the changes have been added (for bug fixes / features)
-   [ ] Docs have been added / updated (for bug fixes / features)

### PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

-   [x] Bugfix
-   [ ] Feature
-   [ ] Code style update (formatting, local variables)
-   [ ] Refactoring (no functional changes, no api changes)
-   [ ] Build related changes
-   [ ] CI related changes
-   [ ] Performance improves
-   [ ] Adding missing tests
-   [ ] Documentation content changes
-   [ ] Other... Please describe:

### What is the current behavior?

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

## Fixes # (issue)

### What is the new behavior?

### Does this PR introduce a breaking change?

-   [ ] Yes
-   [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

### Additional context

Add any other context or screenshots about the feature pr here.
