### PR TITLE
fix: update multiselect chip to disable clear button when multiselect is disabled

### DIFF
--- a/packages/core/src/components/MultiSelect/InputSuffix/InputSuffix.tsx
+++ b/packages/core/src/components/MultiSelect/InputSuffix/InputSuffix.tsx
@@ -10,7 +10,9 @@ export const InputSuffix: FC<InputSuffixProps> = React.memo(props => {
 
     return (
         <InputSuffixStyled id={id} size={size}>
-            {optionsCount > 0 && <Chip id={`${id}-chip`} label={optionsCount} state={state} size={size} {...restProps} />}
+            {optionsCount > 0 && (
+                <Chip id={`${id}-chip`} label={optionsCount} state={state} size={size} disabled={disabled} {...restProps} />
+            )}
             <ChevronDownIcon size={size} />
         </InputSuffixStyled>
     );


### PR DESCRIPTION
affects: @medly-components/core

ISSUES CLOSED: #223

### PR Checklist

Please check if your PR fulfills the following requirements:

-   [x] Tests for the changes have been added (for bug fixes / features)
-   [ ] Docs have been added / updated (for bug fixes / features)

### PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

-   [x] Bugfix
-   [ ] Feature
-   [ ] Code style update (formatting, local variables)
-   [ ] Refactoring (no functional changes, no api changes)
-   [ ] Build related changes
-   [ ] CI related changes
-   [ ] Performance improves
-   [ ] Adding missing tests
-   [ ] Documentation content changes
-   [ ] Other... Please describe:

### What is the current behavior?

#223 

## Fixes #223 

### What is the new behavior?

When the disabled prop is passed to the multi-select component, the `onClear` function no longer fires when the clear icon is clicked

### Does this PR introduce a breaking change?

-   [ ] Yes
-   [ ] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

### Additional context

Add any other context or screenshots about the feature pr here.
