### PR TITLE
fix: showing error even if date is filled when required prop is passe…

### DIFF
--- a/packages/core/src/components/DatePicker/DatePicker.tsx
+++ b/packages/core/src/components/DatePicker/DatePicker.tsx
@@ -35,6 +35,7 @@ export const DatePicker: React.FC<DatePickerProps> & WithStyle = React.memo(
             );
         const wrapperRef = useRef<HTMLDivElement>(null),
             inputRef = useCombinedRefs<HTMLInputElement>(ref, React.useRef(null)),
+            [inputKey, setInputKey] = useState(0),
             [textValue, setTextValue] = useState(''),
             [builtInErrorMessage, setErrorMessage] = useState(''),
             [showCalendar, toggleCalendar] = useState(false),
@@ -110,6 +111,10 @@ export const DatePicker: React.FC<DatePickerProps> & WithStyle = React.memo(
             toggleCalendar(false);
         }, wrapperRef);
 
+        useEffect(() => {
+            date && !showCalendar && setInputKey(key => key + 1);
+        }, [date, showCalendar]);
+
         const suffixEl = () => (
             <DateIconWrapper variant={restProps.variant} isErrorPresent={isErrorPresent} isActive={active} disabled={disabled} size={size}>
                 <DateRangeIcon id={`${id}-calendar-icon`} onClick={onIconClick} size={size} />
@@ -129,6 +134,7 @@ export const DatePicker: React.FC<DatePickerProps> & WithStyle = React.memo(
                 <TextField
                     errorText={errorText || builtInErrorMessage}
                     id={id}
+                    key={inputKey}
                     ref={inputRef}
                     required={required}
                     {...(showCalendarIcon && { suffix: suffixEl })}


### PR DESCRIPTION
…d to DatePicker

affects: @medly-components/core

### PR Checklist

Please check if your PR fulfills the following requirements:

-   [x] Tests for the changes have been added (for bug fixes / features)
-   [x] Docs have been added / updated (for bug fixes / features)

### PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

-   [x] Bugfix
-   [ ] Feature
-   [ ] Code style update (formatting, local variables)
-   [ ] Refactoring (no functional changes, no api changes)
-   [ ] Build related changes
-   [ ] CI related changes
-   [ ] Performance improves
-   [ ] Adding missing tests
-   [ ] Documentation content changes
-   [ ] Other... Please describe:

### What is the current behavior?

If we select date in DatePicker component when it is required,  it gives error.

## Fixes #285 

### What is the new behavior?

It will show any error if we select date.

### Does this PR introduce a breaking change?

-   [ ] Yes
-   [x] No