### PR TITLE
PES-1463 add 'xs' button size

### DIFF
--- a/packages/core/src/components/Button/Button.stories.mdx
+++ b/packages/core/src/components/Button/Button.stories.mdx
@@ -34,7 +34,19 @@ You can play with the props in canvas tab.
 
 ### Sizes
 
-There are two button sizes are available `S` | `M`
+There are four button sizes available: `XS` | `S` | `M` | `L`
+
+##### Extra Small Buttons
+
+<Preview>
+    <Button size="XS">Extra Small Size</Button>
+    <Button size="XS" edges="rounded">
+        Extra Small Size
+    </Button>
+    <Button size="XS" edges="circle">
+        <SendIcon size="XS" />
+    </Button>
+</Preview>
 
 ##### Small Buttons
 
@@ -57,6 +69,18 @@ There are two button sizes are available `S` | `M`
     </Button>
     <Button size="M" edges="circle">
         <SendIcon size="M" />
+    </Button>
+</Preview>
+
+##### Large Buttons
+
+<Preview>
+    <Button size="L">Large Size</Button>
+    <Button size="L" edges="rounded">
+        Large Size
+    </Button>
+    <Button size="L" edges="circle">
+        <SendIcon size="L" />
     </Button>
 </Preview>
 

--- a/packages/core/src/components/Button/Button.stories.tsx
+++ b/packages/core/src/components/Button/Button.stories.tsx
@@ -2,7 +2,7 @@ import { ButtonTheme, defaultTheme } from '@medly-components/theme';
 import React from 'react';
 import { Props } from './types';
 
-export const sizes: Props['size'][] = ['S', 'M', 'L'];
+export const sizes: Props['size'][] = ['XS', 'S', 'M', 'L'];
 export const edges: Props['edges'][] = ['square', 'rounded', 'circle'];
 export const variants: Props['variant'][] = ['solid', 'flat', 'outlined'];
 export const colors: Props['color'][] = ['default', 'confirmation', 'error'];

--- a/packages/core/src/components/Button/Button.test.tsx
+++ b/packages/core/src/components/Button/Button.test.tsx
@@ -32,7 +32,7 @@ describe('Button component', () => {
             expect(container).toMatchSnapshot();
         });
 
