### PR TITLE
feat(core): update pagination theme with pageNumber.fontWeights to ma…

### DIFF
--- a/packages/core/src/components/Pagination/Pagination.styled.tsx
+++ b/packages/core/src/components/Pagination/Pagination.styled.tsx
@@ -1,14 +1,26 @@
 import { ChevronLeftIcon, ChevronRightIcon, SvgIcon } from '@medly-components/icons';
-import { css, getFontStyle, styled } from '@medly-components/utils';
+import { Theme } from '@medly-components/theme';
+import { css, styled } from '@medly-components/utils';
 import List from '../List';
 import Text from '../Text';
+
+const getStyling = ({ theme }: { theme: Theme }) => {
+    const { variants } = theme.font;
+    const { fontSize, letterSpacing, lineHeight } = variants[theme.pagination.fontVariant];
+
+    return css`
+        font-size: ${fontSize};
+        letter-spacing: ${letterSpacing};
+        line-height: ${lineHeight};
+    `;
+};
 
 export const ListWrapper = styled(List)`
     & > li {
         margin: 0;
     }
     ${Text.Style} {
-        ${({ theme }) => getFontStyle({ theme, fontVariant: theme.pagination.fontVariant })}
+        ${getStyling}
     }
 `;
 

--- a/packages/core/src/components/Pagination/Pagination.tsx
+++ b/packages/core/src/components/Pagination/Pagination.tsx
@@ -1,4 +1,5 @@
 import { ChevronLeftIcon, ChevronRightIcon } from '@medly-components/icons';
+import { defaultTheme } from '@medly-components/theme';
 import { WithStyle } from '@medly-components/utils';
 import React, { FC, useMemo } from 'react';
 import Popover from '../Popover';
@@ -7,6 +8,8 @@ import { paginator } from './helper';
 import { ListWrapper, PageNavButton, PageNumberButton } from './Pagination.styled';
 import PaginationPopup from './PaginationPopup';
 import { PaginationProps } from './types';
