### PR TITLE
fix: npm warnings for projects using react 17

### DIFF
--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -21,8 +21,8 @@
         "@medly-components/icons": "1.6.2",
         "@medly-components/theme": "1.30.10",
         "@medly-components/utils": "1.9.2",
-        "effector": "^20.16.1",
-        "effector-react": "^20.7.4",
+        "effector": "^21.8.12",
+        "effector-react": "^21.3.2",
         "polished": "^3.6.2",
         "resize-observer-polyfill": "^1.5.1"
     }

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -13,8 +13,8 @@
     },
     "license": "MIT",
     "peerDependencies": {
-        "react": "^16 || ^17",
-        "react-dom": "^16 || ^17",
+        "react": "16.x || 17.x",
+        "react-dom": "16.x || 17.x",
         "styled-components": "^5.1.0"
     },
     "dependencies": {

--- a/packages/forms/package.json
+++ b/packages/forms/package.json
@@ -13,8 +13,8 @@
     },
     "license": "MIT",
     "peerDependencies": {
-        "react": "^16 || ^17",
-        "react-dom": "^16 || ^17",
+        "react": "16.x || 17.x",
+        "react-dom": "16.x || 17.x",
         "styled-components": "^5.1.0"
     },
     "dependencies": {

--- a/packages/icons/package.json
+++ b/packages/icons/package.json
@@ -17,8 +17,8 @@
         "precreate-icons": "rimraf ./src/icons && rimraf ./src/index.ts && rimraf ./src/icons.stories.mdx"
     },
     "peerDependencies": {
-        "react": "^16 || ^17",
-        "react-dom": "^16 || ^17",
+        "react": "16.x || 17.x",
+        "react-dom": "16.x || 17.x",
         "styled-components": "^5.1.0"
     },
     "dependencies": {

--- a/packages/layout/package.json
+++ b/packages/layout/package.json
@@ -13,8 +13,8 @@
     },
     "license": "MIT",
     "peerDependencies": {
-        "react": "^16 || ^17",
-        "react-dom": "^16 || ^17",
+        "react": "16.x || 17.x",
+        "react-dom": "16.x || 17.x",
         "styled-components": "^5.1.0"
     },
     "dependencies": {

--- a/packages/loaders/package.json
+++ b/packages/loaders/package.json
@@ -13,8 +13,8 @@
     },
     "license": "MIT",
     "peerDependencies": {
-        "react": "^16 || ^17",
-        "react-dom": "^16 || ^17",
+        "react": "16.x || 17.x",
+        "react-dom": "16.x || 17.x",
         "styled-components": "^5.1.0"
     },
     "dependencies": {

--- a/packages/utils/package.json
+++ b/packages/utils/package.json
@@ -13,8 +13,8 @@
     },
     "license": "MIT",
     "peerDependencies": {
-        "react": "^16 || ^17",
-        "react-dom": "^16 || ^17",
+        "react": "16.x || 17.x",
+        "react-dom": "16.x || 17.x",
         "styled-components": "^5.1.0"
     },
     "dependencies": {

--- a/yarn.lock
+++ b/yarn.lock
@@ -7204,17 +7204,15 @@ ee-first@1.1.1:
   resolved "https://registry.yarnpkg.com/ee-first/-/ee-first-1.1.1.tgz#590c61156b0ae2f4f0255732a158b266bc56b21d"
   integrity sha1-WQxhFWsK4vTwJVcyoViyZrxWsh0=
 
-effector-react@^20.7.4:
-  version "20.9.0"
-  resolved "https://registry.yarnpkg.com/effector-react/-/effector-react-20.9.0.tgz#51cc0469321f56107ae75e219cc0280d46f72ae6"
-  integrity sha512-Fh/dGPFDGz8YyCbIeBxmqSlTGHdsTVl7lWSI92Z4PWf9Gac7Zvd7/1gE5a5uhfYSZvo0SjqYfT7fFsz81G4pEA==
+effector-react@^21.3.2:
+  version "21.3.2"
+  resolved "https://registry.yarnpkg.com/effector-react/-/effector-react-21.3.2.tgz#1ef52bf72fb304cb76e8bd1d7b75dd5f588ff661"
+  integrity sha512-+SGFgsfVnQ4cSwcjugjK+DnKVk7MDaNTOOzw2n1+8/c477w6YwFi4KusPnMfeWtaAdfidTmRn1EoYSvUhAX+EQ==
 
-effector@^20.16.1:
-  version "20.17.2"
-  resolved "https://registry.yarnpkg.com/effector/-/effector-20.17.2.tgz#825987cdbf91b062e01074b5b47bcca9720efe94"
-  integrity sha512-Msbq6xem+Dal9BzReq6qqSKcb3ey4gVeJzG9S3wRVSPmErs8886STqGFGz9BbxrBR7Xy52cEMfI7KsBmmT1K7A==
-  dependencies:
-    symbol-observable "^1.2.0"
+effector@^21.8.12:
+  version "21.8.12"
+  resolved "https://registry.yarnpkg.com/effector/-/effector-21.8.12.tgz#075ba0e17e41386bef271567a259585f407067ae"
+  integrity sha512-Xlw+qvPlfiF0qOHwRQ3RzS5/TtbfpCZ88ucLqG6o8algEV0nxI+Rd8fyJObDljfqQH0+2ByInawu731IXz5RCA==
 
 ejs@^2.7.4:
   version "2.7.4"
@@ -15275,11 +15273,6 @@ svgo@^1.2.2:
     stable "^0.1.8"
     unquote "~1.1.1"
     util.promisify "~1.0.0"
-
-symbol-observable@^1.2.0:
-  version "1.2.0"
-  resolved "https://registry.yarnpkg.com/symbol-observable/-/symbol-observable-1.2.0.tgz#c22688aed4eab3cdc2dfeacbb561660560a00804"
-  integrity sha512-e900nM8RRtGhlV36KGEU9k65K3mPb1WV70OdjfxlG2EAuM1noi/E/BaW/uMhL7bPEssK8QV57vN3esixjUvcXQ==
 
 symbol-tree@^3.2.2:
   version "3.2.4"


### PR DESCRIPTION
### PR Checklist

Please check if your PR fulfills the following requirements:

-   [ ] Tests for the changes have been added (for bug fixes / features)
-   [ ] Docs have been added / updated (for bug fixes / features)

### PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

-   [x] Bugfix
-   [ ] Feature
-   [ ] Code style update (formatting, local variables)
-   [ ] Refactoring (no functional changes, no api changes)
-   [ ] Build related changes
-   [ ] CI related changes
-   [ ] Performance improves
-   [ ] Adding missing tests
-   [ ] Documentation content changes
-   [ ] Other... Please describe:

### What is the current behavior?

Currently for projects using react 17 medly components gives warnings.

## Fixes # (issue)

### What is the new behavior?

Added `react 17` also as peer dependency to suppress the warning for projects using react 17.

### Does this PR introduce a breaking change?

-   [ ] Yes
-   [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

### Additional context

Add any other context or screenshots about the feature pr here.
