### PR TITLE
style(core): added zero opacity to the table’s hidden div

### DIFF
--- a/packages/core/src/components/DateRangePicker/__snapshots__/DateRangePicker.test.tsx.snap
+++ b/packages/core/src/components/DateRangePicker/__snapshots__/DateRangePicker.test.tsx.snap
@@ -22836,7 +22836,7 @@ exports[`DateRangePicker should render properly 1`] = `
               </button>
             </div>
             <div
-              class="c35"
+              class="c30"
             >
               <button
                 class="c31"
@@ -22851,7 +22851,7 @@ exports[`DateRangePicker should render properly 1`] = `
               </button>
             </div>
             <div
-              class="c30"
+              class="c35"
             >
               <button
                 class="c31"
@@ -25188,7 +25188,7 @@ exports[`DateRangePicker should render properly with single month 1`] = `
               </button>
             </div>
             <div
-              class="c40"
+              class="c35"
             >
               <button
                 class="c36"
@@ -25203,7 +25203,7 @@ exports[`DateRangePicker should render properly with single month 1`] = `
               </button>
             </div>
             <div
-              class="c35"
+              class="c40"
             >
               <button
                 class="c36"

--- a/packages/core/src/components/Table/Table.styled.tsx
+++ b/packages/core/src/components/Table/Table.styled.tsx
@@ -4,6 +4,7 @@ import { TableStyledProps } from './types';
 export const HiddenDiv = styled('div')`
     position: absolute;
     left: -1000px;
+    opacity: 0;
     ${({ theme }) => getFontStyle({ theme, fontVariant: 'body2' })}
 `;
 

--- a/packages/core/src/components/Table/__snapshots__/Table.test.tsx.snap
+++ b/packages/core/src/components/Table/__snapshots__/Table.test.tsx.snap
@@ -115,6 +115,7 @@ exports[`Table component pagination should call onPageChange prop on click on an
 .c0 {
   position: absolute;
   left: -1000px;
+  opacity: 0;
   font-size: 1.4rem;
   font-weight: 400;
   -webkit-letter-spacing: 0rem;
@@ -1624,6 +1625,7 @@ exports[`Table component should render properly 1`] = `
 .c0 {
   position: absolute;
   left: -1000px;
+  opacity: 0;
   font-size: 1.4rem;
   font-weight: 400;
   -webkit-letter-spacing: 0rem;


### PR DESCRIPTION
affects: @medly-components/core

There’s a hidden div used internally to calculate the length of the column’s largest text to provide
proper column expanding feature. This div was visible on the viewport when the text was longer. In
this fix, we added opacity to the hidden div, so that it is not visible in the viewport.

### PR Checklist

Please check if your PR fulfills the following requirements:

-   [ ] Tests for the changes have been added (for bug fixes / features)
-   [ ] Docs have been added / updated (for bug fixes / features)

### PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

-   [ ] Bugfix
-   [ ] Feature
-   [x] Code style update (formatting, local variables)
-   [ ] Refactoring (no functional changes, no api changes)
-   [ ] Build related changes
-   [ ] CI related changes
-   [ ] Performance improves
-   [ ] Adding missing tests
-   [ ] Documentation content changes
-   [ ] Other... Please describe:

### What is the current behavior?

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

## Fixes # (issue)

### What is the new behavior?

### Does this PR introduce a breaking change?

-   [ ] Yes
-   [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

### Additional context

Add any other context or screenshots about the feature pr here.
