### PR TITLE
fix(core): textField - setIsTextPresent updates based on value not on onChange of field

### DIFF
--- a/packages/core/src/components/TextField/TextField.tsx
+++ b/packages/core/src/components/TextField/TextField.tsx
@@ -40,6 +40,7 @@ export const TextField: FC<TextFieldProps> & WithStyle = React.memo(
             [maskLabel, setMaskLabel] = useState(mask),
             [inputWidth, setInputWidth] = useState(0);
 
+        const [testValue, setTestValue] = useState('');
         const validate = useCallback(
             (event: FormEvent<HTMLInputElement>, eventFunc: (e: FormEvent<HTMLInputElement>) => void) => {
                 event.preventDefault();
@@ -64,11 +65,14 @@ export const TextField: FC<TextFieldProps> & WithStyle = React.memo(
                         e.target.value = maskedValue;
                         setMaskLabel(`${maskedValue}${mask.substr(maskedValue.length)}`);
                     }
-                    setIsTextPresent(!!e.target.value);
                     props.onChange && props.onChange(e);
                 },
                 [mask, props.onChange]
             );
+
+        useEffect(() => {
+            setIsTextPresent(!!value);
+        }, [value]);
 
         useEffect(() => {
             mask && value && value.toString().length === mask.length && setMaskLabel(value.toString());
@@ -105,7 +109,7 @@ export const TextField: FC<TextFieldProps> & WithStyle = React.memo(
                     <Styled.InputWrapper multiline={multiline} size={size} variant={props.variant}>
                         <Styled.Input
                             ref={inputRef}
-                            value={value}
+                            value={value || testValue}
                             id={`${inputId}-input`}
                             aria-describedby={`${inputId}-helper-text`}
                             required={required}

--- a/packages/core/src/components/TextField/TextField.tsx
+++ b/packages/core/src/components/TextField/TextField.tsx
@@ -40,7 +40,6 @@ export const TextField: FC<TextFieldProps> & WithStyle = React.memo(
             [maskLabel, setMaskLabel] = useState(mask),
             [inputWidth, setInputWidth] = useState(0);
 
-        const [testValue, setTestValue] = useState('');
         const validate = useCallback(
             (event: FormEvent<HTMLInputElement>, eventFunc: (e: FormEvent<HTMLInputElement>) => void) => {
                 event.preventDefault();

--- a/packages/core/src/components/TextField/TextField.tsx
+++ b/packages/core/src/components/TextField/TextField.tsx
@@ -108,7 +108,7 @@ export const TextField: FC<TextFieldProps> & WithStyle = React.memo(
                     <Styled.InputWrapper multiline={multiline} size={size} variant={props.variant}>
                         <Styled.Input
                             ref={inputRef}
-                            value={value || testValue}
+                            value={value}
                             id={`${inputId}-input`}
                             aria-describedby={`${inputId}-helper-text`}
                             required={required}


### PR DESCRIPTION

affects: @medly-components/core

### PR Checklist

Please check if your PR fulfills the following requirements:

-   [ ] Tests for the changes have been added (for bug fixes / features)
-   [ ] Docs have been added / updated (for bug fixes / features)

### PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

-   [x] Bugfix
-   [ ] Feature
-   [ ] Code style update (formatting, local variables)
-   [ ] Refactoring (no functional changes, no api changes)
-   [ ] Build related changes
-   [ ] CI related changes
-   [ ] Performance improves
-   [ ] Adding missing tests
-   [ ] Documentation content changes
-   [ ] Other... Please describe:

### What is the current behavior?
Issue was noticed when we tried to add a new autosuggestion feature within noapp to update the form with selected values. The selected values would update the textFields but the textFields were still greyed out when using `variant: fusion` because there was no "change" in each field. @jaredgiangrasso pointed out this can be resolved by placing a useEffect inside the textField to look out for change in value + updating `setIsTextPresent` based on whether or not there is value present. This takes care of the textfield turning from grey to white when text is present instead of waiting for a change.

## Fixes # (issue)

### What is the new behavior?
When the variant is set to fusion, the textField updates (turns from grey to white, and also white to grey) based on the value being inside the field. 

### Does this PR introduce a breaking change?

-   [ ] Yes
-   [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

### Additional context

Add any other context or screenshots about the feature pr here.