+
+const pageNumberStyling = defaultTheme.pagination.pageNumber;
 
 export const Pagination: FC<PaginationProps> & WithStyle = React.memo(
     React.forwardRef((props, ref) => {
@@ -34,7 +37,12 @@ export const Pagination: FC<PaginationProps> & WithStyle = React.memo(
             else
                 links.push(
                     <PageNumberButton key={i} onClick={onClickHandler(linkItems[i])} isActive={linkItems[i] === currentPage}>
-                        <Text textAlign="center" textWeight={linkItems[i] === currentPage ? 'Strong' : 'Medium'}>
+                        <Text
+                            textAlign="center"
+                            textWeight={
+                                linkItems[i] === currentPage ? pageNumberStyling.fontWeight.selected : pageNumberStyling.fontWeight.default
+                            }
+                        >
                             {linkItems[i]}
                         </Text>
                     </PageNumberButton>

--- a/packages/core/src/components/Pagination/__snapshots__/Pagination.test.tsx.snap
+++ b/packages/core/src/components/Pagination/__snapshots__/Pagination.test.tsx.snap
@@ -47,13 +47,11 @@ exports[`Pagination component should render correctly when total items is 0 1`] 
 
 .c1 .sc-AxhCb {
   font-size: 1.2rem;
-  font-weight: 700;
   -webkit-letter-spacing: 0.12rem;
   -moz-letter-spacing: 0.12rem;
   -ms-letter-spacing: 0.12rem;
   letter-spacing: 0.12rem;
   line-height: 2.0rem;
-  font-family: Open Sans,Helvetica Neue,Helvetica,Arial,sans-serif;
 }
 
 .c2 {
@@ -267,13 +265,11 @@ exports[`Pagination component should render correctly with all the default props
 
 .c1 .c6 {
   font-size: 1.2rem;
-  font-weight: 700;
   -webkit-letter-spacing: 0.12rem;
   -moz-letter-spacing: 0.12rem;
   -ms-letter-spacing: 0.12rem;
   letter-spacing: 0.12rem;
   line-height: 2.0rem;
-  font-family: Open Sans,Helvetica Neue,Helvetica,Arial,sans-serif;
 }
 
 .c5 {
@@ -621,13 +617,11 @@ exports[`Pagination component should render correctly with all the props given 1
 
 .c1 .c3 {
   font-size: 1.2rem;
-  font-weight: 700;
   -webkit-letter-spacing: 0.12rem;
   -moz-letter-spacing: 0.12rem;
   -ms-letter-spacing: 0.12rem;
   letter-spacing: 0.12rem;
   line-height: 2.0rem;
-  font-family: Open Sans,Helvetica Neue,Helvetica,Arial,sans-serif;
 }
 
 .c2 {

--- a/packages/core/src/components/Table/Body/Row/Row.styled.tsx
+++ b/packages/core/src/components/Table/Body/Row/Row.styled.tsx
@@ -86,13 +86,6 @@ const getBorderStyle = (rowHoveredStyle: 'shadow' | 'outlined') =>
           `
         : ``;
 
-const getPadding = (rowHoveredStyle: 'shadow' | 'outlined') =>
-    rowHoveredStyle === 'outlined'
-        ? css`
-              padding-bottom: 0.1rem;
-          `
-        : '';
-
 const normalStyle = css<StyledProps>`
     &&:hover {
         z-index: 2;
@@ -121,7 +114,6 @@ const normalStyle = css<StyledProps>`
 
     &:not(:last-child) {
         border-bottom: 0.1rem solid ${({ theme }) => theme.table.row.separatorColor};
-        ${({ theme }) => getPadding(theme.table.row.hoveredStyle.style)}
     }
 `;
 

--- a/packages/theme/src/core/pagination/index.ts
+++ b/packages/theme/src/core/pagination/index.ts
@@ -6,6 +6,7 @@ const { grey, black, white, blue } = colors;
 const pagination: PaginationTheme = {
     fontVariant: 'h5',
     pageNumber: {
+        borderRadius: '50%',
         color: {
             default: grey[800],
             hovered: grey[900],
@@ -18,7 +19,10 @@ const pagination: PaginationTheme = {
             pressed: grey[100],
             active: blue[100]
         },
-        borderRadius: '50%'
+        fontWeight: {
+            default: 'Medium',
+            selected: 'Strong'
+        }
     },
     pageNav: {
         color: {

--- a/packages/theme/src/core/pagination/types.ts
+++ b/packages/theme/src/core/pagination/types.ts
@@ -1,4 +1,4 @@
-import { FontVariants } from "../font/types";
+import { FontVariants, FontWeights } from '../font/types';
 
 export interface PaginationTheme {
     /** The font variant */
@@ -16,6 +16,10 @@ export interface PaginationTheme {
             hovered: string;
             pressed: string;
             active: string;
+        };
+        fontWeight: {
+            default: FontWeights;
+            selected: FontWeights;
         };
         borderRadius: string;
     };


### PR DESCRIPTION
update pagination theme with pageNumber.fontWeight to manipulate the weights of the selected vs unselected page numbers. Remove padding from Row when `hoveredStyle = 'outlined'`. 

affects: @medly-components/core, @medly-components/theme

### PR Checklist

Please check if your PR fulfills the following requirements:

-   [ ] Tests for the changes have been added (for bug fixes/features)
-   [ ] Docs have been added/updated (for bug fixes/features)

### PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

-   [ ] Bugfix
-   [X] Feature
-   [ ] Code style update (formatting, local variables)
-   [ ] Refactoring (no functional changes, no api changes)
-   [ ] Build related changes
-   [ ] CI related changes
-   [ ] Performance improves
-   [ ] Adding missing tests
-   [ ] Documentation content changes
-   [ ] Other... Please describe:

### What is the current behavior?

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

## Fixes # (issue)

### What is the new behavior?

### Does this PR introduce a breaking change?

-   [ ] Yes
-   [X] No

<!-- If this PR contains a breaking change, please describe the impact and migration path of the existing applications below. -->

### Additional context

Provide any additional context or screenshots about the feature PR.
