### PR TITLE
feat(core): Add pressed state to Avatar component

### DIFF
--- a/packages/core/src/components/Avatar/Avatar.styled.tsx
+++ b/packages/core/src/components/Avatar/Avatar.styled.tsx
@@ -26,6 +26,18 @@ const hoverStyle = ({ theme, hoverBgColor, hoverTextColor }: StyledProps) => {
     `;
 };
 
+const pressedStyle = ({ theme, pressedBgColor, pressedTextColor }: StyledProps) => {
+    const { defaults } = theme.avatar;
+    return css`
+        &:active {
+            background: ${pressedBgColor || defaults.pressed.bgColor};
+            ${Text.Style} {
+                color: ${pressedTextColor || defaults.pressed.textColor};
+            }
+        }
+    `;
+};
+
 const getTextStyle = ({ theme, ...props }: StyledProps) => {
     const { size, textColor, bgColor } = props,
         { defaults, sizes } = theme.avatar,
@@ -68,5 +80,6 @@ export const AvatarStyled = styled('div').attrs(({ theme: { avatar: { defaults }
         border-radius: ${({ defaults }) => defaults.borderRadius};
     }
 
-    ${({ withHoverEffect }) => withHoverEffect && hoverStyle}
+    ${props => props.onClick && hoverStyle};
+    ${props => props.onClick && pressedStyle};
 `;

--- a/packages/core/src/components/Avatar/Avatar.test.tsx
+++ b/packages/core/src/components/Avatar/Avatar.test.tsx
@@ -5,7 +5,7 @@ import { Avatar } from './Avatar';
 
 describe('Avatar component', () => {
     it('should render with default theme', () => {
-        const { container } = render(<Avatar withHoverEffect={true}>M</Avatar>);
+        const { container } = render(<Avatar>M</Avatar>);
         expect(container).toMatchSnapshot();
     });
 
@@ -15,11 +15,26 @@ describe('Avatar component', () => {
                 size="M"
                 textColor={defaultTheme.colors.green[500]}
                 bgColor={defaultTheme.colors.green[100]}
-                withHoverEffect={true}
                 hoverBgColor={defaultTheme.colors.green[400]}
                 hoverTextColor={defaultTheme.colors.white}
                 hoverImgShadowColor="rgba(96, 120, 144, 0.35)"
                 hoverTextShadowColor="rgba(0, 128, 0, 0.35)"
+                pressedBgColor="rgba(96, 120, 144, 0.65)"
+                pressedTextColor="rgba(0, 128, 0, 0.65)"
+                onClick={jest.fn()}
+            >
+                M
+            </Avatar>
+        );
+        expect(container).toMatchSnapshot();
+    });
+
+    it('should render with default hover and pressed states', () => {
+        const { container } = render(
+            <Avatar
+                size="M"
+                textColor={defaultTheme.colors.green[500]}
+                bgColor={defaultTheme.colors.green[100]}
                 onClick={jest.fn()}
             >
                 M
@@ -39,14 +54,14 @@ describe('Avatar component', () => {
 
     it('should render image avatar properly', () => {
         const { container } = render(
-            <Avatar size="L" withHoverEffect={true}>
+            <Avatar size="L" onClick={jest.fn()}>
                 <img src="http://dummurl" />
             </Avatar>
         );
         expect(container).toMatchSnapshot();
     });
 
-    it('should render avatar without hover', () => {
+    it('should render avatar without hover and pressed states', () => {
         const { container } = render(
             <Avatar
                 size="M"
@@ -56,7 +71,8 @@ describe('Avatar component', () => {
                 hoverTextColor={defaultTheme.colors.white}
                 hoverImgShadowColor="rgba(96, 120, 144, 0.35)"
                 hoverTextShadowColor="rgba(0, 128, 0, 0.35)"
-                onClick={jest.fn()}
+                pressedBgColor="rgba(96, 120, 144, 0.65)"
+                pressedTextColor="rgba(0, 128, 0, 0.65)"
             >
                 M
             </Avatar>

--- a/packages/core/src/components/Avatar/Avatar.tsx
+++ b/packages/core/src/components/Avatar/Avatar.tsx
@@ -26,6 +26,3 @@ export const Avatar: FC<Props> & WithStyle = React.memo(
 );
 Avatar.displayName = 'Avatar';
 Avatar.Style = AvatarStyled;
-Avatar.defaultProps = {
-    withHoverEffect: false
-};

--- a/packages/core/src/components/Avatar/__snapshots__/Avatar.test.tsx.snap
+++ b/packages/core/src/components/Avatar/__snapshots__/Avatar.test.tsx.snap
@@ -1,6 +1,6 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`Avatar component should render avatar without hover 1`] = `
+exports[`Avatar component should render avatar without hover and pressed states 1`] = `
 .c2 {
   margin: 0;
   color: inherit;
@@ -25,7 +25,7 @@ exports[`Avatar component should render avatar without hover 1`] = `
   height: 4rem;
   border-radius: 50%;
   overflow: hidden;
-  cursor: pointer;
+  cursor: inherit;
   color: #008000;
   background: #E6F2E6;
   -webkit-user-select: none;
@@ -74,7 +74,7 @@ exports[`Avatar component should render image avatar properly 1`] = `
   height: 4.8rem;
   border-radius: 50%;
   overflow: hidden;
-  cursor: inherit;
+  cursor: pointer;
   color: #126AFA;
   background: #E7F0FF;
   -webkit-user-select: none;
@@ -100,11 +100,19 @@ exports[`Avatar component should render image avatar properly 1`] = `
 }
 
 .c0:hover {
-  background: #70ADE9;
+  background: #126AFA;
   box-shadow: 0 0.4rem 0.8rem rgba(96,120,144,0.35);
 }
 
 .c0:hover .sc-AxjAm {
+  color: #ffffff;
+}
+
+.c0:active {
+  background: #0F5AD5;
+}
+
+.c0:active .sc-AxjAm {
   color: #ffffff;
 }
 
@@ -178,6 +186,94 @@ exports[`Avatar component should render with all the props given 1`] = `
   color: #ffffff;
 }
 
+.c0:active {
+  background: rgba(96,120,144,0.65);
+}
+
+.c0:active .c1 {
+  color: rgba(0,128,0,0.65);
+}
+
+<div>
+  <div
+    class="c0"
+  >
+    <strong
+      class="c1 c2"
+    >
+      M
+    </strong>
+  </div>
+</div>
+`;
+
+exports[`Avatar component should render with default hover and pressed states 1`] = `
+.c2 {
+  margin: 0;
+  color: inherit;
+  font-size: 1.4rem;
+  font-weight: 700;
+  -webkit-letter-spacing: 0rem;
+  -moz-letter-spacing: 0rem;
+  -ms-letter-spacing: 0rem;
+  letter-spacing: 0rem;
+  line-height: 2.2rem;
+  text-align: initial;
+  text-transform: uppercase;
+}
+
+.c0 {
+  display: inline-block;
+  text-align: center;
+  min-width: -webkit-max-content;
+  min-width: -moz-max-content;
+  min-width: max-content;
+  width: 4rem;
+  height: 4rem;
+  border-radius: 50%;
+  overflow: hidden;
+  cursor: pointer;
+  color: #008000;
+  background: #E6F2E6;
+  -webkit-user-select: none;
+  -moz-user-select: none;
+  -ms-user-select: none;
+  user-select: none;
+}
+
+.c0 .c1 {
+  line-height: 4rem;
+  font-size: 1.6rem;
+  font-weight: 400;
+  font-family: Open Sans;
+}
+
+.c0 img {
+  width: 4rem;
+  height: 4rem;
+  object-fit: cover;
+  border: 0.1rem solid #dfe4e9;
+  box-sizing: border-box;
+  border-radius: 50%;
+}
+
+.c0:hover {
+  background: #126AFA;
+  box-shadow: 0 0.4rem 0.8rem rgba(0,90,238,0.35);
+}
+
+.c0:hover .c1 {
+  color: #ffffff;
+}
+
+.c0:active {
+  background: #0F5AD5;
+}
+
+.c0:active .c1 {
+  color: #ffffff;
+}
+
 <div>
   <div
     class="c0"
@@ -239,15 +335,6 @@ exports[`Avatar component should render with default theme 1`] = `
   border: 0.1rem solid #dfe4e9;
   box-sizing: border-box;
   border-radius: 50%;
-}
-
-.c0:hover {
-  background: #70ADE9;
-  box-shadow: 0 0.4rem 0.8rem rgba(0,90,238,0.35);
-}
-
-.c0:hover .c1 {
-  color: #ffffff;
 }
 
 <div>

--- a/packages/core/src/components/Avatar/types.ts
+++ b/packages/core/src/components/Avatar/types.ts
@@ -8,8 +8,6 @@ export interface Props extends Omit<HTMLProps<HTMLDivElement>, 'size'>, WithThem
     textColor?: string;
     /** Background color */
     bgColor?: string;
-    /** Set it true to show the hover effect */
-    withHoverEffect?: boolean;
     /** Hover Text color */
     hoverTextColor?: string;
     /** Hover Background color */
@@ -18,6 +16,10 @@ export interface Props extends Omit<HTMLProps<HTMLDivElement>, 'size'>, WithThem
     hoverTextShadowColor?: string;
     /** Hover image shadow color */
     hoverImgShadowColor?: string;
+    /** Pressed Background color */
+    pressedBgColor?: string,
+    /** Pressed Text color */
+    pressedTextColor?: string,
 }
 
 export interface StyledProps extends Props {

--- a/packages/theme/src/core/avatar/index.ts
+++ b/packages/theme/src/core/avatar/index.ts
@@ -28,8 +28,12 @@ const avatar: AvatarTheme = {
             textShadowColor: 'rgba(0, 90, 238, 0.35)',
             imgShadowColor: 'rgba(96, 120, 144, 0.35)',
             textColor: colors.white,
-            bgColor: colors.blue[400]
-        }
+            bgColor: colors.blue[500],
+        },
+        pressed: {
+            bgColor: colors.blue[600],
+            textColor: colors.white,
+        },
     }
 };
 

--- a/packages/theme/src/core/avatar/types.ts
+++ b/packages/theme/src/core/avatar/types.ts
@@ -25,5 +25,9 @@ export interface AvatarTheme {
             textShadowColor: string;
             imgShadowColor: string;
         };
+        pressed: {
+            bgColor: string;
+            textColor: string;
+        };
     };
 }


### PR DESCRIPTION
affects: @medly-components/core, @medly-components/theme

Add pressed state to Avatar component and enable pressed and hover state with onClick prop. Remove
withHoverEffect prop.

BREAKING CHANGE:
withHoverEffect prop was removed.

### PR Checklist

Please check if your PR fulfills the following requirements:

-   [x] Tests for the changes have been added (for bug fixes / features)
-   [ ] Docs have been added / updated (for bug fixes / features)

### PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

-   [ ] Bugfix
-   [x] Feature
-   [ ] Code style update (formatting, local variables)
-   [ ] Refactoring (no functional changes, no api changes)
-   [ ] Build related changes
-   [ ] CI related changes
-   [ ] Performance improves
-   [ ] Adding missing tests
-   [ ] Documentation content changes
-   [ ] Other... Please describe:

### What is the current behavior?

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->
The current behavior requires withHoverEffect prop in order to enable hover state for Avatar component. There is no pressed state for Avatar component.
## Fixes # (issue)

### What is the new behavior?
The new behavior is that the hover and pressed state are enabled when onClick prop exists in Avatar component. If onClick prop does not exist, then hover and pressed state are not enabled. The withHoverEffect prop was removed.
### Does this PR introduce a breaking change?

-   [x] Yes
-   [ ] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->
This was discussed on slack with Mukul and per his feedback, the only app currently using withHoverEffect is connect, but it's used with onClick prop.
### Additional context

Add any other context or screenshots about the feature pr here.
