### PR TITLE
textField characterCount updates

### DIFF
--- a/packages/core/src/components/TextField/Styled/CharacterCount.styled.tsx
+++ b/packages/core/src/components/TextField/Styled/CharacterCount.styled.tsx
@@ -1,4 +1,4 @@
-import { styled } from '@medly-components/utils';
+import { styled, WithThemeProp } from '@medly-components/utils';
 
 const getMarginTop = ({ size, multiline }: { multiline?: boolean; size: 'S' | 'M' }) => {
     if (multiline) return '.1rem';
@@ -12,16 +12,64 @@ const getMarginTop = ({ size, multiline }: { multiline?: boolean; size: 'S' | 'M
     }
 };
 
-export const CharacterCount = styled.div<{ multiline?: boolean; size: 'S' | 'M'; variant: 'fusion' | 'outlined' | 'filled' }>`
+const getTextColor = ({
+    maxLength,
+    characterCount,
+    theme,
+    variant
+}: { maxLength: number; characterCount: number; variant: 'fusion' | 'outlined' | 'filled' } & WithThemeProp) => {
+    const characterCountPercentage = (characterCount / maxLength) * 100;
+
+    if (characterCountPercentage === 100) {
+        return theme.colors.red[500];
+    } else if (characterCountPercentage >= 80) {
+        return theme.colors.heartbeat[500];
+    } else if (variant === 'fusion') {
+        return theme.colors.grey[600];
+    } else {
+        return theme.colors.grey[500];
+    }
+};
+
+const getTransform = (translateXValue: string) => ({ variant }: { variant: 'fusion' | 'outlined' | 'filled' }): string => {
+    // If variant is fusion, we preserve the -167% translateY value which is applied on focus
+    return variant === 'fusion' ? `transform: translate(${translateXValue}, -167%)` : `transform: translateX(${translateXValue})`;
+};
+
+export const CharacterCount = styled.div<{
+    maxLength: number;
+    characterCount: number;
+    multiline?: boolean;
+    size: 'S' | 'M';
+    variant: 'fusion' | 'outlined' | 'filled';
+}>`
+    @keyframes wiggle {
+        0% {
+            ${getTransform('0.1rem')};
+        }
+        25% {
+            ${getTransform('-0.2rem')};
+        }
+        50% {
+            ${getTransform('0.2rem')};
+        }
+        75% {
+            ${getTransform('-0.1rem')};
+        }
+        100% {
+            ${getTransform('0')};
+        }
+    }
     font-size: 1rem;
     line-height: 1rem;
     position: absolute;
     top: 0;
     right: 0;
-    color: ${({ theme, variant }) => (variant === 'fusion' ? theme.colors.grey[600] : theme.colors.grey[500])};
+    color: ${getTextColor};
     align-self: flex-start;
     z-index: 50;
     transition: all 150ms cubic-bezier(0.4, 0, 0.2, 1);
     margin-top: ${getMarginTop};
     margin-left: ${({ size }) => size === 'S' && '1.2rem'};
+    animation: ${({ characterCount, maxLength }) => characterCount === maxLength && `0.2s wiggle ease-in-out`};
 `;

--- a/packages/core/src/components/TextField/TextField.test.tsx
+++ b/packages/core/src/components/TextField/TextField.test.tsx
@@ -98,6 +98,16 @@ describe('TextField', () => {
             const { getByText } = render(<TextField withCharacterCount maxLength={20} defaultValue="test" />);
             expect(getByText('4/20')).toBeInTheDocument();
         });
+
+        it('should correctly render character count when the count value is 80% of the maxLength', () => {
+            const { container } = render(<TextField withCharacterCount maxLength={10} defaultValue="12345678" />);
+            expect(container).toMatchSnapshot();
+        });
+
+        it('should correctly render character count when the count value is 100% of the maxLength', () => {
+            const { container } = render(<TextField withCharacterCount maxLength={10} defaultValue="1234567890" />);
+            expect(container).toMatchSnapshot();
+        });
     });
 
     it('should call onChange prop on changing the value', () => {

--- a/packages/core/src/components/TextField/TextField.tsx
+++ b/packages/core/src/components/TextField/TextField.tsx
@@ -145,11 +145,13 @@ export const TextField: FC<TextFieldProps> & WithStyle = React.memo(
                         >
                             {label}
                         </Styled.Label>
-                        {withCharacterCount && props.maxLength && (
+                        {withCharacterCount && props.maxLength >= 0 && props.maxLength !== null && (
                             <Styled.CharacterCount
                                 variant={props.variant}
                                 size={size}
                                 multiline={multiline}
+                                characterCount={characterCountValue}
+                                maxLength={props.maxLength}
                             >{`${characterCountValue}/${props.maxLength}`}</Styled.CharacterCount>
                         )}
                     </Styled.InputWrapper>

--- a/packages/core/src/components/TextField/__snapshots__/TextField.test.tsx.snap
+++ b/packages/core/src/components/TextField/__snapshots__/TextField.test.tsx.snap
@@ -323,6 +323,7 @@ exports[`TextField character count should correctly render character count for S
         />
         <div
           class="c6 c7"
+          maxlength="20"
         >
           0/20
         </div>
@@ -677,6 +678,7 @@ exports[`TextField character count should correctly render character count for f
         />
         <div
           class="c6 c7"
+          maxlength="20"
         >
           0/20
         </div>
@@ -1006,6 +1008,7 @@ exports[`TextField character count should correctly render character count for m
         />
         <div
           class="c6"
+          maxlength="20"
         >
           0/20
         </div>
@@ -1335,8 +1338,671 @@ exports[`TextField character count should correctly render character count if we
         />
         <div
           class="c6"
+          maxlength="20"
         >
           0/20
+        </div>
+      </div>
+    </div>
+    
+  </div>
+</div>
+`;
+
+exports[`TextField character count should correctly render character count when the count value is 80% of the maxLength 1`] = `
+.c6 {
+  font-size: 1rem;
+  line-height: 1rem;
+  position: absolute;
+  top: 0;
+  right: 0;
+  color: #FD7284;
+  -webkit-align-self: flex-start;
+  -ms-flex-item-align: start;
+  align-self: flex-start;
+  z-index: 50;
+  -webkit-transition: all 150ms cubic-bezier(0.4,0,0.2,1);
+  transition: all 150ms cubic-bezier(0.4,0,0.2,1);
+  margin-top: 1.2rem;
+}
+
+.c5 {
+  top: 50%;
+  left: 0;
+  cursor: text;
+  -webkit-user-select: none;
+  -moz-user-select: none;
+  -ms-user-select: none;
+  user-select: none;
+  position: absolute;
+  pointer-events: none;
+  -webkit-transition: all 150ms cubic-bezier(0.4,0,0.2,1);
+  transition: all 150ms cubic-bezier(0.4,0,0.2,1);
+  font-size: 1.6rem;
+  font-weight: 400;
+  -webkit-letter-spacing: 0rem;
+  -moz-letter-spacing: 0rem;
+  -ms-letter-spacing: 0rem;
+  letter-spacing: 0rem;
+  line-height: 2.6rem;
+  font-family: Open Sans,Helvetica Neue,Helvetica,Arial,sans-serif;
+  -webkit-transform-origin: 0 0;
+  -ms-transform-origin: 0 0;
+  transform-origin: 0 0;
+  touch-action: manipulation;
+  -webkit-transform: translateY(-50%);
+  -ms-transform: translateY(-50%);
+  transform: translateY(-50%);
+  opacity: 1;
+  z-index: 1;
+  width: calc(0px - 2rem);
+  max-width: -webkit-min-content;
+  max-width: -moz-min-content;
+  max-width: min-content;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
+.c1 {
+  position: relative;
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  -webkit-flex-direction: row;
+  -ms-flex-direction: row;
+  flex-direction: row;
+  box-sizing: border-box;
+  height: 5.6rem;
+  padding: 0 1.6rem;
+  -webkit-transition: all 100ms ease-out;
+  transition: all 100ms ease-out;
+  cursor: text;
+  border-radius: 0.4rem 0.4rem 0 0;
+  background-color: #eff2f4;
+}
+
+.c1 .c4 {
+  color: #546A7F;
+}
+
+.c1 .sc-AxhUy,
+.c1 .sc-AxgMl {
+  color: #546A7F;
+}
+
+.c1 .sc-AxhUy *,
+.c1 .sc-AxgMl * {
+  fill: #546A7F;
+}
+
+.c1 ~ .sc-AxiKw {
+  color: #546A7F;
+}
+
+.c1::after {
+  content: '';
+  width: 100%;
+  height: 0;
+  position: absolute;
+  bottom: 0;
+  left: 0;
+  box-sizing: border-box;
+  border-top: 0.1rem solid #546A7F;
+  -webkit-transition: all 100ms ease-out;
+  transition: all 100ms ease-out;
+}
+
+.c1:hover::after,
+.c1:focus-within::after {
+  border-width: 0.2rem;
+}
+
+.c1 input {
+  box-shadow: 0 0 0 100000px #eff2f4 inset;
+}
+
+.c1:focus-within,
+.c1:focus-within:hover {
+  background-color: #E7F0FF;
+}
+
+.c1:focus-within::after,
+.c1:focus-within:hover::after {
+  border-color: #126AFA;
+}
+
+.c1:focus-within .c4,
+.c1:focus-within:hover .c4 {
+  color: #126AFA;
+}
+
+.c1:focus-within .sc-AxhUy,
+.c1:focus-within:hover .sc-AxhUy,
+.c1:focus-within .sc-AxgMl,
+.c1:focus-within:hover .sc-AxgMl {
+  color: #126AFA;
+}
+
+.c1:focus-within .sc-AxhUy *,
+.c1:focus-within:hover .sc-AxhUy *,
+.c1:focus-within .sc-AxgMl *,
+.c1:focus-within:hover .sc-AxgMl * {
+  fill: #126AFA;
+}
+
+.c1:focus-within input,
+.c1:focus-within:hover input {
+  box-shadow: 0 0 0 100000px #E7F0FF inset;
+}
+
+.c1:focus-within input::-webkit-input-placeholder,
+.c1:focus-within:hover input::-webkit-input-placeholder {
+  color: rgba(0,90,238,.2);
+}
+
+.c1:focus-within input::-moz-placeholder,
+.c1:focus-within:hover input::-moz-placeholder {
+  color: rgba(0,90,238,.2);
+}
+
+.c1:focus-within input:-ms-input-placeholder,
+.c1:focus-within:hover input:-ms-input-placeholder {
+  color: rgba(0,90,238,.2);
+}
+
+.c1:focus-within input::placeholder,
+.c1:focus-within:hover input::placeholder {
+  color: rgba(0,90,238,.2);
+}
+
+.c2 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  position: relative;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  background-color: transparent;
+  -webkit-flex: 1;
+  -ms-flex: 1;
+  flex: 1;
+  height: 100%;
+}
+
+.c0 {
+  position: relative;
+  -webkit-flex-direction: column;
+  -ms-flex-direction: column;
+  flex-direction: column;
+  display: -webkit-inline-box;
+  display: -webkit-inline-flex;
+  display: -ms-inline-flexbox;
+  display: inline-flex;
+  width: -webkit-min-content;
+  width: -moz-min-content;
+  width: min-content;
+  min-width: 20rem;
+  margin: 0.8rem 0.8rem 0.8rem 0;
+}
+
+.c3 {
+  color: #13181D;
+  width: 100%;
+  margin: 0;
+  padding: 0;
+  box-sizing: border-box;
+  -webkit-transition: all 100ms ease-out;
+  transition: all 100ms ease-out;
+  background-color: transparent;
+  border: none;
+  text-overflow: ellipsis;
+  resize: none;
+  z-index: 1;
+}
+
+.c3,
+.c3 ~ .sc-AxmLO {
+  font-size: 1.6rem;
+  font-weight: 400;
+  -webkit-letter-spacing: 0rem;
+  -moz-letter-spacing: 0rem;
+  -ms-letter-spacing: 0rem;
+  letter-spacing: 0rem;
+  line-height: 2.6rem;
+  font-family: Open Sans,Helvetica Neue,Helvetica,Arial,sans-serif;
+}
+
+.c3.c3.c3:focus {
+  outline: none;
+  box-shadow: unset;
+}
+
+.c3.c3.c3:focus::-webkit-input-placeholder {
+  opacity: 1;
+}
+
+.c3.c3.c3:focus::-moz-placeholder {
+  opacity: 1;
+}
+
+.c3.c3.c3:focus:-ms-input-placeholder {
+  opacity: 1;
+}
+
+.c3.c3.c3:focus::placeholder {
+  opacity: 1;
+}
+
+.c3:disabled ~ .c4,
+.c3:disabled ~ .sc-AxmLO {
+  cursor: not-allowed;
+}
+
+.c3::-webkit-input-placeholder {
+  opacity: 0;
+  -webkit-transition: all 100ms ease-out;
+  transition: all 100ms ease-out;
+}
+
+.c3::-moz-placeholder {
+  opacity: 0;
+  -webkit-transition: all 100ms ease-out;
+  transition: all 100ms ease-out;
+}
+
+.c3:-ms-input-placeholder {
+  opacity: 0;
+  -webkit-transition: all 100ms ease-out;
+  transition: all 100ms ease-out;
+}
+
+.c3::placeholder {
+  opacity: 0;
+  -webkit-transition: all 100ms ease-out;
+  transition: all 100ms ease-out;
+}
+
+.c3:not(:placeholder-shown) ~ .c4,
+.c3:focus ~ .c4 {
+  -webkit-transform: translateY(-87%) scale(0.75);
+  -ms-transform: translateY(-87%) scale(0.75);
+  transform: translateY(-87%) scale(0.75);
+}
+
+.c3:not(:placeholder-shown) ~ .sc-AxmLO {
+  opacity: 1;
+}
+
+<div>
+  <div
+    class="c0"
+    id="medly-textField-input-wrapper"
+  >
+    <div
+      class="c1"
+    >
+      <div
+        class="c2"
+      >
+        <input
+          aria-describedby="medly-textField-helper-text"
+          class="c3"
+          id="medly-textField-input"
+          maxlength="10"
+          placeholder=" "
+          type="text"
+          value="12345678"
+        />
+        <label
+          class="c4 c5"
+          for="medly-textField-input"
+        />
+        <div
+          class="c6"
+          maxlength="10"
+        >
+          8/10
+        </div>
+      </div>
+    </div>
+    
+  </div>
+</div>
+`;
+
+exports[`TextField character count should correctly render character count when the count value is 100% of the maxLength 1`] = `
+.c6 {
+  font-size: 1rem;
+  line-height: 1rem;
+  position: absolute;
+  top: 0;
+  right: 0;
+  color: #cc0000;
+  -webkit-align-self: flex-start;
+  -ms-flex-item-align: start;
+  align-self: flex-start;
+  z-index: 50;
+  -webkit-transition: all 150ms cubic-bezier(0.4,0,0.2,1);
+  transition: all 150ms cubic-bezier(0.4,0,0.2,1);
+  margin-top: 1.2rem;
+  -webkit-animation: 0.2s wiggle ease-in-out;
+  animation: 0.2s wiggle ease-in-out;
+}
+
+.c5 {
+  top: 50%;
+  left: 0;
+  cursor: text;
+  -webkit-user-select: none;
+  -moz-user-select: none;
+  -ms-user-select: none;
+  user-select: none;
+  position: absolute;
+  pointer-events: none;
+  -webkit-transition: all 150ms cubic-bezier(0.4,0,0.2,1);
+  transition: all 150ms cubic-bezier(0.4,0,0.2,1);
+  font-size: 1.6rem;
+  font-weight: 400;
+  -webkit-letter-spacing: 0rem;
+  -moz-letter-spacing: 0rem;
+  -ms-letter-spacing: 0rem;
+  letter-spacing: 0rem;
+  line-height: 2.6rem;
+  font-family: Open Sans,Helvetica Neue,Helvetica,Arial,sans-serif;
+  -webkit-transform-origin: 0 0;
+  -ms-transform-origin: 0 0;
+  transform-origin: 0 0;
+  touch-action: manipulation;
+  -webkit-transform: translateY(-50%);
+  -ms-transform: translateY(-50%);
+  transform: translateY(-50%);
+  opacity: 1;
+  z-index: 1;
+  width: calc(0px - 2rem);
+  max-width: -webkit-min-content;
+  max-width: -moz-min-content;
+  max-width: min-content;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
+.c1 {
+  position: relative;
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  -webkit-flex-direction: row;
+  -ms-flex-direction: row;
+  flex-direction: row;
+  box-sizing: border-box;
+  height: 5.6rem;
+  padding: 0 1.6rem;
+  -webkit-transition: all 100ms ease-out;
+  transition: all 100ms ease-out;
+  cursor: text;
+  border-radius: 0.4rem 0.4rem 0 0;
+  background-color: #eff2f4;
+}
+
+.c1 .c4 {
+  color: #546A7F;
+}
+
+.c1 .sc-AxhUy,
+.c1 .sc-AxgMl {
+  color: #546A7F;
+}
+
+.c1 .sc-AxhUy *,
+.c1 .sc-AxgMl * {
+  fill: #546A7F;
+}
+
+.c1 ~ .sc-AxiKw {
+  color: #546A7F;
+}
+
+.c1::after {
+  content: '';
+  width: 100%;
+  height: 0;
+  position: absolute;
+  bottom: 0;
+  left: 0;
+  box-sizing: border-box;
+  border-top: 0.1rem solid #546A7F;
+  -webkit-transition: all 100ms ease-out;
+  transition: all 100ms ease-out;
+}
+
+.c1:hover::after,
+.c1:focus-within::after {
+  border-width: 0.2rem;
+}
+
+.c1 input {
+  box-shadow: 0 0 0 100000px #eff2f4 inset;
+}
+
+.c1:focus-within,
+.c1:focus-within:hover {
+  background-color: #E7F0FF;
+}
+
+.c1:focus-within::after,
+.c1:focus-within:hover::after {
+  border-color: #126AFA;
+}
+
+.c1:focus-within .c4,
+.c1:focus-within:hover .c4 {
+  color: #126AFA;
+}
+
+.c1:focus-within .sc-AxhUy,
+.c1:focus-within:hover .sc-AxhUy,
+.c1:focus-within .sc-AxgMl,
+.c1:focus-within:hover .sc-AxgMl {
+  color: #126AFA;
+}
+
+.c1:focus-within .sc-AxhUy *,
+.c1:focus-within:hover .sc-AxhUy *,
+.c1:focus-within .sc-AxgMl *,
+.c1:focus-within:hover .sc-AxgMl * {
+  fill: #126AFA;
+}
+
+.c1:focus-within input,
+.c1:focus-within:hover input {
+  box-shadow: 0 0 0 100000px #E7F0FF inset;
+}
+
+.c1:focus-within input::-webkit-input-placeholder,
+.c1:focus-within:hover input::-webkit-input-placeholder {
+  color: rgba(0,90,238,.2);
+}
+
+.c1:focus-within input::-moz-placeholder,
+.c1:focus-within:hover input::-moz-placeholder {
+  color: rgba(0,90,238,.2);
+}
+
+.c1:focus-within input:-ms-input-placeholder,
+.c1:focus-within:hover input:-ms-input-placeholder {
+  color: rgba(0,90,238,.2);
+}
+
+.c1:focus-within input::placeholder,
+.c1:focus-within:hover input::placeholder {
+  color: rgba(0,90,238,.2);
+}
+
+.c2 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  position: relative;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  background-color: transparent;
+  -webkit-flex: 1;
+  -ms-flex: 1;
+  flex: 1;
+  height: 100%;
+}
+
+.c0 {
+  position: relative;
+  -webkit-flex-direction: column;
+  -ms-flex-direction: column;
+  flex-direction: column;
+  display: -webkit-inline-box;
+  display: -webkit-inline-flex;
+  display: -ms-inline-flexbox;
+  display: inline-flex;
+  width: -webkit-min-content;
+  width: -moz-min-content;
+  width: min-content;
+  min-width: 20rem;
+  margin: 0.8rem 0.8rem 0.8rem 0;
+}
+
+.c3 {
+  color: #13181D;
+  width: 100%;
+  margin: 0;
+  padding: 0;
+  box-sizing: border-box;
+  -webkit-transition: all 100ms ease-out;
+  transition: all 100ms ease-out;
+  background-color: transparent;
+  border: none;
+  text-overflow: ellipsis;
+  resize: none;
+  z-index: 1;
+}
+
+.c3,
+.c3 ~ .sc-AxmLO {
+  font-size: 1.6rem;
+  font-weight: 400;
+  -webkit-letter-spacing: 0rem;
+  -moz-letter-spacing: 0rem;
+  -ms-letter-spacing: 0rem;
+  letter-spacing: 0rem;
+  line-height: 2.6rem;
+  font-family: Open Sans,Helvetica Neue,Helvetica,Arial,sans-serif;
+}
+
+.c3.c3.c3:focus {
+  outline: none;
+  box-shadow: unset;
+}
+
+.c3.c3.c3:focus::-webkit-input-placeholder {
+  opacity: 1;
+}
+
+.c3.c3.c3:focus::-moz-placeholder {
+  opacity: 1;
+}
+
+.c3.c3.c3:focus:-ms-input-placeholder {
+  opacity: 1;
+}
+
+.c3.c3.c3:focus::placeholder {
+  opacity: 1;
+}
+
+.c3:disabled ~ .c4,
+.c3:disabled ~ .sc-AxmLO {
+  cursor: not-allowed;
+}
+
+.c3::-webkit-input-placeholder {
+  opacity: 0;
+  -webkit-transition: all 100ms ease-out;
+  transition: all 100ms ease-out;
+}
+
+.c3::-moz-placeholder {
+  opacity: 0;
+  -webkit-transition: all 100ms ease-out;
+  transition: all 100ms ease-out;
+}
+
+.c3:-ms-input-placeholder {
+  opacity: 0;
+  -webkit-transition: all 100ms ease-out;
+  transition: all 100ms ease-out;
+}
+
+.c3::placeholder {
+  opacity: 0;
+  -webkit-transition: all 100ms ease-out;
+  transition: all 100ms ease-out;
+}
+
+.c3:not(:placeholder-shown) ~ .c4,
+.c3:focus ~ .c4 {
+  -webkit-transform: translateY(-87%) scale(0.75);
+  -ms-transform: translateY(-87%) scale(0.75);
+  transform: translateY(-87%) scale(0.75);
+}
+
+.c3:not(:placeholder-shown) ~ .sc-AxmLO {
+  opacity: 1;
+}
+
+<div>
+  <div
+    class="c0"
+    id="medly-textField-input-wrapper"
+  >
+    <div
+      class="c1"
+    >
+      <div
+        class="c2"
+      >
+        <input
+          aria-describedby="medly-textField-helper-text"
+          class="c3"
+          id="medly-textField-input"
+          maxlength="10"
+          placeholder=" "
+          type="text"
+          value="1234567890"
+        />
+        <label
+          class="c4 c5"
+          for="medly-textField-input"
+        />
+        <div
+          class="c6"
+          maxlength="10"
+        >
+          10/10
         </div>
       </div>
     </div>


### PR DESCRIPTION
affects: @medly-components/core

### PR Checklist

Please check if your PR fulfills the following requirements:

-   [x] Tests for the changes have been added (for bug fixes / features)
-   [ ] Docs have been added / updated (for bug fixes / features)

### PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

-   [ ] Bugfix
-   [x] Feature
-   [ ] Code style update (formatting, local variables)
-   [ ] Refactoring (no functional changes, no api changes)
-   [ ] Build related changes
-   [ ] CI related changes
-   [ ] Performance improves
-   [ ] Adding missing tests
-   [ ] Documentation content changes
-   [ ] Other... Please describe:

### What is the current behavior?

Currently, the `characterCount` feature does not change style based on input length:

![Screen Shot 2021-05-18 at 10 50 03 AM](https://user-images.githubusercontent.com/42226043/118673598-21e59100-b7c7-11eb-8807-5efdc1915609.png)

## Fixes # (issue)

### What is the new behavior?

The `characterCount` now changes to `theme.colors.heartbeat[500]` when the textField input value is greater than or equal to 80% of the `maxLength` and changes to `theme.colors.red[500]` and does a .2s shake animation when the textField input value length is 100% of the `maxLength`:

![Screen Shot 2021-05-18 at 10 50 25 AM](https://user-images.githubusercontent.com/42226043/118673595-214cfa80-b7c7-11eb-90c0-0a17ba71cd8f.png)

Additionally, made a small fix to the render logic for `characterCount` which was originally behaving incorrectly when `characterCount={true}` and `maxLength={0}` were passed.

### Does this PR introduce a breaking change?

-   [ ] Yes
-   [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

### Additional context

Add any other context or screenshots about the feature pr here.
