### PR TITLE
fix: focus issue when we select either month or year in single month …

### DIFF
--- a/packages/core/src/components/Calendar/MonthAndYearSelection/MonthAndYearSelection.tsx
+++ b/packages/core/src/components/Calendar/MonthAndYearSelection/MonthAndYearSelection.tsx
@@ -12,8 +12,8 @@ export const MonthAndYearSelection: React.FC<MonthAndYearSelectionProps> & WithS
             { month: maxMonth, year: maxYear } = getMonthAndYearFromDate(maxSelectableDate);
 
         const stopPropagation = useCallback(e => e.stopPropagation(), []),
-            handleMonthChange = useCallback((value: number) => onChange({ year: year, month: value }), [year]),
-            handleYearChange = useCallback((value: number) => onChange({ month: month, year: value }), [month]);
+            handleMonthChange = useCallback((value: number) => onChange({ year: year, month: value }), [year, onChange]),
+            handleYearChange = useCallback((value: number) => onChange({ month: month, year: value }), [month, onChange]);
 
         const monthOptions = useMemo(
                 () =>

--- a/packages/core/src/components/DateRangePicker/DateRangeCalendar/DateRangeCalendar.tsx
+++ b/packages/core/src/components/DateRangePicker/DateRangeCalendar/DateRangeCalendar.tsx
@@ -55,10 +55,13 @@ export const DateRangeCalendar: React.FC<Props> & WithStyle = React.memo(props =
             focusElement(focusedElement);
             setActive(true);
         }, [focusedElement]),
-        handleMonthAndYearChange = useCallback((val: { month: number; year: number }) => {
-            handleCalendarClick();
-            setMonthAndYear(val);
-        }, []),
+        handleMonthAndYearChange = useCallback(
+            (val: { month: number; year: number }) => {
+                handleCalendarClick();
+                setMonthAndYear(val);
+            },
+            [focusedElement]
+        ),
         handleAnimationEnd = useCallback(() => {
             if (slideDirection === 'move-out-left' || slideDirection === 'move-out-right') {
                 if (slideDirection === 'move-out-left') {


### PR DESCRIPTION
…calendar view

affects: @medly-components/core

### PR Checklist

Please check if your PR fulfills the following requirements:

-   [x] Tests for the changes have been added (for bug fixes / features)
-   [x] Docs have been added / updated (for bug fixes / features)

### PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

-   [x] Bugfix
-   [ ] Feature
-   [ ] Code style update (formatting, local variables)
-   [ ] Refactoring (no functional changes, no api changes)
-   [ ] Build related changes
-   [ ] CI related changes
-   [ ] Performance improves
-   [ ] Adding missing tests
-   [ ] Documentation content changes
-   [ ] Other... Please describe:

### What is the current behavior?

As soon as we select From date from calendar the cursor moves to To date field but if I click on calendar to select the month/year then that cursor again comes to From date field and it selects again from date only.

## Fixes #294

### What is the new behavior?

As soon as we select From date from calendar the cursor moves to To date field and stays there after selecting month/year.

### Does this PR introduce a breaking change?

-   [ ] Yes
-   [x] No
