### PR TITLE
fix(core): remove optional theme.table.header.fontVariant

### DIFF
--- a/packages/core/src/components/Table/Head/HeadCell/HeadCell.styled.tsx
+++ b/packages/core/src/components/Table/Head/HeadCell/HeadCell.styled.tsx
@@ -1,6 +1,6 @@
 import { SvgIcon } from '@medly-components/icons';
 import { Theme } from '@medly-components/theme';
-import { clearMarginPadding, css, getFontStyle, styled } from '@medly-components/utils';
+import { clearMarginPadding, css, styled } from '@medly-components/utils';
 import { rgba } from 'polished';
 import Checkbox from '../../../Checkbox';
 import Text from '../../../Text';
@@ -64,7 +64,6 @@ export const HeadCellStyled = styled.th<HeadCellStyledProps>`
     position: ${({ frozen }) => (frozen ? 'sticky' : 'relative')};
     cursor: ${({ isRowActionCell }) => isRowActionCell && 'default'};
     padding: ${getHeadCellPadding};
-    ${({ theme }) => theme.table.header.fontVariant && getFontStyle({ theme, fontVariant: theme.table.header.fontVariant })}
 
     &:not(:last-child) {
         &::after {

--- a/packages/theme/src/core/table/types.ts
+++ b/packages/theme/src/core/table/types.ts
@@ -1,4 +1,3 @@
-import { FontVariants } from '../font/types';
 
 export interface TableTheme {
     borderColor: string;
@@ -98,7 +97,6 @@ export interface TableTheme {
             };
         };
         separatorColor?: string;
-        fontVariant?: FontVariants;
     };
     actionBar?: {
         bgColor: string;


### PR DESCRIPTION
affects: @medly-components/core, @medly-components/theme

remove optional theme.table.header.fontVariant, added on Friday, as it's no longer needed. It
currently is overridden by the Text component's textVariant prop.

BREAKING CHANGE:
should not have any breaking changes as current implementation of optional
theme.table.header.fontVariant is overridden by the Text component's textVariant prop.

### PR Checklist

Please check if your PR fulfills the following requirements:

-   [ ] Tests for the changes have been added (for bug fixes / features)
-   [ ] Docs have been added / updated (for bug fixes / features)

### PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

-   [x] Bugfix
-   [ ] Feature
-   [ ] Code style update (formatting, local variables)
-   [ ] Refactoring (no functional changes, no api changes)
-   [ ] Build related changes
-   [ ] CI related changes
-   [ ] Performance improves
-   [ ] Adding missing tests
-   [ ] Documentation content changes
-   [ ] Other... Please describe:

### What is the current behavior?

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

## Fixes # (issue)

### What is the new behavior?

### Does this PR introduce a breaking change?
should not have any breaking changes as current implementation of optional
theme.table.header.fontVariant is overridden by the Text component's textVariant prop.
-   [ ] Yes
-   [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

### Additional context

Add any other context or screenshots about the feature pr here.
