### PR TITLE
fix: remove isMobile functionality

### DIFF
--- a/packages/core/src/components/DatePicker/DatePicker.stories.mdx
+++ b/packages/core/src/components/DatePicker/DatePicker.stories.mdx
@@ -46,6 +46,7 @@ To open the calendar click on the icon inside the datepicker component and to cl
                     label={text('Label', 'Date of Birth')}
                     variant={select('variant', variants, 'outlined')}
                     required={boolean('Required', false)}
+                    showCalendarIcon={boolean('Show calendar icon', true)}
                 />
             );
         }}

--- a/packages/core/src/components/DatePicker/DatePicker.tsx
+++ b/packages/core/src/components/DatePicker/DatePicker.tsx
@@ -131,7 +131,7 @@ export const DatePicker: React.FC<DatePickerProps> & WithStyle = React.memo(
                     id={id}
                     ref={inputRef}
                     required={required}
-                    suffix={suffixEl}
+                    {...(showCalendarIcon && { suffix: suffixEl })}
                     fullWidth
                     mask={displayFormat.replace(new RegExp('\\/|\\-', 'g'), ' $& ').toUpperCase()}
                     pattern={datePickerPattern[displayFormat]}

--- a/packages/core/src/components/DatePicker/DatePicker.tsx
+++ b/packages/core/src/components/DatePicker/DatePicker.tsx
@@ -1,5 +1,5 @@
 import { DateRangeIcon } from '@medly-components/icons';
-import { isMobile, parseToDate, useCombinedRefs, useOuterClickNotifier, WithStyle } from '@medly-components/utils';
+import { parseToDate, useCombinedRefs, useOuterClickNotifier, WithStyle } from '@medly-components/utils';
 import { format } from 'date-fns';
 import React, { FormEvent, useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import Calendar from '../Calendar';
@@ -14,6 +14,7 @@ export const DatePicker: React.FC<DatePickerProps> & WithStyle = React.memo(
                 value,
                 onChange,
                 size,
+                displayFormat,
                 fullWidth,
                 minWidth,
                 required,
@@ -28,7 +29,6 @@ export const DatePicker: React.FC<DatePickerProps> & WithStyle = React.memo(
                 ...restProps
             } = props,
             id = props.id || props.label.toLowerCase().replace(/\s/g, '') || 'medly-datepicker', // TODO:- Remove static ID concept to avoid dup ID
-            displayFormat = isMobile ? 'yyyy-MM-dd' : props.displayFormat,
             date: Date | null = useMemo(
                 () => (value instanceof Date ? value : typeof value === 'string' ? parseToDate(value, displayFormat) : null),
                 [value, displayFormat]
@@ -42,7 +42,7 @@ export const DatePicker: React.FC<DatePickerProps> & WithStyle = React.memo(
             isErrorPresent = useMemo(() => !!errorText || !!builtInErrorMessage, [errorText, builtInErrorMessage]);
 
         useEffect(() => {
-            date && setTextValue(format(date, displayFormat).replace(new RegExp('\\/|\\-', 'g'), isMobile ? '$&' : ' $& '));
+            date && setTextValue(format(date, displayFormat).replace(new RegExp('\\/|\\-', 'g'), ' $& '));
         }, [date, displayFormat]);
         const onTextChange = useCallback(
                 (event: React.ChangeEvent<HTMLInputElement>) => {
@@ -116,26 +116,6 @@ export const DatePicker: React.FC<DatePickerProps> & WithStyle = React.memo(
             </DateIconWrapper>
         );
 
-        const sharedProps = {
-                errorText: errorText || builtInErrorMessage,
-                id: id,
-                ref: inputRef,
-                required: required,
-                fullWidth: true,
-                size: size,
-                disabled: disabled,
-                value: textValue,
-                onChange: onTextChange,
-                ...{ ...restProps, onBlur, onFocus, onInvalid }
-            },
-            mobileProps = { ...sharedProps, type: 'date' },
-            desktopProps = {
-                ...sharedProps,
-                ...(showCalendarIcon && { suffix: suffixEl }),
-                pattern: datePickerPattern[displayFormat],
-                mask: displayFormat.replace(new RegExp('\\/|\\-', 'g'), ' $& ').toUpperCase()
-            };
-
         return (
             <Wrapper
                 id={`${id}-datepicker-wrapper`}
@@ -146,7 +126,22 @@ export const DatePicker: React.FC<DatePickerProps> & WithStyle = React.memo(
                 className={className}
                 placement={popoverPlacement}
             >
-                <TextField {...(isMobile ? mobileProps : desktopProps)} />
+                <TextField
+                    errorText={errorText || builtInErrorMessage}
+                    id={id}
+                    ref={inputRef}
+                    required={required}
+                    suffix={suffixEl}
+                    fullWidth
+                    mask={displayFormat.replace(new RegExp('\\/|\\-', 'g'), ' $& ').toUpperCase()}
+                    pattern={datePickerPattern[displayFormat]}
+                    size={size}
+                    disabled={disabled}
+                    value={textValue}
+                    onChange={onTextChange}
+                    {...{ ...restProps, onBlur, onFocus, onInvalid }}
+                />
+
                 {showCalendar && (
                     <Calendar
                         id={`${id}-calendar`}

--- a/packages/forms/src/hooks/useForm/useForm.ts
+++ b/packages/forms/src/hooks/useForm/useForm.ts
@@ -1,4 +1,4 @@
-import { isMobile, parseToDate, useUpdateEffect } from '@medly-components/utils';
+import { parseToDate, useUpdateEffect } from '@medly-components/utils';
 import { format } from 'date-fns';
 import memoize from 'fast-memoize';
 import { useCallback, useState } from 'react';
@@ -89,8 +89,7 @@ export const useForm = (initialState: object): UseFormResult => {
 
     const handleDateChange: Handlers['handleDateChange'] = useCallback(
         memoize((name, displayFormat) => value => {
-            const formattedDisplayFormat = format(value, displayFormat || (isMobile ? 'yyyy-MM-dd' : 'MM/dd/yyyy'));
-            setValues(val => ({ ...val, [name]: value ? formattedDisplayFormat : '' }));
+            setValues(val => ({ ...val, [name]: value ? format(value, displayFormat || 'MM/dd/yyyy') : '' }));
         }),
         []
     );

--- a/packages/utils/src/helpers/index.ts
+++ b/packages/utils/src/helpers/index.ts
@@ -1,5 +1,4 @@
 export * from './debounce';
-export * from './isMobile';
 export * from './parseToDate';
 export * from './positionalSpacing';
 export * from './ReactHelper';

--- a/packages/utils/src/helpers/isMobile.ts
+++ b/packages/utils/src/helpers/isMobile.ts
@@ -1,4 +1,0 @@
-export const isMobile =
-    typeof window !== 'undefined'
-        ? /Android|webOS|iPhone|iPad|iPod|BlackBerry|IEMobile|Opera Mini/i.test(window.navigator.userAgent)
-        : false;


### PR DESCRIPTION
Removed isMobile from date picker as requested in [PNA-488](https://medlypharmacy.atlassian.net/browse/PNA-488
)
### PR Checklist

Please check if your PR fulfills the following requirements:

-   [ ] Tests for the changes have been added (for bug fixes / features)
-   [ ] Docs have been added / updated (for bug fixes / features)

### PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

-   [x] Bugfix
-   [ ] Feature
-   [ ] Code style update (formatting, local variables)
-   [ ] Refactoring (no functional changes, no api changes)
-   [ ] Build related changes
-   [ ] CI related changes
-   [ ] Performance improves
-   [ ] Adding missing tests
-   [ ] Documentation content changes
-   [ ] Other... Please describe:

### What is the current behavior?

On mobile, the native datepicker appears when entering a dob on patient authentication. Desired behavior is for mobile datepicker to behave more like text field - with no calendar popover appearing. 

## Fixes # (issue)
PNA-488

### What is the new behavior?
DOB field behaves like textfield with validations of datepicker

### Does this PR introduce a breaking change?

-   [ ] Yes
-   [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

### Additional context

Add any other context or screenshots about the feature pr here.
