### PR TITLE
fix: flickering in single select component

### DIFF
--- a/packages/core/src/components/DatePicker/DatePicker.test.tsx
+++ b/packages/core/src/components/DatePicker/DatePicker.test.tsx
@@ -193,7 +193,7 @@ describe('DatePicker component', () => {
             expect(mockOnChange).toHaveBeenCalledWith(dateToSelect);
         });
 
-        it('should call focus and blur handlers if passed', () => {
+        it('should call focus and blur handlers if passed', async () => {
             const mockOnFocus = jest.fn(),
                 mockOnChange = jest.fn(),
                 mockOnBlur = jest.fn(),
@@ -211,7 +211,7 @@ describe('DatePicker component', () => {
             fireEvent.click(container.querySelector('svg'));
             expect(mockOnFocus).toHaveBeenCalled();
             fireEvent.blur(inputEl);
-            expect(mockOnBlur).toHaveBeenCalled();
+            await waitFor(() => expect(mockOnBlur).toHaveBeenCalled());
         });
 
         it('should call invalid handler if passed', () => {

--- a/packages/core/src/components/SingleSelect/SingleSelect.test.tsx
+++ b/packages/core/src/components/SingleSelect/SingleSelect.test.tsx
@@ -149,8 +149,10 @@ describe('SingleSelect component', () => {
     });
 
     it('should show options on click on drop icon when options are custom components', async () => {
-        const componentAsOptions = [{ value: <>Component1</>, label: 'Component1' },
-        { value: <>Component2</>, label: 'Component2' }]
+        const componentAsOptions = [
+            { value: <>Component1</>, label: 'Component1' },
+            { value: <>Component2</>, label: 'Component2' }
+        ];
         const { container } = render(<SingleSelect options={componentAsOptions} />);
         fireEvent.click(container.querySelector('svg'));
         waitFor(() => expect(screen.getByRole('list')).toBeVisible());
@@ -277,7 +279,7 @@ describe('SingleSelect component', () => {
         const inputEl = screen.getByRole('textbox');
         fireEvent.click(inputEl);
         fireEvent.blur(inputEl);
-        expect(mockOnBlur).toHaveBeenCalled();
+        await waitFor(() => expect(mockOnBlur).toHaveBeenCalled());
         await waitFor(() => expect(screen.queryByRole('list')).toBeNull(), { timeout: 251 });
     });
 
@@ -304,12 +306,12 @@ describe('SingleSelect component', () => {
 
             it('should change input', async () => {
                 const mockOnChange = jest.fn(),
-                    { container } = render(<SingleSelect value="all" options={options} onChange={mockOnChange} isSearchable />);
+                    { container } = render(<SingleSelect value="all" options={options} onChange={mockOnChange} />);
                 fireEvent.click(screen.getByRole('textbox'));
                 fireEvent.keyDown(container, { key: 'ArrowDown', code: 40 });
                 fireEvent.keyDown(container, { key: 'Enter', code: 13 });
-                expect(screen.getByRole('textbox')).toHaveValue('Dummy1');
-                expect(mockOnChange).toHaveBeenCalledWith('Dummy1');
+                await waitFor(() => expect(mockOnChange).toHaveBeenCalledWith('Dummy1'));
+                await waitFor(() => expect(screen.getByRole('textbox')).toHaveValue('Dummy1'));
             });
 
             it('should change input value to the first option when currently selected options is the last option ', async () => {

--- a/packages/core/src/components/SingleSelect/SingleSelect.tsx
+++ b/packages/core/src/components/SingleSelect/SingleSelect.tsx
@@ -171,7 +171,6 @@ export const SingleSelect: FC<SelectProps> & WithStyle = React.memo(
                 ) : (
                     <TextField
                         fullWidth
-                        key={selectedOption.value}
                         variant={variant}
                         autoComplete="off"
                         onChange={handleInputChange}

--- a/packages/core/src/components/TextField/TextField.test.tsx
+++ b/packages/core/src/components/TextField/TextField.test.tsx
@@ -175,12 +175,13 @@ describe('TextField', () => {
         it('should render custom error message if validator function is returning error message', async () => {
             const mockOnBlur = jest.fn(),
                 validator = (val: string) => val.length < 3 && 'Email should be more then 3 characters',
-                { container, getByText } = render(
+                { container, findByText } = render(
                     <TextField label="Name" required type="email" value="du" onBlur={mockOnBlur} validator={validator} />
                 ),
                 input = container.querySelector('input');
             fireEvent.blur(input);
-            expect(getByText('Email should be more then 3 characters')).toBeInTheDocument();
+            const message = await findByText('Email should be more then 3 characters');
+            expect(message).toBeInTheDocument();
             expect(input.validationMessage).toEqual('Email should be more then 3 characters');
             expect(mockOnBlur).toBeCalled();
         });

--- a/packages/core/src/components/TextField/TextField.tsx
+++ b/packages/core/src/components/TextField/TextField.tsx
@@ -57,7 +57,7 @@ export const TextField: FC<TextFieldProps> & WithStyle = React.memo(
                     validatorMessage = (validator && validator(element.value, event.type)) || '',
                     message = validator ? validatorMessage : element.validationMessage;
                 setErrorMessage(message);
-                validator && inputRef.current.setCustomValidity(validatorMessage);
+                validator && inputRef.current?.setCustomValidity(validatorMessage);
                 eventFunc && eventFunc(event);
             },
             [validator, builtInErrorMessage]
@@ -65,7 +65,14 @@ export const TextField: FC<TextFieldProps> & WithStyle = React.memo(
 
         const stopPropagation = useCallback((event: React.MouseEvent) => event.stopPropagation(), []),
             handleWrapperClick = useCallback(() => !disabled && inputRef.current.focus(), [inputRef, disabled]),
-            onBlur = useCallback((event: FocusEvent<HTMLInputElement>) => validate(event, props.onBlur), [validate, props.onBlur]),
+            onBlur = useCallback(
+                (event: FocusEvent<HTMLInputElement>) => {
+                    event.persist();
+                    event.preventDefault();
+                    setTimeout(() => validate(event, props.onBlur), 100);
+                },
+                [validate, props.onBlur]
+            ),
             onInvalid = useCallback((event: FormEvent<HTMLInputElement>) => validate(event, props.onInvalid), [validate, props.onInvalid]),
             onChange = useCallback(
                 (e: React.ChangeEvent<HTMLInputElement>) => {

--- a/packages/forms/src/components/Form/Form.test.tsx
+++ b/packages/forms/src/components/Form/Form.test.tsx
@@ -66,13 +66,14 @@ describe('Form', () => {
         expect(getByRole('textbox', { name: 'Last Name' })).not.toBeDisabled();
     });
 
-    it('should render error message properly', () => {
-        const { container, getByText } = render(
+    it('should render error message properly', async () => {
+        const { container, findByText } = render(
             <Form fieldSchema={{ firstName: { required: true, type: 'text' } }} onSubmit={jest.fn()} />
         );
         fireEvent.focus(container.querySelector('#firstName-input'));
         fireEvent.blur(container.querySelector('#firstName-input'));
-        expect(getByText('Constraints not satisfied')).toBeInTheDocument();
+        const message = await findByText('Constraints not satisfied');
+        expect(message).toBeInTheDocument();
     });
 
     it('should not render any field if component type is not matched', () => {


### PR DESCRIPTION
affects: @medly-components/core, @medly-components/forms

### PR Checklist

Please check if your PR fulfills the following requirements:

-   [x] Tests for the changes have been added (for bug fixes/features)
-   [x] Docs have been added/updated (for bug fixes/features)

### PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

-   [x] Bugfix
-   [ ] Feature
-   [ ] Code style update (formatting, local variables)
-   [ ] Refactoring (no functional changes, no api changes)
-   [ ] Build related changes
-   [ ] CI related changes
-   [ ] Performance improves
-   [ ] Adding missing tests
-   [ ] Documentation content changes
-   [ ] Other... Please describe:

### What is the current behavior?

SingleSelect component flickers when `isSearchable` and required prop is given to the component and then we select any options.

## Fixes # (issue)

### What is the new behavior?

We are calling the `onBlur` event after `100ms` so that the value being set before setting the error message.

### Does this PR introduce a breaking change?

-   [ ] Yes
-   [x] No