### PR TITLE
Add showCalendarIcon to DatePicker

### DIFF
--- a/packages/core/src/components/DatePicker/DatePicker.test.tsx
+++ b/packages/core/src/components/DatePicker/DatePicker.test.tsx
@@ -88,6 +88,28 @@ describe('DatePicker component', () => {
         });
     });
 
+    describe('calendar icon', () => {
+        it('should show calendar icon when showCalendarIcon prop is true', () => {
+            const { container } = render(
+                <DatePicker showCalendarIcon id="dob" value={new Date(2020, 0, 1)} displayFormat="MM/dd/yyyy" onChange={jest.fn()} />
+            );
+            expect(container.querySelector('#dob-calendar-icon')).toBeVisible();
+        });
+
+        it('should not show calendar icon when showCalendarIcon prop is true', () => {
+            const { container } = render(
+                <DatePicker
+                    showCalendarIcon={false}
+                    id="dob"
+                    value={new Date(2020, 0, 1)}
+                    displayFormat="MM/dd/yyyy"
+                    onChange={jest.fn()}
+                />
+            );
+            expect(container.querySelector('#dob-calendar-icon')).toBeNull();
+        });
+    });
+
     describe('on text change', () => {
         it('should change call onChange with expected date', () => {
             const mockOnChange = jest.fn(),

--- a/packages/core/src/components/DatePicker/DatePicker.tsx
+++ b/packages/core/src/components/DatePicker/DatePicker.tsx
@@ -24,6 +24,7 @@ export const DatePicker: React.FC<DatePickerProps> & WithStyle = React.memo(
                 popoverPlacement,
                 minSelectableDate,
                 maxSelectableDate,
+                showCalendarIcon,
                 ...restProps
             } = props,
             id = props.id || props.label.toLowerCase().replace(/\s/g, '') || 'medly-datepicker', // TODO:- Remove static ID concept to avoid dup ID
@@ -130,7 +131,7 @@ export const DatePicker: React.FC<DatePickerProps> & WithStyle = React.memo(
             mobileProps = { ...sharedProps, type: 'date' },
             desktopProps = {
                 ...sharedProps,
-                suffix: suffixEl,
+                ...(showCalendarIcon && { suffix: suffixEl }),
                 pattern: datePickerPattern[displayFormat],
                 mask: displayFormat.replace(new RegExp('\\/|\\-', 'g'), ' $& ').toUpperCase()
             };
@@ -170,7 +171,8 @@ DatePicker.defaultProps = {
     fullWidth: false,
     minSelectableDate: new Date(1901, 0, 1),
     maxSelectableDate: new Date(2100, 11, 1),
-    popoverPlacement: 'bottom-start'
+    popoverPlacement: 'bottom-start',
+    showCalendarIcon: true
 };
 DatePicker.displayName = 'DatePicker';
 DatePicker.Style = Wrapper;

--- a/packages/core/src/components/DatePicker/types.ts
+++ b/packages/core/src/components/DatePicker/types.ts
@@ -48,6 +48,8 @@ export interface DatePickerProps extends Omit<HTMLProps<HTMLInputElement>, 'valu
     errorText?: string;
     /** Popover placement */
     popoverPlacement?: Placement;
+    /** Show the calendar icon */
+    showCalendarIcon?: boolean;
 }
 
 export interface StyleProps extends Pick<DatePickerProps, 'variant' | 'fullWidth' | 'disabled' | 'minWidth' | 'size'> {

--- a/packages/core/src/components/DateRangePicker/__snapshots__/DateRangePicker.test.tsx.snap
+++ b/packages/core/src/components/DateRangePicker/__snapshots__/DateRangePicker.test.tsx.snap
@@ -21865,10 +21865,6 @@ exports[`DateRangePicker should render properly 1`] = `
   width: 7.2rem;
 }
 
-.c29 > button {
-  border-color: #C7D0D8;
-}
-
 .c29:hover > button:not(:disabled) {
   border-color: #126AFA;
 }
@@ -21899,6 +21895,10 @@ exports[`DateRangePicker should render properly 1`] = `
 .c32::before {
   right: -1.8rem;
   width: 7.2rem;
+}
+
+.c32 > button {
+  border-color: #C7D0D8;
 }
 
 .c32:hover > button:not(:disabled) {
@@ -22562,7 +22562,7 @@ exports[`DateRangePicker should render properly 1`] = `
               </button>
             </div>
             <div
-              class="c32"
+              class="c29"
             >
               <button
                 class="c30"
@@ -22577,7 +22577,7 @@ exports[`DateRangePicker should render properly 1`] = `
               </button>
             </div>
             <div
-              class="c32"
+              class="c29"
             >
               <button
                 class="c30"
@@ -22592,7 +22592,7 @@ exports[`DateRangePicker should render properly 1`] = `
               </button>
             </div>
             <div
-              class="c32"
+              class="c29"
             >
               <button
                 class="c30"
@@ -22637,7 +22637,7 @@ exports[`DateRangePicker should render properly 1`] = `
               </button>
             </div>
             <div
-              class="c32"
+              class="c29"
             >
               <button
                 class="c30"
@@ -22652,7 +22652,7 @@ exports[`DateRangePicker should render properly 1`] = `
               </button>
             </div>
             <div
-              class="c32"
+              class="c29"
             >
               <button
                 class="c30"
@@ -22667,7 +22667,7 @@ exports[`DateRangePicker should render properly 1`] = `
               </button>
             </div>
             <div
-              class="c32"
+              class="c29"
             >
               <button
                 class="c30"
@@ -22682,7 +22682,7 @@ exports[`DateRangePicker should render properly 1`] = `
               </button>
             </div>
             <div
-              class="c32"
+              class="c29"
             >
               <button
                 class="c30"
@@ -22697,7 +22697,7 @@ exports[`DateRangePicker should render properly 1`] = `
               </button>
             </div>
             <div
-              class="c32"
+              class="c29"
             >
               <button
                 class="c30"
@@ -22742,7 +22742,7 @@ exports[`DateRangePicker should render properly 1`] = `
               </button>
             </div>
             <div
-              class="c32"
+              class="c29"
             >
               <button
                 class="c30"
@@ -22757,7 +22757,7 @@ exports[`DateRangePicker should render properly 1`] = `
               </button>
             </div>
             <div
-              class="c32"
+              class="c29"
             >
               <button
                 class="c30"
@@ -22772,7 +22772,7 @@ exports[`DateRangePicker should render properly 1`] = `
               </button>
             </div>
             <div
-              class="c32"
+              class="c29"
             >
               <button
                 class="c30"
@@ -22787,7 +22787,7 @@ exports[`DateRangePicker should render properly 1`] = `
               </button>
             </div>
             <div
-              class="c32"
+              class="c29"
             >
               <button
                 class="c30"
@@ -22802,7 +22802,7 @@ exports[`DateRangePicker should render properly 1`] = `
               </button>
             </div>
             <div
-              class="c32"
+              class="c29"
             >
               <button
                 class="c30"
@@ -22847,7 +22847,7 @@ exports[`DateRangePicker should render properly 1`] = `
               </button>
             </div>
             <div
-              class="c32"
+              class="c29"
             >
               <button
                 class="c30"
@@ -22862,7 +22862,7 @@ exports[`DateRangePicker should render properly 1`] = `
               </button>
             </div>
             <div
-              class="c32"
+              class="c29"
             >
               <button
                 class="c30"
@@ -22877,7 +22877,7 @@ exports[`DateRangePicker should render properly 1`] = `
               </button>
             </div>
             <div
-              class="c32"
+              class="c29"
             >
               <button
                 class="c30"
@@ -22892,7 +22892,7 @@ exports[`DateRangePicker should render properly 1`] = `
               </button>
             </div>
             <div
-              class="c32"
+              class="c29"
             >
               <button
                 class="c30"
@@ -22907,7 +22907,7 @@ exports[`DateRangePicker should render properly 1`] = `
               </button>
             </div>
             <div
-              class="c32"
+              class="c29"
             >
               <button
                 class="c30"
@@ -23024,7 +23024,7 @@ exports[`DateRangePicker should render properly 1`] = `
               class="c28"
             />
             <div
-              class="c32"
+              class="c29"
             >
               <button
                 class="c30"
@@ -23039,7 +23039,7 @@ exports[`DateRangePicker should render properly 1`] = `
               </button>
             </div>
             <div
-              class="c32"
+              class="c29"
             >
               <button
                 class="c30"
@@ -23054,7 +23054,7 @@ exports[`DateRangePicker should render properly 1`] = `
               </button>
             </div>
             <div
-              class="c32"
+              class="c29"
             >
               <button
                 class="c30"
@@ -23069,7 +23069,7 @@ exports[`DateRangePicker should render properly 1`] = `
               </button>
             </div>
             <div
-              class="c32"
+              class="c29"
             >
               <button
                 class="c30"
@@ -23084,7 +23084,7 @@ exports[`DateRangePicker should render properly 1`] = `
               </button>
             </div>
             <div
-              class="c32"
+              class="c29"
             >
               <button
                 class="c30"
@@ -23129,7 +23129,7 @@ exports[`DateRangePicker should render properly 1`] = `
               </button>
             </div>
             <div
-              class="c32"
+              class="c29"
             >
               <button
                 class="c30"
@@ -23144,7 +23144,7 @@ exports[`DateRangePicker should render properly 1`] = `
               </button>
             </div>
             <div
-              class="c32"
+              class="c29"
             >
               <button
                 class="c30"
@@ -23159,7 +23159,7 @@ exports[`DateRangePicker should render properly 1`] = `
               </button>
             </div>
             <div
-              class="c32"
+              class="c29"
             >
               <button
                 class="c30"
@@ -23174,7 +23174,7 @@ exports[`DateRangePicker should render properly 1`] = `
               </button>
             </div>
             <div
-              class="c32"
+              class="c29"
             >
               <button
                 class="c30"
@@ -23189,7 +23189,7 @@ exports[`DateRangePicker should render properly 1`] = `
               </button>
             </div>
             <div
-              class="c32"
+              class="c29"
             >
               <button
                 class="c30"
@@ -23234,7 +23234,7 @@ exports[`DateRangePicker should render properly 1`] = `
               </button>
             </div>
             <div
-              class="c32"
+              class="c29"
             >
               <button
                 class="c30"
@@ -23249,7 +23249,7 @@ exports[`DateRangePicker should render properly 1`] = `
               </button>
             </div>
             <div
-              class="c32"
+              class="c29"
             >
               <button
                 class="c30"
@@ -23264,7 +23264,7 @@ exports[`DateRangePicker should render properly 1`] = `
               </button>
             </div>
             <div
-              class="c32"
+              class="c29"
             >
               <button
                 class="c30"
@@ -23279,7 +23279,7 @@ exports[`DateRangePicker should render properly 1`] = `
               </button>
             </div>
             <div
-              class="c32"
+              class="c29"
             >
               <button
                 class="c30"
@@ -23294,7 +23294,7 @@ exports[`DateRangePicker should render properly 1`] = `
               </button>
             </div>
             <div
-              class="c32"
+              class="c29"
             >
               <button
                 class="c30"
@@ -23339,7 +23339,7 @@ exports[`DateRangePicker should render properly 1`] = `
               </button>
             </div>
             <div
-              class="c32"
+              class="c29"
             >
               <button
                 class="c30"
@@ -23354,7 +23354,7 @@ exports[`DateRangePicker should render properly 1`] = `
               </button>
             </div>
             <div
-              class="c32"
+              class="c29"
             >
               <button
                 class="c30"
@@ -23369,7 +23369,7 @@ exports[`DateRangePicker should render properly 1`] = `
               </button>
             </div>
             <div
-              class="c32"
+              class="c29"
             >
               <button
                 class="c30"
@@ -23384,7 +23384,7 @@ exports[`DateRangePicker should render properly 1`] = `
               </button>
             </div>
             <div
-              class="c32"
+              class="c29"
             >
               <button
                 class="c30"
@@ -23399,7 +23399,7 @@ exports[`DateRangePicker should render properly 1`] = `
               </button>
             </div>
             <div
-              class="c32"
+              class="c29"
             >
               <button
                 class="c30"
@@ -23444,7 +23444,7 @@ exports[`DateRangePicker should render properly 1`] = `
               </button>
             </div>
             <div
-              class="c32"
+              class="c29"
             >
               <button
                 class="c30"
@@ -23459,7 +23459,7 @@ exports[`DateRangePicker should render properly 1`] = `
               </button>
             </div>
             <div
-              class="c32"
+              class="c29"
             >
               <button
                 class="c30"
@@ -23474,7 +23474,7 @@ exports[`DateRangePicker should render properly 1`] = `
               </button>
             </div>
             <div
-              class="c32"
+              class="c29"
             >
               <button
                 class="c30"
@@ -24142,10 +24142,6 @@ exports[`DateRangePicker should render properly with single month 1`] = `
   width: 7.2rem;
 }
 
-.c34 > button {
-  border-color: #C7D0D8;
-}
-
 .c34:hover > button:not(:disabled) {
   border-color: #126AFA;
 }
@@ -24176,6 +24172,10 @@ exports[`DateRangePicker should render properly with single month 1`] = `
 .c37::before {
   right: -1.8rem;
   width: 7.2rem;
+}
+
+.c37 > button {
+  border-color: #C7D0D8;
 }
 
 .c37:hover > button:not(:disabled) {
@@ -24897,7 +24897,7 @@ exports[`DateRangePicker should render properly with single month 1`] = `
               </button>
             </div>
             <div
-              class="c37"
+              class="c34"
             >
               <button
                 class="c35"
@@ -24912,7 +24912,7 @@ exports[`DateRangePicker should render properly with single month 1`] = `
               </button>
             </div>
             <div
-              class="c37"
+              class="c34"
             >
               <button
                 class="c35"
@@ -24927,7 +24927,7 @@ exports[`DateRangePicker should render properly with single month 1`] = `
               </button>
             </div>
             <div
-              class="c37"
+              class="c34"
             >
               <button
                 class="c35"
@@ -24972,7 +24972,7 @@ exports[`DateRangePicker should render properly with single month 1`] = `
               </button>
             </div>
             <div
-              class="c37"
+              class="c34"
             >
               <button
                 class="c35"
@@ -24987,7 +24987,7 @@ exports[`DateRangePicker should render properly with single month 1`] = `
               </button>
             </div>
             <div
-              class="c37"
+              class="c34"
             >
               <button
                 class="c35"
@@ -25002,7 +25002,7 @@ exports[`DateRangePicker should render properly with single month 1`] = `
               </button>
             </div>
             <div
-              class="c37"
+              class="c34"
             >
               <button
                 class="c35"
@@ -25017,7 +25017,7 @@ exports[`DateRangePicker should render properly with single month 1`] = `
               </button>
             </div>
             <div
-              class="c37"
+              class="c34"
             >
               <button
                 class="c35"
@@ -25032,7 +25032,7 @@ exports[`DateRangePicker should render properly with single month 1`] = `
               </button>
             </div>
             <div
-              class="c37"
+              class="c34"
             >
               <button
                 class="c35"
@@ -25077,7 +25077,7 @@ exports[`DateRangePicker should render properly with single month 1`] = `
               </button>
             </div>
             <div
-              class="c37"
+              class="c34"
             >
               <button
                 class="c35"
@@ -25092,7 +25092,7 @@ exports[`DateRangePicker should render properly with single month 1`] = `
               </button>
             </div>
             <div
-              class="c37"
+              class="c34"
             >
               <button
                 class="c35"
@@ -25107,7 +25107,7 @@ exports[`DateRangePicker should render properly with single month 1`] = `
               </button>
             </div>
             <div
-              class="c37"
+              class="c34"
             >
               <button
                 class="c35"
@@ -25122,7 +25122,7 @@ exports[`DateRangePicker should render properly with single month 1`] = `
               </button>
             </div>
             <div
-              class="c37"
+              class="c34"
             >
               <button
                 class="c35"
@@ -25137,7 +25137,7 @@ exports[`DateRangePicker should render properly with single month 1`] = `
               </button>
             </div>
             <div
-              class="c37"
+              class="c34"
             >
               <button
                 class="c35"
@@ -25182,7 +25182,7 @@ exports[`DateRangePicker should render properly with single month 1`] = `
               </button>
             </div>
             <div
-              class="c37"
+              class="c34"
             >
               <button
                 class="c35"
@@ -25197,7 +25197,7 @@ exports[`DateRangePicker should render properly with single month 1`] = `
               </button>
             </div>
             <div
-              class="c37"
+              class="c34"
             >
               <button
                 class="c35"
@@ -25212,7 +25212,7 @@ exports[`DateRangePicker should render properly with single month 1`] = `
               </button>
             </div>
             <div
-              class="c37"
+              class="c34"
             >
               <button
                 class="c35"
@@ -25227,7 +25227,7 @@ exports[`DateRangePicker should render properly with single month 1`] = `
               </button>
             </div>
             <div
-              class="c37"
+              class="c34"
             >
               <button
                 class="c35"
@@ -25242,7 +25242,7 @@ exports[`DateRangePicker should render properly with single month 1`] = `
               </button>
             </div>
             <div
-              class="c37"
+              class="c34"
             >
               <button
                 class="c35"

--- a/packages/core/src/components/DateRangePicker/__snapshots__/DateRangePicker.test.tsx.snap
+++ b/packages/core/src/components/DateRangePicker/__snapshots__/DateRangePicker.test.tsx.snap
@@ -22547,7 +22547,7 @@ exports[`DateRangePicker should render properly 1`] = `
               </button>
             </div>
             <div
-              class="c32"
+              class="c29"
             >
               <button
                 class="c30"
@@ -22562,7 +22562,7 @@ exports[`DateRangePicker should render properly 1`] = `
               </button>
             </div>
             <div
-              class="c29"
+              class="c32"
             >
               <button
                 class="c30"
@@ -24882,7 +24882,7 @@ exports[`DateRangePicker should render properly with single month 1`] = `
               </button>
             </div>
             <div
-              class="c37"
+              class="c34"
             >
               <button
                 class="c35"
@@ -24897,7 +24897,7 @@ exports[`DateRangePicker should render properly with single month 1`] = `
               </button>
             </div>
             <div
-              class="c34"
+              class="c37"
             >
               <button
                 class="c35"


### PR DESCRIPTION
affects: @medly-components/core

### PR Checklist

Please check if your PR fulfills the following requirements:

-   [x] Tests for the changes have been added (for bug fixes / features)
-   [x] Docs have been added / updated (for bug fixes / features)

### PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

-   [ ] Bugfix
-   [x] Feature
-   [ ] Code style update (formatting, local variables)
-   [ ] Refactoring (no functional changes, no api changes)
-   [ ] Build related changes
-   [ ] CI related changes
-   [ ] Performance improves
-   [ ] Adding missing tests
-   [ ] Documentation content changes
-   [ ] Other... Please describe:

### What is the current behavior?

The DatePicker calendar icon currently always displays on desktop

## Fixes # (issue)

### What is the new behavior?

A new `showCalendarIcon` prop has been added to the DatePicker component. It defaults to `true` but can be set to `false` to hide the calendar icon.

### Does this PR introduce a breaking change?

-   [ ] Yes
-   [x] No

### Additional context

Add any other context or screenshots about the feature pr here.
