### PR TITLE
feat(core): add headerFontVariant prop to Table in order to control t…

### DIFF
--- a/packages/core/src/components/Table/Head/Head.tsx
+++ b/packages/core/src/components/Table/Head/Head.tsx
@@ -31,7 +31,8 @@ const Head: React.FC<Props> = React.memo(props => {
             onSelectAllClick,
             maxColumnSizes,
             showShadowAtBottom,
-            showShadowAfterFrozenElement
+            showShadowAfterFrozenElement,
+            fontVariant
         } = props;
 
     const [{ sortField }, setTableState] = useContext(TableStateContext);
@@ -103,6 +104,7 @@ const Head: React.FC<Props> = React.memo(props => {
                             addColumnMaxSize={addColumnMaxSize}
                             isRowActionCell={config.field === 'row-actions'}
                             showShadowAtRight={config.field === 'row-actions' && showShadowAfterFrozenElement}
+                            fontVariant={fontVariant}
                         >
                             {config.field === 'row-actions' && isRowSelectable ? selectAllCheckBox : config.title}
                         </HeadCell>

--- a/packages/core/src/components/Table/Head/HeadCell/HeadCell.styled.tsx
+++ b/packages/core/src/components/Table/Head/HeadCell/HeadCell.styled.tsx
@@ -1,6 +1,6 @@
 import { SvgIcon } from '@medly-components/icons';
 import { Theme } from '@medly-components/theme';
-import { clearMarginPadding, css, getFontStyle, styled } from '@medly-components/utils';
+import { clearMarginPadding, css, styled } from '@medly-components/utils';
 import { rgba } from 'polished';
 import Checkbox from '../../../Checkbox';
 import Text from '../../../Text';
@@ -64,7 +64,6 @@ export const HeadCellStyled = styled.th<HeadCellStyledProps>`
     position: ${({ frozen }) => (frozen ? 'sticky' : 'relative')};
     cursor: ${({ isRowActionCell }) => isRowActionCell && 'default'};
     padding: ${getHeadCellPadding};
-    ${({ theme }) => theme.table.header.fontVariant && getFontStyle({ theme, fontVariant: theme.table.header.fontVariant })}
 
     &:not(:last-child) {
         &::after {

--- a/packages/core/src/components/Table/Head/HeadCell/HeadCell.tsx
+++ b/packages/core/src/components/Table/Head/HeadCell/HeadCell.tsx
@@ -23,6 +23,7 @@ const HeadCell: React.FC<HeadCellProps> & WithStyle = React.memo(props => {
         tableSize,
         hiddenDivRef,
         addColumnMaxSize,
+        fontVariant,
         ...restProps
     } = props;
 
@@ -107,7 +108,7 @@ const HeadCell: React.FC<HeadCellProps> & WithStyle = React.memo(props => {
                                 isSelected={sortField === field && !isLoading}
                                 withHoverEffect={sortable && !isLoading}
                             >
-                                <Text textVariant="h5" uppercase>
+                                <Text textVariant={fontVariant || 'h5'} uppercase>
                                     {c}
                                 </Text>
                                 {sortable && sortIcon}

--- a/packages/core/src/components/Table/Head/HeadCell/types.ts
+++ b/packages/core/src/components/Table/Head/HeadCell/types.ts
@@ -1,3 +1,4 @@
+import { FontVariants } from '@medly-components/theme';
 import { TableProps } from '../../types';
 
 export type SortOrder = 'asc' | 'desc';
@@ -28,4 +29,5 @@ export type HeadCellProps = HeadCellStyledProps & {
     as?: keyof JSX.IntrinsicElements | React.ComponentType<any>;
     hiddenDivRef?: React.MutableRefObject<any>;
     addColumnMaxSize?: (field: string, value: number) => void;
+    fontVariant?: FontVariants;
 };

--- a/packages/core/src/components/Table/Head/types.ts
+++ b/packages/core/src/components/Table/Head/types.ts
@@ -1,5 +1,5 @@
+import { FontVariants } from '@medly-components/theme';
 import { MaxColumnSizes, TableColumnConfig } from '../types';
-
 export interface Props {
     setColumns: React.Dispatch<React.SetStateAction<TableColumnConfig[]>>;
     areAllRowsSelected?: boolean;
@@ -9,4 +9,5 @@ export interface Props {
     maxColumnSizes: MaxColumnSizes;
     showShadowAtBottom: boolean;
     showShadowAfterFrozenElement?: boolean;
+    fontVariant?: FontVariants;
 }

--- a/packages/core/src/components/Table/Table.tsx
+++ b/packages/core/src/components/Table/Table.tsx
@@ -33,6 +33,7 @@ export const Table: FC<TableProps> & WithStyle & StaticProps = React.memo(
                 withActionBar,
                 withPagination,
                 onScrolledToBottom,
+                headerFontVariant,
                 ...restProps
             } = props,
             isGroupedTable = !!restProps.groupBy,
@@ -119,6 +120,7 @@ export const Table: FC<TableProps> & WithStyle & StaticProps = React.memo(
                                 isSelectAllDisable: isSelectAllDisable,
                                 showShadowAtBottom: !scrollState.isScrolledToTop,
                                 showShadowAfterFrozenElement: !scrollState.isScrolledToLeft,
+                                fontVariant: headerFontVariant,
                                 isAnyRowSelected:
                                     !areAllRowsSelected && (isGroupedTable ? groupedRowSelector.selectedIds.length > 0 : isAnyRowSelected)
                             }}

--- a/packages/core/src/components/Table/types.ts
+++ b/packages/core/src/components/Table/types.ts
@@ -1,3 +1,4 @@
+import { FontVariants } from '@medly-components/theme';
 import { HTMLProps, Omit } from '@medly-components/utils';
 import { Dispatch, SetStateAction } from 'react';
 import ColumnConfiguration from './ColumnConfiguration';
@@ -115,6 +116,8 @@ export interface TableProps extends Omit<HTMLProps<HTMLTableElement>, 'data' | '
     onScrolledToBottom?: () => any;
     /** Enables a mini map to scroll horizontally across the table*/
     withMinimap?: boolean;
+    /** Defines the Font Variant for the Table Header */
+    headerFontVariant?: FontVariants;
 }
 
 export interface StaticProps {

--- a/packages/theme/src/core/table/types.ts
+++ b/packages/theme/src/core/table/types.ts
@@ -1,4 +1,3 @@
-import { FontVariants } from '../font/types';
 
 export interface TableTheme {
     borderColor: string;
@@ -98,7 +97,6 @@ export interface TableTheme {
             };
         };
         separatorColor?: string;
-        fontVariant?: FontVariants;
     };
     actionBar?: {
         bgColor: string;


### PR DESCRIPTION
…he fontVariant for Text in Head

affects: @medly-components/core

add optional headerFontVariant prop to Table component in order to optionally pass down a
fontVariant to Text component in HeadCell. Removed (in second commit) the optional theme.table.header.fontVariant introduced on Friday as it currently does not work and does not alter the header's font styling.

### PR Checklist

Please check if your PR fulfills the following requirements:

-   [ ] Tests for the changes have been added (for bug fixes / features)
-   [x] Docs have been added / updated (for bug fixes / features)

### PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

-   [x] Bugfix
-   [ ] Feature
-   [ ] Code style update (formatting, local variables)
-   [ ] Refactoring (no functional changes, no api changes)
-   [ ] Build related changes
-   [ ] CI related changes
-   [ ] Performance improves
-   [ ] Adding missing tests
-   [ ] Documentation content changes
-   [ ] Other... Please describe:

### What is the current behavior?

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->
optional theme.table.header.fontVariant, introduced on Friday, currently does not alter the header's font styling.
## Fixes # (issue)

### What is the new behavior?
adding optional headerFontVariant prop to Table to be able to optionally modify the fontVariant for the Text Component in the HeadCell.
### Does this PR introduce a breaking change?
Should not introduce a breaking change as current implementation does not work.
-   [ ] Yes
-   [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

### Additional context

Add any other context or screenshots about the feature pr here.
