### PR TITLE
feat(core): add and use new single-select props for suffix icon + hovered color

### DIFF
--- a/packages/core/src/components/DateRangePicker/__snapshots__/DateRangePicker.test.tsx.snap
+++ b/packages/core/src/components/DateRangePicker/__snapshots__/DateRangePicker.test.tsx.snap
@@ -39,6 +39,10 @@ exports[`DateRangePicker Custom date range options popover placement should rend
   background-color: #F7F8F9;
 }
 
+.c2:hover > .c3 {
+  color: #13181D;
+}
+
 .c2:active {
   background-color: #eff2f4;
 }
@@ -191,6 +195,10 @@ exports[`DateRangePicker Custom date range options popover placement should rend
   background-color: #F7F8F9;
 }
 
+.c2:hover > .c3 {
+  color: #13181D;
+}
+
 .c2:active {
   background-color: #eff2f4;
 }
@@ -340,6 +348,10 @@ exports[`DateRangePicker Custom date range options popover placement should rend
   background-color: #F7F8F9;
 }
 
+.c2:hover > .c3 {
+  color: #13181D;
+}
+
 .c2:active {
   background-color: #eff2f4;
 }
@@ -487,6 +499,10 @@ exports[`DateRangePicker Custom date range options popover placement should rend
 
 .c2:hover {
   background-color: #F7F8F9;
+}
+
+.c2:hover > .c3 {
+  color: #13181D;
 }
 
 .c2:active {
@@ -641,6 +657,10 @@ exports[`DateRangePicker Custom date range options popover placement should rend
   background-color: #F7F8F9;
 }
 
+.c2:hover > .c3 {
+  color: #13181D;
+}
+
 .c2:active {
   background-color: #eff2f4;
 }
@@ -790,6 +810,10 @@ exports[`DateRangePicker Custom date range options popover placement should rend
   background-color: #F7F8F9;
 }
 
+.c2:hover > .c3 {
+  color: #13181D;
+}
+
 .c2:active {
   background-color: #eff2f4;
 }
@@ -937,6 +961,10 @@ exports[`DateRangePicker Custom date range options popover placement should rend
 
 .c2:hover {
   background-color: #F7F8F9;
+}
+
+.c2:hover > .c3 {
+  color: #13181D;
 }
 
 .c2:active {
@@ -1091,6 +1119,10 @@ exports[`DateRangePicker Custom date range options popover placement should rend
   background-color: #F7F8F9;
 }
 
+.c2:hover > .c3 {
+  color: #13181D;
+}
+
 .c2:active {
   background-color: #eff2f4;
 }
@@ -1240,6 +1272,10 @@ exports[`DateRangePicker Custom date range options popover placement should rend
   background-color: #F7F8F9;
 }
 
+.c2:hover > .c3 {
+  color: #13181D;
+}
+
 .c2:active {
   background-color: #eff2f4;
 }
@@ -1387,6 +1423,10 @@ exports[`DateRangePicker Custom date range options popover placement should rend
 
 .c2:hover {
   background-color: #F7F8F9;
+}
+
+.c2:hover > .c3 {
+  color: #13181D;
 }
 
 .c2:active {
@@ -1541,6 +1581,10 @@ exports[`DateRangePicker Custom date range options popover placement should rend
   background-color: #F7F8F9;
 }
 
+.c2:hover > .c3 {
+  color: #13181D;
+}
+
 .c2:active {
   background-color: #eff2f4;
 }
@@ -1688,6 +1732,10 @@ exports[`DateRangePicker Custom date range options popover placement should rend
 
 .c2:hover {
   background-color: #F7F8F9;
+}
+
+.c2:hover > .c3 {
+  color: #13181D;
 }
 
 .c2:active {
@@ -2040,6 +2088,10 @@ exports[`DateRangePicker Custom date range options should render properly with c
 
 .c17:hover {
   background-color: #F7F8F9;
+}
+
+.c17:hover > .c18 {
+  color: #13181D;
 }
 
 .c17:active {

--- a/packages/core/src/components/SearchBox/__snapshots__/SearchBox.test.tsx.snap
+++ b/packages/core/src/components/SearchBox/__snapshots__/SearchBox.test.tsx.snap
@@ -54,6 +54,10 @@ exports[`SearchBox options should render options when user search option specifi
   background-color: #F7F8F9;
 }
 
+.c10:hover > .c11 {
+  color: #13181D;
+}
+
 .c10:active {
   background-color: #eff2f4;
 }

--- a/packages/core/src/components/SingleSelect/Options/Option/Option.styled.tsx
+++ b/packages/core/src/components/SingleSelect/Options/Option/Option.styled.tsx
@@ -29,6 +29,9 @@ export const OptionStyled = styled('li').attrs(({ theme: { singleSelect } }) => 
 
     &:hover {
         background-color: ${({ disabled, selected, bgColor }) => !disabled && !selected && bgColor.hovered};
+        & > ${Text.Style} {
+            color: ${({ textColor }) => textColor.hovered};
+        }
     }
 
     &:active {

--- a/packages/core/src/components/SingleSelect/SingleSelect.stories.mdx
+++ b/packages/core/src/components/SingleSelect/SingleSelect.stories.mdx
@@ -173,7 +173,7 @@ You can provide a prefix icon, which will always take the label color.
     </PreviewContent>
 </Preview>
 
-You can also provide a doop suffix icon, which also takes the label color.
+You can also provide a suffix icon, which also takes the label color.
 
 <Preview>
     <PreviewContent>

--- a/packages/core/src/components/SingleSelect/SingleSelect.stories.mdx
+++ b/packages/core/src/components/SingleSelect/SingleSelect.stories.mdx
@@ -1,6 +1,6 @@
 import { useState } from 'react';
 import { PreviewContent } from '@medly-components/utils';
-import { StarIcon } from '@medly-components/icons';
+import { ArrowDropDownCircleIcon, StarIcon } from '@medly-components/icons';
 import { SingleSelect } from './SingleSelect';
 import { boolean, select, text } from '@storybook/addon-knobs';
 import { Preview, Story, Meta, Props } from '@storybook/addon-docs/blocks';
@@ -140,7 +140,7 @@ As mentioned in the `TextField` component, either you can pass `errorText` or `v
 
 ##### With Icons
 
-You can also provide prefix icon, which will always take the label color.
+You can provide a prefix icon, which will always take the label color.
 
 <Preview>
     <PreviewContent>
@@ -167,6 +167,40 @@ You can also provide prefix icon, which will always take the label color.
                         label="Pharmacy"
                         includesNestedOptions
                     />
+                </>
+            );
+        }}
+    </PreviewContent>
+</Preview>
+
+You can also provide a doop suffix icon, which also takes the label color.
+
+<Preview>
+    <PreviewContent>
+        {() => {
+            const [filledValue, setFilledValue] = useState('Dummy4 option'),
+                [outlinedValue, setOutlinedValue] = useState('Dummy4 option');
+            return (
+                <>                 
+                    <SingleSelect
+                        suffix={ArrowDropDownCircleIcon}
+                        variant="filled"
+                        options={options}
+                        value={outlinedValue}
+                        onChange={setOutlinedValue}
+                        label="Pharmacy"
+                        includesNestedOptions
+                    />
+                    <SingleSelect
+                        suffix={ArrowDropDownCircleIcon}
+                        variant="outlined"
+                        options={options}
+                        value={outlinedValue}
+                        onChange={setOutlinedValue}
+                        label="Pharmacy"
+                        includesNestedOptions
+                    />
+                  
                 </>
             );
         }}

--- a/packages/core/src/components/SingleSelect/SingleSelect.tsx
+++ b/packages/core/src/components/SingleSelect/SingleSelect.tsx
@@ -28,6 +28,7 @@ export const SingleSelect: FC<SelectProps> & WithStyle = React.memo(
                 className,
                 validator,
                 isSearchable,
+                suffix,
                 ...inputProps
             } = props,
             selectId = useMemo(() => id || inputProps.label?.toLocaleLowerCase() || 'medly-singleSelect', [id, inputProps.label]),
@@ -189,7 +190,7 @@ export const SingleSelect: FC<SelectProps> & WithStyle = React.memo(
                         variant={variant}
                         autoComplete="off"
                         onChange={handleInputChange}
-                        suffix={ChevronDownIcon}
+                        suffix={suffix || ChevronDownIcon}
                         {...inputProps}
                         {...commonProps}
                         minWidth={minWidth}

--- a/packages/core/src/components/SingleSelect/__snapshots__/SingleSelect.test.tsx.snap
+++ b/packages/core/src/components/SingleSelect/__snapshots__/SingleSelect.test.tsx.snap
@@ -807,6 +807,10 @@ exports[`SingleSelect component should render properly with M size 1`] = `
   background-color: #F7F8F9;
 }
 
+.c0:hover > .c1 {
+  color: #13181D;
+}
+
 .c0:active {
   background-color: #eff2f4;
 }
@@ -829,6 +833,10 @@ exports[`SingleSelect component should render properly with M size 1`] = `
 
 .c0 > .c3 * {
   fill: #13181D;
+}
+
+.c4:hover > .c1 {
+  color: #13181D;
 }
 
 .c4 > .c1 {
@@ -894,6 +902,10 @@ exports[`SingleSelect component should render properly with S size 1`] = `
   background-color: #F7F8F9;
 }
 
+.c0:hover > .c1 {
+  color: #13181D;
+}
+
 .c0:active {
   background-color: #eff2f4;
 }
@@ -916,6 +928,10 @@ exports[`SingleSelect component should render properly with S size 1`] = `
 
 .c0 > .c3 * {
   fill: #13181D;
+}
+
+.c4:hover > .c1 {
+  color: #13181D;
 }
 
 .c4 > .c1 {
@@ -1272,6 +1288,10 @@ exports[`SingleSelect component should take passed max width 1`] = `
 
 .c13:hover {
   background-color: #F7F8F9;
+}
+
+.c13:hover > .c14 {
+  color: #13181D;
 }
 
 .c13:active {
@@ -1924,6 +1944,10 @@ exports[`SingleSelect component with filled variant should render options correc
 
 .c1:hover {
   background-color: #F7F8F9;
+}
+
+.c1:hover > .c2 {
+  color: #13181D;
 }
 
 .c1:active {
@@ -2789,6 +2813,10 @@ exports[`SingleSelect component with filled variant should render properly when 
   background-color: #F7F8F9;
 }
 
+.c15:hover > .c16 {
+  color: #13181D;
+}
+
 .c15:active {
   background-color: #eff2f4;
 }
@@ -2832,6 +2860,10 @@ exports[`SingleSelect component with filled variant should render properly when 
   min-width: -webkit-fit-content;
   min-width: -moz-fit-content;
   min-width: fit-content;
+}
+
+.c18:hover > .c16 {
+  color: #13181D;
 }
 
 .c18 > .c16 {
@@ -3794,6 +3826,10 @@ exports[`SingleSelect component with flat variant should render options correctl
   background-color: #F7F8F9;
 }
 
+.c1:hover > .c2 {
+  color: #13181D;
+}
+
 .c1:active {
   background-color: #eff2f4;
 }
@@ -4375,6 +4411,10 @@ exports[`SingleSelect component with flat variant should render properly when op
   background-color: #F7F8F9;
 }
 
+.c12:hover > .c5 {
+  color: #13181D;
+}
+
 .c12:active {
   background-color: #eff2f4;
 }
@@ -4418,6 +4458,10 @@ exports[`SingleSelect component with flat variant should render properly when op
   min-width: -webkit-fit-content;
   min-width: -moz-fit-content;
   min-width: fit-content;
+}
+
+.c14:hover > .c5 {
+  color: #13181D;
 }
 
 .c14 > .c5 {
@@ -5320,6 +5364,10 @@ exports[`SingleSelect component with outlined variant should render options corr
   background-color: #F7F8F9;
 }
 
+.c1:hover > .c2 {
+  color: #13181D;
+}
+
 .c1:active {
   background-color: #eff2f4;
 }
@@ -6211,6 +6259,10 @@ exports[`SingleSelect component with outlined variant should render properly whe
   background-color: #F7F8F9;
 }
 
+.c15:hover > .c16 {
+  color: #13181D;
+}
+
 .c15:active {
   background-color: #eff2f4;
 }
@@ -6254,6 +6306,10 @@ exports[`SingleSelect component with outlined variant should render properly whe
   min-width: -webkit-fit-content;
   min-width: -moz-fit-content;
   min-width: fit-content;
+}
+
+.c18:hover > .c16 {
+  color: #13181D;
 }
 
 .c18 > .c16 {

--- a/packages/core/src/components/SingleSelect/types.ts
+++ b/packages/core/src/components/SingleSelect/types.ts
@@ -1,3 +1,4 @@
+import { SvgIconProps } from '@medly-components/icons';
 import { HTMLProps, Omit, WithThemeProp } from '@medly-components/utils';
 import React from 'react';
 
@@ -61,7 +62,7 @@ export interface SelectProps extends InputProps, WithThemeProp {
     /** Show Helper text and error text in a tooltip (popover) */
     showTooltipForHelperAndErrorText?: boolean;
     /** Toggle icon */
-    suffix?:  React.FC<any>;
+    suffix?:  React.FC<SvgIconProps>;
 }
 
 export interface SelectWrapperProps extends Omit<SelectProps, 'ref' | 'options'> {

--- a/packages/core/src/components/SingleSelect/types.ts
+++ b/packages/core/src/components/SingleSelect/types.ts
@@ -1,4 +1,5 @@
 import { HTMLProps, Omit, WithThemeProp } from '@medly-components/utils';
+import React from 'react';
 
 export interface Option {
     /** Option value */
@@ -59,6 +60,8 @@ export interface SelectProps extends InputProps, WithThemeProp {
     validator?: (val: any) => string;
     /** Show Helper text and error text in a tooltip (popover) */
     showTooltipForHelperAndErrorText?: boolean;
+    /** Toggle icon */
+    suffix?:  React.FC<any>;
 }
 
 export interface SelectWrapperProps extends Omit<SelectProps, 'ref' | 'options'> {

--- a/packages/theme/src/core/singleSelect/index.ts
+++ b/packages/theme/src/core/singleSelect/index.ts
@@ -60,6 +60,7 @@ const singleSelect: SingleSelectTheme = {
         },
         textColor: {
             default: colors.black,
+            hovered: colors.black,
             selected: colors.blue[500],
             error: colors.red[500],
             disabled: colors.grey[500]

--- a/packages/theme/src/core/singleSelect/types.ts
+++ b/packages/theme/src/core/singleSelect/types.ts
@@ -58,6 +58,7 @@ export interface SingleSelectTheme {
         };
         textColor: {
             default: string;
+            hovered: string;
             selected: string;
             error: string;
             disabled: string;


### PR DESCRIPTION
affects: @medly-components/core, @medly-components/theme

### PR Checklist

Please check if your PR fulfills the following requirements:

-   [ ] Tests for the changes have been added (for bug fixes/features)
-   [x] Docs have been added/updated (for bug fixes/features)

### PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

-   [ ] Bugfix
-   [x] Feature
-   [ ] Code style update (formatting, local variables)
-   [ ] Refactoring (no functional changes, no api changes)
-   [ ] Build related changes
-   [ ] CI related changes
-   [ ] Performance improves
-   [ ] Adding missing tests
-   [ ] Documentation content changes
-   [ ] Other... Please describe:

### What is the current behavior?
Currently, the `ChevronDownIcon` is the default suffix/toggle icon for the `SingleSelect` component as it is not customizable. Also, the text color for the `SingleSelect` - `Option` is not customizable as it is set to the single-select default theme text color.

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

## Fixes # (issue)

### What is the new behavior?
Changes in this PR allow for customization of the `SingleSelect` suffix icon and its Option text color, on hover.
- Similar to the existing `prefix` prop, a new optional `suffix` prop of type *`React.FC<SvgIconProps>` was added to the component - if passed, that icon will be rendered as the toggle icon instead of `ChevronDownIcon`. 
- A `textColor.hovered` theme was added to `SingleSelect`, which defaults to the black, similar to the default text color.

### Does this PR introduce a breaking change?

-   [ ] Yes
-   [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path of the existing applications below. -->

### Additional context
This PR relates to PharmOS design/theme requirements for `rx-app`.

Provide any additional context or screenshots about the feature PR.