-        test.each(['S', 'M', 'L'])('should render properly with %p size', (size: Props['size']) => {
+        test.each(['XS', 'S', 'M', 'L'])('should render properly with %p size', (size: Props['size']) => {
             const { container } = render(
                 <Button size={size} variant={variant}>
                     Button

--- a/packages/core/src/components/Button/__snapshots__/Button.test.tsx.snap
+++ b/packages/core/src/components/Button/__snapshots__/Button.test.tsx.snap
@@ -2636,7 +2636,7 @@ exports[`Button component with "flat" variant should render properly with "XS" s
   text-decoration: none;
   -webkit-transition: all 100ms ease-out;
   transition: all 100ms ease-out;
-  padding: 0.7rem 1.6rem 0.9rem;
+  padding: 0.4rem 1.6rem 0.6rem;
   border-radius: 0.8rem;
   background-color: transparent;
   display: -webkit-inline-box;
@@ -3814,7 +3814,7 @@ exports[`Button component with "outlined" variant should render properly with "X
   text-decoration: none;
   -webkit-transition: all 100ms ease-out;
   transition: all 100ms ease-out;
-  padding: 0.7rem 1.6rem 0.9rem;
+  padding: 0.4rem 1.6rem 0.6rem;
   border-radius: 0.8rem;
   background-color: transparent;
   display: -webkit-inline-box;
@@ -4766,7 +4766,7 @@ exports[`Button component with "solid" variant should render properly with "XS" 
   text-decoration: none;
   -webkit-transition: all 100ms ease-out;
   transition: all 100ms ease-out;
-  padding: 0.7rem 1.6rem 0.9rem;
+  padding: 0.4rem 1.6rem 0.6rem;
   border-radius: 0.8rem;
   display: -webkit-inline-box;
   display: -webkit-inline-flex;

--- a/packages/core/src/components/Button/__snapshots__/Button.test.tsx.snap
+++ b/packages/core/src/components/Button/__snapshots__/Button.test.tsx.snap
@@ -2610,6 +2610,163 @@ exports[`Button component with "flat" variant should render properly with "S" si
 </div>
 `;
 
+exports[`Button component with "flat" variant should render properly with "XS" size 1`] = `
+.c2 {
+  margin: 0;
+  color: inherit;
+  font-size: 1.4rem;
+  font-weight: 600;
+  -webkit-letter-spacing: 0rem;
+  -moz-letter-spacing: 0rem;
+  -ms-letter-spacing: 0rem;
+  letter-spacing: 0rem;
+  line-height: 2.2rem;
+  text-align: initial;
+}
+
+.c0 {
+  border: none;
+  position: relative;
+  -webkit-user-select: none;
+  -moz-user-select: none;
+  -ms-user-select: none;
+  user-select: none;
+  font-family: inherit;
+  -webkit-text-decoration: none;
+  text-decoration: none;
+  -webkit-transition: all 100ms ease-out;
+  transition: all 100ms ease-out;
+  padding: 0.7rem 1.6rem 0.9rem;
+  border-radius: 0.8rem;
+  background-color: transparent;
+  display: -webkit-inline-box;
+  display: -webkit-inline-flex;
+  display: -ms-inline-flexbox;
+  display: inline-flex;
+  -webkit-box-pack: center;
+  -webkit-justify-content: center;
+  -ms-flex-pack: center;
+  justify-content: center;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+}
+
+.c0,
+.c0 .c1,
+.c0 .sc-AxjAm,
+.c0 .sc-AxjAm * {
+  -webkit-transition: all 100ms ease-out;
+  transition: all 100ms ease-out;
+}
+
+.c0:hover {
+  cursor: pointer;
+}
+
+.c0:focus {
+  outline: none;
+}
+
+.c0:disabled {
+  cursor: not-allowed;
+}
+
+.c0::after {
+  content: '';
+  display: block;
+  position: absolute;
+  width: 0;
+  bottom: 0.85rem;
+  left: 50%;
+  height: 0.15rem;
+  -webkit-transition: all 100ms ease-out;
+  transition: all 100ms ease-out;
+  border-radius: 0.15rem;
+  -webkit-transform: translate(-50%);
+  -ms-transform: translate(-50%);
+  transform: translate(-50%);
+}
+
+.c0:disabled {
+  color: #98A7B7;
+}
+
+.c0:disabled::after {
+  background-color: #98A7B7;
+}
+
+.c0:disabled .sc-AxjAm * {
+  fill: #98A7B7;
+}
+
+.c0:not(:disabled):not(:hover) {
+  color: #126AFA;
+}
+
+.c0:not(:disabled):not(:hover)::after {
+  background-color: #126AFA;
+}
+
+.c0:not(:disabled):not(:hover) .sc-AxjAm * {
+  fill: #126AFA;
+}
+
+.c0:not(:disabled):active {
+  color: #0D4AAF;
+}
+
+.c0:not(:disabled):active::after {
+  background-color: #0D4AAF;
+}
+
+.c0:not(:disabled):active .sc-AxjAm * {
+  fill: #0D4AAF;
+}
+
+.c0:not(:disabled):active::after {
+  width: calc(100% - 4.8rem);
+}
+
+.c0:not(:disabled):not(:active):hover {
+  color: #0F5AD5;
+}
+
+.c0:not(:disabled):not(:active):hover::after {
+  background-color: #0F5AD5;
+}
+
+.c0:not(:disabled):not(:active):hover .sc-AxjAm * {
+  fill: #0F5AD5;
+}
+
+.c0:not(:disabled):not(:active):hover::after {
+  width: calc(100% - 4.8rem);
+}
+
+.c0 .sc-AxjAm + .c1 {
+  margin-left: 0.8rem;
+}
+
+.c0 .c1 + .sc-AxjAm {
+  margin-left: 0.8rem;
+}
+
+<div>
+  <button
+    class="c0"
+    type="button"
+  >
+    <span
+      class="c1 c2"
+    >
+      Button
+    </span>
+  </button>
+</div>
+`;
+
 exports[`Button component with "outlined" variant should render properly 1`] = `
 .c2 {
   margin: 0;
@@ -3631,6 +3788,165 @@ exports[`Button component with "outlined" variant should render properly with "S
 </div>
 `;
 
+exports[`Button component with "outlined" variant should render properly with "XS" size 1`] = `
+.c2 {
+  margin: 0;
+  color: inherit;
+  font-size: 1.4rem;
+  font-weight: 600;
+  -webkit-letter-spacing: 0rem;
+  -moz-letter-spacing: 0rem;
+  -ms-letter-spacing: 0rem;
+  letter-spacing: 0rem;
+  line-height: 2.2rem;
+  text-align: initial;
+}
+
+.c0 {
+  border: none;
+  position: relative;
+  -webkit-user-select: none;
+  -moz-user-select: none;
+  -ms-user-select: none;
+  user-select: none;
+  font-family: inherit;
+  -webkit-text-decoration: none;
+  text-decoration: none;
+  -webkit-transition: all 100ms ease-out;
+  transition: all 100ms ease-out;
+  padding: 0.7rem 1.6rem 0.9rem;
+  border-radius: 0.8rem;
+  background-color: transparent;
+  display: -webkit-inline-box;
+  display: -webkit-inline-flex;
+  display: -ms-inline-flexbox;
+  display: inline-flex;
+  -webkit-box-pack: center;
+  -webkit-justify-content: center;
+  -ms-flex-pack: center;
+  justify-content: center;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+}
+
+.c0,
+.c0 .c1,
+.c0 .sc-AxjAm,
+.c0 .sc-AxjAm * {
+  -webkit-transition: all 100ms ease-out;
+  transition: all 100ms ease-out;
+}
+
+.c0:hover {
+  cursor: pointer;
+}
+
+.c0:focus {
+  outline: none;
+}
+
+.c0:disabled {
+  cursor: not-allowed;
+}
+
+.c0::after {
+  content: '';
+  box-sizing: border-box;
+  width: 100%;
+  height: 100%;
+  position: absolute;
+  top: 0;
+  right: 0;
+  bottom: 0;
+  left: 0;
+  background-color: transparent;
+  -webkit-transition: all 100ms ease-out;
+  transition: all 100ms ease-out;
+  border-radius: 0.8rem;
+  border-style: solid;
+}
+
+.c0:disabled {
+  color: #98A7B7;
+  background-color: transparent;
+}
+
+.c0:disabled::after {
+  border-width: 0.1rem;
+  border-color: #98A7B7;
+}
+
+.c0:disabled .sc-AxjAm * {
+  fill: #98A7B7;
+}
+
+.c0:not(:disabled):not(:hover) {
+  color: #126AFA;
+  background-color: transparent;
+}
+
+.c0:not(:disabled):not(:hover)::after {
+  border-width: 0.1rem;
+  border-color: #126AFA;
+}
+
+.c0:not(:disabled):not(:hover) .sc-AxjAm * {
+  fill: #126AFA;
+}
+
+.c0:not(:disabled):active {
+  color: #0D4AAF;
+  background-color: #E7F0FF;
+}
+
+.c0:not(:disabled):active::after {
+  border-width: 0.2rem;
+  border-color: #0D4AAF;
+}
+
+.c0:not(:disabled):active .sc-AxjAm * {
+  fill: #0D4AAF;
+}
+
+.c0:not(:disabled):not(:active):hover {
+  color: #0F5AD5;
+  background-color: transparent;
+  box-shadow: 0 0.2rem 0.8rem rgba(15,90,213,0.35);
+}
+
+.c0:not(:disabled):not(:active):hover::after {
+  border-width: 0.2rem;
+  border-color: #0F5AD5;
+}
+
+.c0:not(:disabled):not(:active):hover .sc-AxjAm * {
+  fill: #0F5AD5;
+}
+
+.c0 .sc-AxjAm + .c1 {
+  margin-left: 0.8rem;
+}
+
+.c0 .c1 + .sc-AxjAm {
+  margin-left: 0.8rem;
+}
+
+<div>
+  <button
+    class="c0"
+    type="button"
+  >
+    <span
+      class="c1 c2"
+    >
+      Button
+    </span>
+  </button>
+</div>
+`;
+
 exports[`Button component with "solid" variant should render properly 1`] = `
 .c2 {
   margin: 0;
@@ -4330,6 +4646,127 @@ exports[`Button component with "solid" variant should render properly with "S" s
   -webkit-transition: all 100ms ease-out;
   transition: all 100ms ease-out;
   padding: 0.8rem 2.4rem 1rem;
+  border-radius: 0.8rem;
+  display: -webkit-inline-box;
+  display: -webkit-inline-flex;
+  display: -ms-inline-flexbox;
+  display: inline-flex;
+  -webkit-box-pack: center;
+  -webkit-justify-content: center;
+  -ms-flex-pack: center;
+  justify-content: center;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+}
+
+.c0,
+.c0 .c1,
+.c0 .sc-AxjAm,
+.c0 .sc-AxjAm * {
+  -webkit-transition: all 100ms ease-out;
+  transition: all 100ms ease-out;
+}
+
+.c0:hover {
+  cursor: pointer;
+}
+
+.c0:focus {
+  outline: none;
+}
+
+.c0:disabled {
+  cursor: not-allowed;
+}
+
+.c0:disabled {
+  color: #98A7B7;
+  background: #dfe4e9;
+}
+
+.c0:disabled .sc-AxjAm * {
+  fill: #98A7B7;
+}
+
+.c0:not(:disabled):not(:hover) {
+  color: #ffffff;
+  background: #126AFA;
+}
+
+.c0:not(:disabled):not(:hover) .sc-AxjAm * {
+  fill: #ffffff;
+}
+
+.c0:not(:disabled):active {
+  color: #ffffff;
+  background: #0D4AAF;
+}
+
+.c0:not(:disabled):active .sc-AxjAm * {
+  fill: #ffffff;
+}
+
+.c0:not(:disabled):not(:active):hover {
+  color: #ffffff;
+  background: #0F5AD5;
+  box-shadow: 0 0.2rem 0.8rem rgba(15,90,213,0.35);
+}
+
+.c0:not(:disabled):not(:active):hover .sc-AxjAm * {
+  fill: #ffffff;
+}
+
+.c0 .sc-AxjAm + .c1 {
+  margin-left: 0.8rem;
+}
+
+.c0 .c1 + .sc-AxjAm {
+  margin-left: 0.8rem;
+}
+
+<div>
+  <button
+    class="c0"
+    type="button"
+  >
+    <span
+      class="c1 c2"
+    >
+      Button
+    </span>
+  </button>
+</div>
+`;
+
+exports[`Button component with "solid" variant should render properly with "XS" size 1`] = `
+.c2 {
+  margin: 0;
+  color: inherit;
+  font-size: 1.4rem;
+  font-weight: 600;
+  -webkit-letter-spacing: 0rem;
+  -moz-letter-spacing: 0rem;
+  -ms-letter-spacing: 0rem;
+  letter-spacing: 0rem;
+  line-height: 2.2rem;
+  text-align: initial;
+}
+
+.c0 {
+  border: none;
+  position: relative;
+  -webkit-user-select: none;
+  -moz-user-select: none;
+  -ms-user-select: none;
+  user-select: none;
+  font-family: inherit;
+  -webkit-text-decoration: none;
+  text-decoration: none;
+  -webkit-transition: all 100ms ease-out;
+  transition: all 100ms ease-out;
+  padding: 0.7rem 1.6rem 0.9rem;
   border-radius: 0.8rem;
   display: -webkit-inline-box;
   display: -webkit-inline-flex;

--- a/packages/theme/src/core/button/index.ts
+++ b/packages/theme/src/core/button/index.ts
@@ -15,11 +15,13 @@ const button: ButtonTheme = {
         textColor: { default: colors.blue[500], hovered: colors.blue[600], pressed: colors.blue[700], disabled: colors.grey[500] }
     },
     padding: {
+        XS: '0.7rem 1.6rem 0.9rem',
         S: '0.8rem 2.4rem 1rem',
         M: '1rem 2.4rem 1.2rem',
         L: '1.2rem 2.4rem 1.4rem'
     },
     textVariant: {
+        XS: 'button2',
         S: 'button2',
         M: 'button1',
         L: 'button1'

--- a/packages/theme/src/core/button/index.ts
+++ b/packages/theme/src/core/button/index.ts
@@ -17,7 +17,7 @@ const button: ButtonTheme = {
         textColor: { default: colors.blue[500], hovered: colors.blue[600], pressed: colors.blue[700], disabled: colors.grey[500] }
     },
     padding: {
-        XS: '0.7rem 1.6rem 0.9rem',
+        XS: '0.4rem 1.6rem 0.6rem',
         S: '0.8rem 2.4rem 1rem',
         M: '1rem 2.4rem 1.2rem',
         L: '1.2rem 2.4rem 1.4rem'

--- a/packages/theme/src/core/button/types.ts
+++ b/packages/theme/src/core/button/types.ts
@@ -1,6 +1,6 @@
 import { FontVariants } from '../font/types';
 
-export type ButtonSizes = 'S' | 'M' | 'L';
+export type ButtonSizes = 'XS' | 'S' | 'M' | 'L';
 
 type Colors = {
     default: string;


### PR DESCRIPTION
### PR Checklist

Please check if your PR fulfills the following requirements:

-   [x] Tests for the changes have been added (for bug fixes / features)
-   [x] Docs have been added / updated (for bug fixes / features)

### PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

-   [ ] Bugfix
-   [x] Feature
-   [ ] Code style update (formatting, local variables)
-   [ ] Refactoring (no functional changes, no api changes)
-   [ ] Build related changes
-   [ ] CI related changes
-   [ ] Performance improves
-   [ ] Adding missing tests
-   [ ] Documentation content changes
-   [ ] Other... Please describe:

### What is the current behavior?

Buttons have three sizes available: S, M, and L.

### What is the new behavior?

Buttons will now have four sizes available: XS, S, M, and L.
The default sizes for S, M, and L have not been altered.
The new XS button follows the spec outlined here: https://medlypharmacy.atlassian.net/browse/PES-1463

### Does this PR introduce a breaking change?

-   [ ] Yes
-   [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

### Additional context

Screencap of storybook showing button size comparison:

<img width="1034" alt="Screen Shot 2021-06-15 at 3 55 51 PM" src="https://user-images.githubusercontent.com/69819314/122115264-43e82880-cdf2-11eb-9182-ec280ac20279.png">

https://user-images.githubusercontent.com/69819314/122115247-3c288400-cdf2-11eb-95c3-c393b501b417.mp4


