### PR TITLE
feat: add as and hidePanel props in Tabs component

### DIFF
--- a/packages/core/src/components/Tabs/Tab/types.ts
+++ b/packages/core/src/components/Tabs/Tab/types.ts
@@ -14,6 +14,8 @@ export type StyledProps = HTMLProps<HTMLButtonElement> &
     };
 
 export interface Props extends HTMLProps<HTMLButtonElement> {
+    /** To be used to render tab as any html tag */
+    as?: any;
     /** Id of tab */
     id: any;
     /** Label of the tab */

--- a/packages/core/src/components/Tabs/Tabs.test.tsx
+++ b/packages/core/src/components/Tabs/Tabs.test.tsx
@@ -11,10 +11,11 @@ const renderer = ({
     tabSize = 'S',
     tabStyle = 'CLOSED',
     tabBackground = 'WHITE',
-    forceRender = false
+    forceRender = false,
+    hidePanel = false
 }: Props) =>
     render(
-        <Tabs {...{ defaultActive, active, onChange, tabSize, tabStyle, tabBackground, forceRender }}>
+        <Tabs {...{ defaultActive, active, onChange, tabSize, tabStyle, tabBackground, forceRender, hidePanel }}>
             <Tab id="tab1" label="Add" count={30} helperText="Details for tab1">
                 Content for the add panel
             </Tab>
@@ -51,6 +52,11 @@ describe('Tabs', () => {
     it('should not render anything if there is no children', () => {
         const { container } = render(<Tabs />);
         expect(container).toBeEmptyDOMElement();
+    });
+
+    it('should not render tabPanel if hidePanel prop is given', () => {
+        renderer({ hidePanel: true });
+        expect(screen.queryByText('Content for the add panel')).not.toBeInTheDocument();
     });
 
     it('should select expected tab on click on any tab, when active prop is not passed', async () => {

--- a/packages/core/src/components/Tabs/Tabs.tsx
+++ b/packages/core/src/components/Tabs/Tabs.tsx
@@ -9,7 +9,7 @@ import { Props, StaticProps } from './types';
 
 export const Tabs: React.FC<Props> & StaticProps & WithStyle = React.memo(
     React.forwardRef((props, ref) => {
-        const { defaultActive, active, onChange, children, tabSize, tabStyle, tabBackground, forceRender, ...restProps } = props,
+        const { hidePanel, defaultActive, active, onChange, children, tabSize, tabStyle, tabBackground, forceRender, ...restProps } = props,
             tabsId = props.id || 'medly-tabs',
             tabIds = useMemo(
                 () =>
@@ -40,9 +40,11 @@ export const Tabs: React.FC<Props> & StaticProps & WithStyle = React.memo(
                     <TabList id={`${tabsId}-list`} active={activeTab} onChange={handleTabChange}>
                         {children}
                     </TabList>
-                    <TabPanel id={`${tabsId}-panel`} active={activeTab} forceRender={forceRender}>
-                        {children}
-                    </TabPanel>
+                    {!hidePanel && (
+                        <TabPanel id={`${tabsId}-panel`} active={activeTab} forceRender={forceRender}>
+                            {children}
+                        </TabPanel>
+                    )}
                 </TabsContext.Provider>
             </Styled.Tabs>
         );
@@ -57,5 +59,6 @@ Tabs.defaultProps = {
     tabSize: 'S',
     tabStyle: 'OPEN',
     tabBackground: 'WHITE',
-    forceRender: false
+    forceRender: false,
+    hidePanel: false
 };

--- a/packages/core/src/components/Tabs/types.ts
+++ b/packages/core/src/components/Tabs/types.ts
@@ -10,6 +10,8 @@ export type TabBackground = 'WHITE' | 'GREY';
 export type TabStyle = 'OPEN' | 'CLOSED';
 
 export interface Props extends HTMLProps<HTMLDivElement> {
+    /** To be used to render tabs as any html tag */
+    as?: any;
     /** Id of the default active tab */
     defaultActive?: any;
     /** Id of the active tab */
@@ -24,6 +26,8 @@ export interface Props extends HTMLProps<HTMLDivElement> {
     tabBackground?: TabBackground;
     /** Force tabs to always stay mounted */
     forceRender?: boolean;
+    /** Hide panel if you want to use only tabs as maybe nav link or so */
+    hidePanel?: boolean;
 }
 
 export interface StaticProps {


### PR DESCRIPTION
affects: @medly-components/core

Added below two prop in `Tabs` component

1. `as` prop to render Tabs as any html tag.
2. `hidePanel` prop to hide the panel section

### PR Checklist

Please check if your PR fulfills the following requirements:

-   [x] Tests for the changes have been added (for bug fixes / features)
-   [x] Docs have been added / updated (for bug fixes / features)

### PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

-   [ ] Bugfix
-   [x] Feature
-   [ ] Code style update (formatting, local variables)
-   [ ] Refactoring (no functional changes, no api changes)
-   [ ] Build related changes
-   [ ] CI related changes
-   [ ] Performance improves
-   [ ] Adding missing tests
-   [ ] Documentation content changes
-   [ ] Other... Please describe:

### What is the current behavior?

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

## Fixes # (issue)

### What is the new behavior?

### Does this PR introduce a breaking change?

-   [ ] Yes
-   [ ] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

### Additional context

Add any other context or screenshots about the feature pr here.
