### PR TITLE
feat(core): textfield custom active border styles

### DIFF
--- a/packages/core/src/components/DatePicker/__snapshots__/DatePicker.test.tsx.snap
+++ b/packages/core/src/components/DatePicker/__snapshots__/DatePicker.test.tsx.snap
@@ -12622,6 +12622,10 @@ exports[`DatePicker component should render properly when value is of date type 
   opacity: 1;
 }
 
+.c6:disabled {
+  color: #435465;
+}
+
 .c6:disabled ~ .c9,
 .c6:disabled ~ .c7 {
   cursor: not-allowed;
@@ -13014,6 +13018,10 @@ exports[`DatePicker component should render properly when value is of string typ
 
 .c6.c6.c6:focus::placeholder {
   opacity: 1;
+}
+
+.c6:disabled {
+  color: #435465;
 }
 
 .c6:disabled ~ .c9,

--- a/packages/core/src/components/DateRangePicker/__snapshots__/DateRangePicker.test.tsx.snap
+++ b/packages/core/src/components/DateRangePicker/__snapshots__/DateRangePicker.test.tsx.snap
@@ -1997,6 +1997,10 @@ exports[`DateRangePicker Custom date range options should render properly with c
   opacity: 1;
 }
 
+.c6:disabled {
+  color: #435465;
+}
+
 .c6:disabled ~ .c9,
 .c6:disabled ~ .c7 {
   cursor: not-allowed;
@@ -24203,6 +24207,10 @@ exports[`DateRangePicker should render properly 1`] = `
   opacity: 1;
 }
 
+.c6:disabled {
+  color: #435465;
+}
+
 .c6:disabled ~ .c9,
 .c6:disabled ~ .c7 {
   cursor: not-allowed;
@@ -26458,6 +26466,10 @@ exports[`DateRangePicker should render properly with single month 1`] = `
 
 .c7.c7.c7:focus::placeholder {
   opacity: 1;
+}
+
+.c7:disabled {
+  color: #435465;
 }
 
 .c7:disabled ~ .c10,

--- a/packages/core/src/components/DateRangePicker/__snapshots__/DateRangePicker.test.tsx.snap
+++ b/packages/core/src/components/DateRangePicker/__snapshots__/DateRangePicker.test.tsx.snap
@@ -2289,6 +2289,7 @@ exports[`DateRangePicker Custom date range options should render properly with c
 .c1:focus-within::after,
 .c1:focus-within:hover::after {
   border-color: #126AFA;
+  border-radius: 0;
 }
 
 .c1:focus-within .c9,
@@ -24946,6 +24947,7 @@ exports[`DateRangePicker should render properly 1`] = `
 .c1:focus-within::after,
 .c1:focus-within:hover::after {
   border-color: #126AFA;
+  border-radius: 0;
 }
 
 .c1:focus-within .c9,
@@ -27377,6 +27379,7 @@ exports[`DateRangePicker should render properly with single month 1`] = `
 .c2:focus-within::after,
 .c2:focus-within:hover::after {
   border-color: #126AFA;
+  border-radius: 0;
 }
 
 .c2:focus-within .c10,

--- a/packages/core/src/components/HelperAndErrorTextTooltip/HelperAndErrorTextTooltip.styled.tsx
+++ b/packages/core/src/components/HelperAndErrorTextTooltip/HelperAndErrorTextTooltip.styled.tsx
@@ -7,6 +7,8 @@ export const HelperAndErrorTextPopover = styled(Popover.Popup)`
 
 export const PopoverIconContainer = styled('div')`
     display: flex;
+    width: 0.8rem;
+    margin-top: 0.2rem;
     :hover {
         cursor: pointer;
     }

--- a/packages/core/src/components/Modal/__snapshots__/Modal.test.tsx.snap
+++ b/packages/core/src/components/Modal/__snapshots__/Modal.test.tsx.snap
@@ -141,6 +141,7 @@ exports[`Modal component should render properly when it is open 1`] = `
   z-index: 20;
   position: absolute;
   border-radius: 50%;
+  border: none;
   background-color: #ffffff;
 }
 

--- a/packages/core/src/components/Modal/__snapshots__/Modal.test.tsx.snap
+++ b/packages/core/src/components/Modal/__snapshots__/Modal.test.tsx.snap
@@ -141,7 +141,6 @@ exports[`Modal component should render properly when it is open 1`] = `
   z-index: 20;
   position: absolute;
   border-radius: 50%;
-  border: none;
   background-color: #ffffff;
 }
 

--- a/packages/core/src/components/MultiSelect/__snapshots__/MultiSelect.test.tsx.snap
+++ b/packages/core/src/components/MultiSelect/__snapshots__/MultiSelect.test.tsx.snap
@@ -248,6 +248,10 @@ exports[`MultiSelect component should render correctly with all the props given 
   opacity: 1;
 }
 
+.c5:disabled {
+  color: #435465;
+}
+
 .c5:disabled ~ .c6,
 .c5:disabled ~ .sc-fznyAO {
   cursor: not-allowed;
@@ -748,6 +752,10 @@ exports[`MultiSelect component should render correctly with default props 1`] = 
   opacity: 1;
 }
 
+.c5:disabled {
+  color: #435465;
+}
+
 .c5:disabled ~ .c6,
 .c5:disabled ~ .sc-fznyAO {
   cursor: not-allowed;
@@ -1168,6 +1176,10 @@ exports[`MultiSelect component should render properly with M size 1`] = `
 
 .c5.c5.c5:focus::placeholder {
   opacity: 1;
+}
+
+.c5:disabled {
+  color: #435465;
 }
 
 .c5:disabled ~ .c6,
@@ -2481,6 +2493,10 @@ exports[`MultiSelect component should render properly with S size 1`] = `
 
 .c5.c5.c5:focus::placeholder {
   opacity: 1;
+}
+
+.c5:disabled {
+  color: #435465;
 }
 
 .c5:disabled ~ .c6,

--- a/packages/core/src/components/MultiSelect/__snapshots__/MultiSelect.test.tsx.snap
+++ b/packages/core/src/components/MultiSelect/__snapshots__/MultiSelect.test.tsx.snap
@@ -627,6 +627,7 @@ exports[`MultiSelect component should render correctly with default props 1`] = 
 .c3:focus-within::after,
 .c3:focus-within:hover::after {
   border-color: #126AFA;
+  border-radius: 0;
 }
 
 .c3:focus-within .c6,
@@ -1049,6 +1050,7 @@ exports[`MultiSelect component should render properly with M size 1`] = `
 .c3:focus-within::after,
 .c3:focus-within:hover::after {
   border-color: #126AFA;
+  border-radius: 0;
 }
 
 .c3:focus-within .c6,
@@ -2370,6 +2372,7 @@ exports[`MultiSelect component should render properly with S size 1`] = `
 .c3:focus-within::after,
 .c3:focus-within:hover::after {
   border-color: #126AFA;
+  border-radius: 0;
 }
 
 .c3:focus-within .c6,

--- a/packages/core/src/components/SingleSelect/SingleSelect.stories.mdx
+++ b/packages/core/src/components/SingleSelect/SingleSelect.stories.mdx
@@ -143,8 +143,7 @@ As mentioned in the `TextField` component, either you can pass `errorText` or `v
     <PreviewContent>
         {() => {
             const [filledValue, setFilledValue] = useState('Dummy4 option'),
-                [outlinedValue, setOutlinedValue] = useState('Dummy4 option'),
-                [flatValue, setFlatValue] = useState('Dummy4 option');
+                [outlinedValue, setOutlinedValue] = useState('Dummy4 option');
             return (
                 <>
                     <SingleSelect
@@ -155,7 +154,7 @@ As mentioned in the `TextField` component, either you can pass `errorText` or `v
                         onChange={setFilledValue}
                         label="Pharmacy"
                         includesNestedOptions
-                        showTooltipForHelperAndErrorText={true}
+                        showTooltipForHelperAndErrorText
                     />
                     <SingleSelect
                         variant="outlined"
@@ -165,7 +164,7 @@ As mentioned in the `TextField` component, either you can pass `errorText` or `v
                         onChange={setOutlinedValue}
                         label="Pharmacy"
                         includesNestedOptions
-                        showTooltipForHelperAndErrorText={true}
+                        showTooltipForHelperAndErrorText
                     />
                 </>
             );

--- a/packages/core/src/components/SingleSelect/SingleSelect.stories.mdx
+++ b/packages/core/src/components/SingleSelect/SingleSelect.stories.mdx
@@ -138,6 +138,41 @@ As mentioned in the `TextField` component, either you can pass `errorText` or `v
     </PreviewContent>
 </Preview>
 
+#### Error validation with Helper Tooltip
+<Preview>
+    <PreviewContent>
+        {() => {
+            const [filledValue, setFilledValue] = useState('Dummy4 option'),
+                [outlinedValue, setOutlinedValue] = useState('Dummy4 option'),
+                [flatValue, setFlatValue] = useState('Dummy4 option');
+            return (
+                <>
+                    <SingleSelect
+                        variant="filled"
+                        errorText="Something wrong"
+                        options={options}
+                        value={filledValue}
+                        onChange={setFilledValue}
+                        label="Pharmacy"
+                        includesNestedOptions
+                        showTooltipForHelperAndErrorText={true}
+                    />
+                    <SingleSelect
+                        variant="outlined"
+                        errorText="Something wrong"
+                        options={options}
+                        value={outlinedValue}
+                        onChange={setOutlinedValue}
+                        label="Pharmacy"
+                        includesNestedOptions
+                        showTooltipForHelperAndErrorText={true}
+                    />
+                </>
+            );
+        }}
+    </PreviewContent>
+</Preview>
+
 ##### With Icons
 
 You can provide a prefix icon, which will always take the label color.

--- a/packages/core/src/components/SingleSelect/__snapshots__/SingleSelect.test.tsx.snap
+++ b/packages/core/src/components/SingleSelect/__snapshots__/SingleSelect.test.tsx.snap
@@ -5057,6 +5057,7 @@ exports[`SingleSelect component with outlined variant should render disabled sta
   -webkit-transition: all 100ms ease-out;
   transition: all 100ms ease-out;
   cursor: text;
+  border-radius: 0.4rem;
   background-color: #ffffff;
   cursor: not-allowed;
   background-color: #ffffff;
@@ -5098,15 +5099,20 @@ exports[`SingleSelect component with outlined variant should render disabled sta
   background-color: transparent;
   -webkit-transition: all 100ms ease-out;
   transition: all 100ms ease-out;
+  border-radius: 0.4rem;
+  border-width: 0.4rem;
   border: 0.1rem solid #98A7B7;
 }
 
 .c3:focus-within {
+  border-radius: 0.4rem;
   box-shadow: 0 0.2rem 0.8rem rgba(18,106,250,0.2);
 }
 
 .c3:focus-within::after {
   border-color: #126AFA;
+  border-radius: 0.4rem;
+  border-width: 0.15rem;
 }
 
 .c3::after,
@@ -5595,6 +5601,7 @@ exports[`SingleSelect component with outlined variant should render properly 1`]
   -webkit-transition: all 100ms ease-out;
   transition: all 100ms ease-out;
   cursor: text;
+  border-radius: 0.4rem;
   background-color: #ffffff;
 }
 
@@ -5634,6 +5641,8 @@ exports[`SingleSelect component with outlined variant should render properly 1`]
   background-color: transparent;
   -webkit-transition: all 100ms ease-out;
   transition: all 100ms ease-out;
+  border-radius: 0.4rem;
+  border-width: 0.4rem;
   border: 0.1rem solid #98A7B7;
 }
 
@@ -5642,15 +5651,19 @@ exports[`SingleSelect component with outlined variant should render properly 1`]
 }
 
 .c3:focus-within {
+  border-radius: 0.4rem;
   box-shadow: 0 0.2rem 0.8rem rgba(18,106,250,0.2);
 }
 
 .c3:hover::after {
   border-color: #607890;
+  border-width: 0.15rem;
 }
 
 .c3:focus-within::after {
   border-color: #126AFA;
+  border-radius: 0.4rem;
+  border-width: 0.15rem;
 }
 
 .c3:focus-within,
@@ -5661,6 +5674,7 @@ exports[`SingleSelect component with outlined variant should render properly 1`]
 .c3:focus-within::after,
 .c3:focus-within:hover::after {
   border-color: #126AFA;
+  border-radius: 0.4rem;
 }
 
 .c3:focus-within .c6,
@@ -6047,6 +6061,7 @@ exports[`SingleSelect component with outlined variant should render properly whe
   -webkit-transition: all 100ms ease-out;
   transition: all 100ms ease-out;
   cursor: text;
+  border-radius: 0.4rem;
   background-color: #ffffff;
 }
 
@@ -6086,6 +6101,8 @@ exports[`SingleSelect component with outlined variant should render properly whe
   background-color: transparent;
   -webkit-transition: all 100ms ease-out;
   transition: all 100ms ease-out;
+  border-radius: 0.4rem;
+  border-width: 0.4rem;
   border: 0.1rem solid #98A7B7;
 }
 
@@ -6094,15 +6111,19 @@ exports[`SingleSelect component with outlined variant should render properly whe
 }
 
 .c3:focus-within {
+  border-radius: 0.4rem;
   box-shadow: 0 0.2rem 0.8rem rgba(18,106,250,0.2);
 }
 
 .c3:hover::after {
   border-color: #607890;
+  border-width: 0.15rem;
 }
 
 .c3:focus-within::after {
   border-color: #126AFA;
+  border-radius: 0.4rem;
+  border-width: 0.15rem;
 }
 
 .c3:focus-within,
@@ -6113,6 +6134,7 @@ exports[`SingleSelect component with outlined variant should render properly whe
 .c3:focus-within::after,
 .c3:focus-within:hover::after {
   border-color: #126AFA;
+  border-radius: 0.4rem;
 }
 
 .c3:focus-within .c6,
@@ -6714,6 +6736,7 @@ exports[`SingleSelect component with outlined variant should render with label p
   -webkit-transition: all 100ms ease-out;
   transition: all 100ms ease-out;
   cursor: text;
+  border-radius: 0.4rem;
   background-color: #ffffff;
 }
 
@@ -6753,6 +6776,8 @@ exports[`SingleSelect component with outlined variant should render with label p
   background-color: transparent;
   -webkit-transition: all 100ms ease-out;
   transition: all 100ms ease-out;
+  border-radius: 0.4rem;
+  border-width: 0.4rem;
   border: 0.1rem solid #98A7B7;
 }
 
@@ -6761,15 +6786,19 @@ exports[`SingleSelect component with outlined variant should render with label p
 }
 
 .c3:focus-within {
+  border-radius: 0.4rem;
   box-shadow: 0 0.2rem 0.8rem rgba(18,106,250,0.2);
 }
 
 .c3:hover::after {
   border-color: #607890;
+  border-width: 0.15rem;
 }
 
 .c3:focus-within::after {
   border-color: #126AFA;
+  border-radius: 0.4rem;
+  border-width: 0.15rem;
 }
 
 .c3:focus-within,
@@ -6780,6 +6809,7 @@ exports[`SingleSelect component with outlined variant should render with label p
 .c3:focus-within::after,
 .c3:focus-within:hover::after {
   border-color: #126AFA;
+  border-radius: 0.4rem;
 }
 
 .c3:focus-within .c6,

--- a/packages/core/src/components/SingleSelect/__snapshots__/SingleSelect.test.tsx.snap
+++ b/packages/core/src/components/SingleSelect/__snapshots__/SingleSelect.test.tsx.snap
@@ -5095,6 +5095,14 @@ exports[`SingleSelect component with outlined variant should render disabled sta
   border: 0.1rem solid #98A7B7;
 }
 
+.c3:focus-within {
+  box-shadow: 0 0.2rem 0.8rem rgba(18,106,250,0.2);
+}
+
+.c3:focus-within::after {
+  border-color: #126AFA;
+}
+
 .c3::after,
 .c3:hover::after {
   border-width: 0.1rem;
@@ -5628,7 +5636,7 @@ exports[`SingleSelect component with outlined variant should render properly 1`]
 }
 
 .c3:focus-within {
-  box-shadow: 0px 0.2rem 0.8rem rgba(18,106,250,0.2);
+  box-shadow: 0 0.2rem 0.8rem rgba(18,106,250,0.2);
 }
 
 .c3:hover::after {
@@ -6081,7 +6089,7 @@ exports[`SingleSelect component with outlined variant should render properly whe
 }
 
 .c3:focus-within {
-  box-shadow: 0px 0.2rem 0.8rem rgba(18,106,250,0.2);
+  box-shadow: 0 0.2rem 0.8rem rgba(18,106,250,0.2);
 }
 
 .c3:hover::after {
@@ -6749,7 +6757,7 @@ exports[`SingleSelect component with outlined variant should render with label p
 }
 
 .c3:focus-within {
-  box-shadow: 0px 0.2rem 0.8rem rgba(18,106,250,0.2);
+  box-shadow: 0 0.2rem 0.8rem rgba(18,106,250,0.2);
 }
 
 .c3:hover::after {

--- a/packages/core/src/components/SingleSelect/__snapshots__/SingleSelect.test.tsx.snap
+++ b/packages/core/src/components/SingleSelect/__snapshots__/SingleSelect.test.tsx.snap
@@ -130,6 +130,7 @@ exports[`SingleSelect component should handle builtin form validation 1`] = `
 .c3:focus-within::after,
 .c3:focus-within:hover::after {
   border-color: #126AFA;
+  border-radius: 0;
 }
 
 .c3:focus-within .c6,
@@ -517,6 +518,7 @@ exports[`SingleSelect component should render properly when isSearchable is true
 .c3:focus-within::after,
 .c3:focus-within:hover::after {
   border-color: #126AFA;
+  border-radius: 0;
 }
 
 .c3:focus-within .c6,
@@ -1109,6 +1111,7 @@ exports[`SingleSelect component should take passed max width 1`] = `
 .c3:focus-within::after,
 .c3:focus-within:hover::after {
   border-color: #126AFA;
+  border-radius: 0;
 }
 
 .c3:focus-within .c6,
@@ -2201,6 +2204,7 @@ exports[`SingleSelect component with filled variant should render properly 1`] =
 .c3:focus-within::after,
 .c3:focus-within:hover::after {
   border-color: #126AFA;
+  border-radius: 0;
 }
 
 .c3:focus-within .c6,
@@ -2639,6 +2643,7 @@ exports[`SingleSelect component with filled variant should render properly when 
 .c3:focus-within::after,
 .c3:focus-within:hover::after {
   border-color: #126AFA;
+  border-radius: 0;
 }
 
 .c3:focus-within .c6,
@@ -3292,6 +3297,7 @@ exports[`SingleSelect component with filled variant should render with label pro
 .c3:focus-within::after,
 .c3:focus-within:hover::after {
   border-color: #126AFA;
+  border-radius: 0;
 }
 
 .c3:focus-within .c6,
@@ -5655,7 +5661,6 @@ exports[`SingleSelect component with outlined variant should render properly 1`]
 .c3:focus-within::after,
 .c3:focus-within:hover::after {
   border-color: #126AFA;
-  border-radius: undefined;
 }
 
 .c3:focus-within .c6,
@@ -6108,7 +6113,6 @@ exports[`SingleSelect component with outlined variant should render properly whe
 .c3:focus-within::after,
 .c3:focus-within:hover::after {
   border-color: #126AFA;
-  border-radius: undefined;
 }
 
 .c3:focus-within .c6,
@@ -6776,7 +6780,6 @@ exports[`SingleSelect component with outlined variant should render with label p
 .c3:focus-within::after,
 .c3:focus-within:hover::after {
   border-color: #126AFA;
-  border-radius: undefined;
 }
 
 .c3:focus-within .c6,

--- a/packages/core/src/components/SingleSelect/__snapshots__/SingleSelect.test.tsx.snap
+++ b/packages/core/src/components/SingleSelect/__snapshots__/SingleSelect.test.tsx.snap
@@ -255,6 +255,10 @@ exports[`SingleSelect component should handle builtin form validation 1`] = `
   opacity: 1;
 }
 
+.c5:disabled {
+  color: #435465;
+}
+
 .c5:disabled ~ .c6,
 .c5:disabled ~ .sc-fznKkj {
   cursor: not-allowed;
@@ -636,6 +640,10 @@ exports[`SingleSelect component should render properly when isSearchable is true
 
 .c5.c5.c5:focus::placeholder {
   opacity: 1;
+}
+
+.c5:disabled {
+  color: #435465;
 }
 
 .c5:disabled ~ .c6,
@@ -1227,6 +1235,10 @@ exports[`SingleSelect component should take passed max width 1`] = `
   opacity: 1;
 }
 
+.c5:disabled {
+  color: #435465;
+}
+
 .c5:disabled ~ .c6,
 .c5:disabled ~ .sc-fznKkj {
   cursor: not-allowed;
@@ -1764,6 +1776,10 @@ exports[`SingleSelect component with filled variant should render disabled state
 
 .c5.c5.c5:focus::placeholder {
   opacity: 1;
+}
+
+.c5:disabled {
+  color: #435465;
 }
 
 .c5:disabled ~ .c6,
@@ -2310,6 +2326,10 @@ exports[`SingleSelect component with filled variant should render properly 1`] =
   opacity: 1;
 }
 
+.c5:disabled {
+  color: #435465;
+}
+
 .c5:disabled ~ .c6,
 .c5:disabled ~ .sc-fznKkj {
   cursor: not-allowed;
@@ -2746,6 +2766,10 @@ exports[`SingleSelect component with filled variant should render properly when 
 
 .c5.c5.c5:focus::placeholder {
   opacity: 1;
+}
+
+.c5:disabled {
+  color: #435465;
 }
 
 .c5:disabled ~ .c6,
@@ -3395,6 +3419,10 @@ exports[`SingleSelect component with filled variant should render with label pro
 
 .c5.c5.c5:focus::placeholder {
   opacity: 1;
+}
+
+.c5:disabled {
+  color: #435465;
 }
 
 .c5:disabled ~ .c6,
@@ -5023,7 +5051,6 @@ exports[`SingleSelect component with outlined variant should render disabled sta
   -webkit-transition: all 100ms ease-out;
   transition: all 100ms ease-out;
   cursor: text;
-  border-radius: 0.4rem;
   background-color: #ffffff;
   cursor: not-allowed;
   background-color: #ffffff;
@@ -5065,7 +5092,6 @@ exports[`SingleSelect component with outlined variant should render disabled sta
   background-color: transparent;
   -webkit-transition: all 100ms ease-out;
   transition: all 100ms ease-out;
-  border-radius: 0.4rem;
   border: 0.1rem solid #98A7B7;
 }
 
@@ -5182,6 +5208,10 @@ exports[`SingleSelect component with outlined variant should render disabled sta
 
 .c5.c5.c5:focus::placeholder {
   opacity: 1;
+}
+
+.c5:disabled {
+  color: #435465;
 }
 
 .c5:disabled ~ .c6,
@@ -5551,7 +5581,6 @@ exports[`SingleSelect component with outlined variant should render properly 1`]
   -webkit-transition: all 100ms ease-out;
   transition: all 100ms ease-out;
   cursor: text;
-  border-radius: 0.4rem;
   background-color: #ffffff;
 }
 
@@ -5591,7 +5620,6 @@ exports[`SingleSelect component with outlined variant should render properly 1`]
   background-color: transparent;
   -webkit-transition: all 100ms ease-out;
   transition: all 100ms ease-out;
-  border-radius: 0.4rem;
   border: 0.1rem solid #98A7B7;
 }
 
@@ -5603,10 +5631,12 @@ exports[`SingleSelect component with outlined variant should render properly 1`]
   box-shadow: 0px 0.2rem 0.8rem rgba(18,106,250,0.2);
 }
 
-.c3:hover::after,
-.c3:focus-within::after {
-  border-width: 0.15rem;
+.c3:hover::after {
   border-color: #607890;
+}
+
+.c3:focus-within::after {
+  border-color: #126AFA;
 }
 
 .c3:focus-within,
@@ -5617,6 +5647,7 @@ exports[`SingleSelect component with outlined variant should render properly 1`]
 .c3:focus-within::after,
 .c3:focus-within:hover::after {
   border-color: #126AFA;
+  border-radius: undefined;
 }
 
 .c3:focus-within .c6,
@@ -5740,6 +5771,10 @@ exports[`SingleSelect component with outlined variant should render properly 1`]
 
 .c5.c5.c5:focus::placeholder {
   opacity: 1;
+}
+
+.c5:disabled {
+  color: #435465;
 }
 
 .c5:disabled ~ .c6,
@@ -5999,7 +6034,6 @@ exports[`SingleSelect component with outlined variant should render properly whe
   -webkit-transition: all 100ms ease-out;
   transition: all 100ms ease-out;
   cursor: text;
-  border-radius: 0.4rem;
   background-color: #ffffff;
 }
 
@@ -6039,7 +6073,6 @@ exports[`SingleSelect component with outlined variant should render properly whe
   background-color: transparent;
   -webkit-transition: all 100ms ease-out;
   transition: all 100ms ease-out;
-  border-radius: 0.4rem;
   border: 0.1rem solid #98A7B7;
 }
 
@@ -6051,10 +6084,12 @@ exports[`SingleSelect component with outlined variant should render properly whe
   box-shadow: 0px 0.2rem 0.8rem rgba(18,106,250,0.2);
 }
 
-.c3:hover::after,
-.c3:focus-within::after {
-  border-width: 0.15rem;
+.c3:hover::after {
   border-color: #607890;
+}
+
+.c3:focus-within::after {
+  border-color: #126AFA;
 }
 
 .c3:focus-within,
@@ -6065,6 +6100,7 @@ exports[`SingleSelect component with outlined variant should render properly whe
 .c3:focus-within::after,
 .c3:focus-within:hover::after {
   border-color: #126AFA;
+  border-radius: undefined;
 }
 
 .c3:focus-within .c6,
@@ -6192,6 +6228,10 @@ exports[`SingleSelect component with outlined variant should render properly whe
 
 .c5.c5.c5:focus::placeholder {
   opacity: 1;
+}
+
+.c5:disabled {
+  color: #435465;
 }
 
 .c5:disabled ~ .c6,
@@ -6662,7 +6702,6 @@ exports[`SingleSelect component with outlined variant should render with label p
   -webkit-transition: all 100ms ease-out;
   transition: all 100ms ease-out;
   cursor: text;
-  border-radius: 0.4rem;
   background-color: #ffffff;
 }
 
@@ -6702,7 +6741,6 @@ exports[`SingleSelect component with outlined variant should render with label p
   background-color: transparent;
   -webkit-transition: all 100ms ease-out;
   transition: all 100ms ease-out;
-  border-radius: 0.4rem;
   border: 0.1rem solid #98A7B7;
 }
 
@@ -6714,10 +6752,12 @@ exports[`SingleSelect component with outlined variant should render with label p
   box-shadow: 0px 0.2rem 0.8rem rgba(18,106,250,0.2);
 }
 
-.c3:hover::after,
-.c3:focus-within::after {
-  border-width: 0.15rem;
+.c3:hover::after {
   border-color: #607890;
+}
+
+.c3:focus-within::after {
+  border-color: #126AFA;
 }
 
 .c3:focus-within,
@@ -6728,6 +6768,7 @@ exports[`SingleSelect component with outlined variant should render with label p
 .c3:focus-within::after,
 .c3:focus-within:hover::after {
   border-color: #126AFA;
+  border-radius: undefined;
 }
 
 .c3:focus-within .c6,
@@ -6855,6 +6896,10 @@ exports[`SingleSelect component with outlined variant should render with label p
 
 .c5.c5.c5:focus::placeholder {
   opacity: 1;
+}
+
+.c5:disabled {
+  color: #435465;
 }
 
 .c5:disabled ~ .c6,

--- a/packages/core/src/components/TextField/Styled/HelperAndErrorTextTooltipWrapper.styled.tsx
+++ b/packages/core/src/components/TextField/Styled/HelperAndErrorTextTooltipWrapper.styled.tsx
@@ -1,7 +1,7 @@
 import styled from 'styled-components';
 
-export const HelperAndErrorTextTooltipWrapper = styled.div<{ displayCharacterCount: boolean; size: 'S' | 'M'; isSuffixPresent: boolean}>`
+export const HelperAndErrorTextTooltipWrapper = styled.div<{ displayCharacterCount: boolean; size: 'S' | 'M'; isSuffixPresent: boolean; }>`
     margin-top: 0.5rem;
-    ${({ isSuffixPresent }) => !isSuffixPresent && 'margin-right: 1rem;'}
-    ${({ displayCharacterCount, size }) => (!displayCharacterCount || size !== 'S' ) && 'margin-left: 1rem;'}
+    margin-right: ${({ isSuffixPresent }) => !isSuffixPresent && '1rem'};
+    margin-left: ${({ displayCharacterCount, size }) => (!displayCharacterCount || size !== 'S' ) && '1rem'};
 `;

--- a/packages/core/src/components/TextField/Styled/HelperAndErrorTextTooltipWrapper.styled.tsx
+++ b/packages/core/src/components/TextField/Styled/HelperAndErrorTextTooltipWrapper.styled.tsx
@@ -1,5 +1,7 @@
 import styled from 'styled-components';
 
-export const HelperAndErrorTextTooltipWrapper = styled.div<{ displayCharacterCount: boolean; size: 'S' | 'M' }>`
-    ${({ displayCharacterCount, size }) => (!displayCharacterCount || size !== 'S') && 'margin-left: 1rem;'}
+export const HelperAndErrorTextTooltipWrapper = styled.div<{ displayCharacterCount: boolean; size: 'S' | 'M'; isSuffixPresent: boolean}>`
+    margin-top: 0.5rem;
+    ${({ isSuffixPresent }) => !isSuffixPresent && 'margin-right: 1rem;'}
+    ${({ displayCharacterCount, size }) => (!displayCharacterCount || size !== 'S' ) && 'margin-left: 1rem;'}
 `;

--- a/packages/core/src/components/TextField/Styled/InnerWrapper/InnerWrapper.styled.tsx
+++ b/packages/core/src/components/TextField/Styled/InnerWrapper/InnerWrapper.styled.tsx
@@ -46,7 +46,7 @@ const activeStyle = ({ theme: { textField }, variant }: InnerWrapperProps) => cs
         background-color: ${textField[variant].active.bgColor};
         &::after {
             border-color: ${textField[variant].active.borderColor};
-            ${ (variant === 'outlined' || variant === 'fusion') && `border-radius: ${textField[variant].active.borderRadius}`} ;
+            border-radius: ${variant === 'outlined' || variant === 'fusion' ? textField[variant].active.borderRadius: '0'};
         }
 
         ${Label} {

--- a/packages/core/src/components/TextField/Styled/InnerWrapper/InnerWrapper.styled.tsx
+++ b/packages/core/src/components/TextField/Styled/InnerWrapper/InnerWrapper.styled.tsx
@@ -46,6 +46,7 @@ const activeStyle = ({ theme: { textField }, variant }: InnerWrapperProps) => cs
         background-color: ${textField[variant].active.bgColor};
         &::after {
             border-color: ${textField[variant].active.borderColor};
+            ${ (variant === 'outlined' || variant === 'fusion') && `border-radius: ${textField[variant].active.borderRadius}`} ;
         }
 
         ${Label} {

--- a/packages/core/src/components/TextField/Styled/InnerWrapper/InnerWrapper.styled.tsx
+++ b/packages/core/src/components/TextField/Styled/InnerWrapper/InnerWrapper.styled.tsx
@@ -46,7 +46,7 @@ const activeStyle = ({ theme: { textField }, variant }: InnerWrapperProps) => cs
         background-color: ${textField[variant].active.bgColor};
         &::after {
             border-color: ${textField[variant].active.borderColor};
-            border-radius: ${variant === 'outlined' || variant === 'fusion' ? textField[variant].active.borderRadius: '0'};
+            border-radius: ${variant === 'filled' ? '0' : textField[variant].active.borderRadius };
         }
 
         ${Label} {

--- a/packages/core/src/components/TextField/Styled/InnerWrapper/fusion.styled.tsx
+++ b/packages/core/src/components/TextField/Styled/InnerWrapper/fusion.styled.tsx
@@ -35,8 +35,9 @@ export const fusionStyle = ({ fusion, disabled, isTextPresent }: InnerWrapperPro
         }
         
         &:focus-within::after {
-            border-width: ${!disabled && fusion.active.borderWidth};
-            border-color: ${!disabled && fusion.active.borderColor};
+            border-color: ${fusion.active.borderColor};
+            border-radius: ${fusion.active.borderRadius}; 
+            border-width: ${fusion.active.borderWidth};
         }
 
         &:focus-within {

--- a/packages/core/src/components/TextField/Styled/InnerWrapper/fusion.styled.tsx
+++ b/packages/core/src/components/TextField/Styled/InnerWrapper/fusion.styled.tsx
@@ -8,8 +8,9 @@ import { Suffix } from '../Suffix.styled';
 export const fusionStyle = ({ fusion, disabled, isTextPresent }: InnerWrapperProps) => {
     const bgColor = fusion[isTextPresent ? 'active' : 'default'].bgColor;
     return css`
-        border-radius: 1rem;
         background-color: ${bgColor};
+        border-radius: ${fusion.default.borderRadius};
+        border-width: ${fusion.default.borderWidth};
         &::after {
             content: '';
             box-sizing: border-box;
@@ -23,14 +24,24 @@ export const fusionStyle = ({ fusion, disabled, isTextPresent }: InnerWrapperPro
             pointer-events: none;
             background-color: transparent;
             transition: all 100ms ease-out;
-            border-radius: 1rem;
+            border-radius: ${fusion.default.borderRadius};
+            border-width: ${fusion.default.borderWidth};
             border: 0.1rem solid ${fusion.default.borderColor};
         }
 
-        &:hover::after,
-        &:focus-within::after {
-            border-width: ${!disabled && `0.15rem`};
+        &:hover::after {
+            border-width: ${!disabled && fusion.hover.borderWidth};
             border-color: ${!disabled && fusion.hover.borderColor};
+        }
+        
+        &:focus-within::after {
+            border-width: ${!disabled && fusion.active.borderWidth};
+            border-color: ${!disabled && fusion.active.borderColor};
+        }
+
+        &:focus-within {
+            border-radius: ${fusion.active.borderRadius};
+            border-width: ${fusion.active.borderWidth};
         }
         input {
             box-shadow: 0 0 0 100000px ${bgColor} inset;

--- a/packages/core/src/components/TextField/Styled/InnerWrapper/outlined.styled.tsx
+++ b/packages/core/src/components/TextField/Styled/InnerWrapper/outlined.styled.tsx
@@ -31,16 +31,17 @@ export const outlinedStyle = ({ outlined, disabled, isErrorPresent }: InnerWrapp
         }
         &:focus-within {
             border-radius: ${outlined.active.borderRadius};
-            box-shadow: ${!disabled && `0px 0.2rem 0.8rem ${rgba(outlined[isErrorPresent ? 'error' : 'active'].shadowColor, 0.2)}`};
+            box-shadow: 0 0.2rem 0.8rem ${rgba(outlined[isErrorPresent ? 'error' : 'active'].shadowColor, 0.2)};
         }
 
         &:hover::after {
-            border-width: ${!disabled && outlined.hover.borderWidth};
             border-color: ${!disabled && outlined.hover.borderColor};
+            border-width: ${!disabled && outlined.hover.borderWidth};
         }
         &:focus-within::after {
-            border-width: ${!disabled && outlined.active.borderWidth};
-            border-color: ${!disabled && outlined.active.borderColor};
+            border-color: ${outlined.active.borderColor};
+            border-radius: ${outlined.active.borderRadius};
+            border-width: ${outlined.active.borderWidth};
         }
 
     `;

--- a/packages/core/src/components/TextField/Styled/InnerWrapper/outlined.styled.tsx
+++ b/packages/core/src/components/TextField/Styled/InnerWrapper/outlined.styled.tsx
@@ -2,9 +2,9 @@ import { css } from '@medly-components/utils';
 import { rgba } from 'polished';
 import { InnerWrapperProps } from '../../types';
 
-export const outlinedStyle = ({ theme, outlined, disabled, isErrorPresent }: InnerWrapperProps) => {
+export const outlinedStyle = ({ outlined, disabled, isErrorPresent }: InnerWrapperProps) => {
     return css`
-        border-radius: ${theme.spacing.S1};
+        border-radius: ${outlined.default.borderRadius};
         background-color: ${outlined.default.bgColor};
         input {
             box-shadow: 0 0 0 100000px ${outlined.default.bgColor} inset;
@@ -22,20 +22,26 @@ export const outlinedStyle = ({ theme, outlined, disabled, isErrorPresent }: Inn
             pointer-events: none;
             background-color: transparent;
             transition: all 100ms ease-out;
-            border-radius: ${theme.spacing.S1};
+            border-radius: ${outlined.default.borderRadius};
+            border-width: ${outlined.default.borderRadius};
             border: 0.1rem solid ${outlined.default.borderColor};
         }
         &:hover {
             box-shadow: ${!disabled && `0px 0.2rem 0.8rem ${rgba(outlined.hover.shadowColor, 0.2)}`};
         }
         &:focus-within {
+            border-radius: ${outlined.active.borderRadius};
             box-shadow: ${!disabled && `0px 0.2rem 0.8rem ${rgba(outlined[isErrorPresent ? 'error' : 'active'].shadowColor, 0.2)}`};
         }
 
-        &:hover::after,
-        &:focus-within::after {
-            border-width: ${!disabled && `0.15rem`};
+        &:hover::after {
+            border-width: ${!disabled && outlined.hover.borderWidth};
             border-color: ${!disabled && outlined.hover.borderColor};
         }
+        &:focus-within::after {
+            border-width: ${!disabled && outlined.active.borderWidth};
+            border-color: ${!disabled && outlined.active.borderColor};
+        }
+
     `;
 };

--- a/packages/core/src/components/TextField/Styled/TextField.styled.tsx
+++ b/packages/core/src/components/TextField/Styled/TextField.styled.tsx
@@ -68,6 +68,7 @@ export const Input = styled('input')<StyledProps>`
     }
 
     &:disabled {
+        color: ${({ variant, theme }) => theme.textField[variant].disabled.textColor};
         & ~ ${Label},& ~ ${MaskPlaceholder} {
             cursor: not-allowed;
         }

--- a/packages/core/src/components/TextField/TextField.stories.mdx
+++ b/packages/core/src/components/TextField/TextField.stories.mdx
@@ -79,9 +79,9 @@ To add the masking feature you need to provide `mask` prop. For now this feature
 ##### Error State with Helper Tooltip
 
 <Preview withToolbar>
-    <TextField id="outline" type="Name" variant="outlined" label="Address" defaultValue="Demo" errorText="Something wrong" showTooltipForHelperAndErrorText={boolean('Show Helper Tooltip', true)} />
-    <TextField id="filled" type="Name" variant="filled" label="Address" defaultValue="Demo" errorText="Something wrong" showTooltipForHelperAndErrorText={boolean('Show Helper Tooltip', true)} />
-    <TextField id="fusion" type="Name" variant="fusion" label="Address" defaultValue="Demo" errorText="Something wrong" showTooltipForHelperAndErrorText={boolean('Show Helper Tooltip', true)} />
+    <TextField id="outline" type="Name" variant="outlined" label="Address" defaultValue="Demo" errorText="Something wrong" showTooltipForHelperAndErrorText />
+    <TextField id="filled" type="Name" variant="filled" label="Address" defaultValue="Demo" errorText="Something wrong" showTooltipForHelperAndErrorText />
+    <TextField id="fusion" type="Name" variant="fusion" label="Address" defaultValue="Demo" errorText="Something wrong" showTooltipForHelperAndErrorText />
 </Preview>
 
 

--- a/packages/core/src/components/TextField/TextField.stories.mdx
+++ b/packages/core/src/components/TextField/TextField.stories.mdx
@@ -76,6 +76,15 @@ To add the masking feature you need to provide `mask` prop. For now this feature
     <TextField id="fusion" type="Name" variant="fusion" label="Address" defaultValue="Demo" errorText="Something wrong" />
 </Preview>
 
+##### Error State with Helper Tooltip
+
+<Preview withToolbar>
+    <TextField id="outline" type="Name" variant="outlined" label="Address" defaultValue="Demo" errorText="Something wrong" showTooltipForHelperAndErrorText={boolean('Show Helper Tooltip', true)} />
+    <TextField id="filled" type="Name" variant="filled" label="Address" defaultValue="Demo" errorText="Something wrong" showTooltipForHelperAndErrorText={boolean('Show Helper Tooltip', true)} />
+    <TextField id="fusion" type="Name" variant="fusion" label="Address" defaultValue="Demo" errorText="Something wrong" showTooltipForHelperAndErrorText={boolean('Show Helper Tooltip', true)} />
+</Preview>
+
+
 ##### Character Count
 
 To display character count, you must provide the `withCharacterCount` prop and a `maxLength` prop.

--- a/packages/core/src/components/TextField/TextField.test.tsx
+++ b/packages/core/src/components/TextField/TextField.test.tsx
@@ -307,6 +307,50 @@ describe('TextField', () => {
             expect(container).toMatchSnapshot();
         });
 
+        it('should render properly with custom border styles (themed)', () => {
+            const borderRadius = '0.25rem';
+            const borderWidth = '0.2rem';
+            const { container } = render(
+                <ThemeProvider
+                    theme={updateNestedValue(defaultTheme, 'textField', {
+                        ...defaultTheme.textField,
+                        filled: {
+                            ...defaultTheme.textField.filled,
+                        },
+                        outlined: {
+                            ...defaultTheme.textField.outlined,
+                            default: {
+                                ...defaultTheme.textField.outlined.default,
+                                borderRadius,
+                                borderWidth
+                            },
+                            active: {
+                                ...defaultTheme.textField.outlined.active,
+                                borderRadius,
+                                borderWidth
+                            }
+                        },
+                        fusion: {
+                            ...defaultTheme.textField.fusion,
+                            default: {
+                                ...defaultTheme.textField.fusion.default,
+                                borderRadius,
+                                borderWidth
+                            },
+                            active: {
+                                ...defaultTheme.textField.fusion.active,
+                                borderRadius,
+                                borderWidth
+                            }
+                        }
+                    })}
+                >
+                    <TextField variant={variant} label="Name" suffix={CheckIcon} disabled />
+                </ThemeProvider>
+            );
+            expect(container).toMatchSnapshot();
+        });
+
         it('should render without suffix/prefix/character-count if we pass showDecorators as false', () => {
             const prefix = () => <span>prefix</span>;
             const suffix = () => <span>suffix</span>;

--- a/packages/core/src/components/TextField/TextField.tsx
+++ b/packages/core/src/components/TextField/TextField.tsx
@@ -163,7 +163,7 @@ export const TextField: FC<TextFieldProps> & WithStyle = React.memo(
                         )}
                     </Styled.InputWrapper>
                     {props.showTooltipForHelperAndErrorText && (
-                        <Styled.HelperAndErrorTextTooltipWrapper size={size} displayCharacterCount={displayCharacterCount}>
+                        <Styled.HelperAndErrorTextTooltipWrapper size={size} displayCharacterCount={displayCharacterCount} isSuffixPresent={isSuffixPresent}>
                             <HelperAndErrorTextTooltip id={inputId} errorText={errorText || builtInErrorMessage} helperText={helperText} />
                         </Styled.HelperAndErrorTextTooltipWrapper>
                     )}

--- a/packages/core/src/components/TextField/__snapshots__/TextField.test.tsx.snap
+++ b/packages/core/src/components/TextField/__snapshots__/TextField.test.tsx.snap
@@ -418,6 +418,8 @@ exports[`TextField character count should correctly render character count for f
   transition: all 100ms ease-out;
   cursor: text;
   background-color: #F7F8F9;
+  border-radius: 1rem;
+  border-width: 0.15rem;
 }
 
 .c1 .c4 {
@@ -452,15 +454,25 @@ exports[`TextField character count should correctly render character count for f
   background-color: transparent;
   -webkit-transition: all 100ms ease-out;
   transition: all 100ms ease-out;
+  border-radius: 1rem;
+  border-width: 0.15rem;
   border: 0.1rem solid #b0bcc8;
 }
 
 .c1:hover::after {
+  border-width: 0.15rem;
   border-color: #607890;
 }
 
 .c1:focus-within::after {
   border-color: #126AFA;
+  border-radius: 1rem;
+  border-width: 0.15rem;
+}
+
+.c1:focus-within {
+  border-radius: 1rem;
+  border-width: 0.15rem;
 }
 
 .c1 input {
@@ -475,6 +487,7 @@ exports[`TextField character count should correctly render character count for f
 .c1:focus-within::after,
 .c1:focus-within:hover::after {
   border-color: #126AFA;
+  border-radius: 1rem;
 }
 
 .c1:focus-within .c4,
@@ -7902,6 +7915,8 @@ exports[`TextField with fusion variant and with label should render default stat
   transition: all 100ms ease-out;
   cursor: text;
   background-color: #F7F8F9;
+  border-radius: 1rem;
+  border-width: 0.15rem;
 }
 
 .c1 .c4 {
@@ -7936,15 +7951,25 @@ exports[`TextField with fusion variant and with label should render default stat
   background-color: transparent;
   -webkit-transition: all 100ms ease-out;
   transition: all 100ms ease-out;
+  border-radius: 1rem;
+  border-width: 0.15rem;
   border: 0.1rem solid #b0bcc8;
 }
 
 .c1:hover::after {
+  border-width: 0.15rem;
   border-color: #607890;
 }
 
 .c1:focus-within::after {
   border-color: #126AFA;
+  border-radius: 1rem;
+  border-width: 0.15rem;
+}
+
+.c1:focus-within {
+  border-radius: 1rem;
+  border-width: 0.15rem;
 }
 
 .c1 input {
@@ -7959,6 +7984,7 @@ exports[`TextField with fusion variant and with label should render default stat
 .c1:focus-within::after,
 .c1:focus-within:hover::after {
   border-color: #126AFA;
+  border-radius: 1rem;
 }
 
 .c1:focus-within .c4,
@@ -8244,6 +8270,8 @@ exports[`TextField with fusion variant and with label should render disabled sta
   transition: all 100ms ease-out;
   cursor: text;
   background-color: #F7F8F9;
+  border-radius: 1rem;
+  border-width: 0.15rem;
   cursor: not-allowed;
   background-color: #ffffff;
 }
@@ -8280,11 +8308,20 @@ exports[`TextField with fusion variant and with label should render disabled sta
   background-color: transparent;
   -webkit-transition: all 100ms ease-out;
   transition: all 100ms ease-out;
+  border-radius: 1rem;
+  border-width: 0.15rem;
   border: 0.1rem solid #b0bcc8;
 }
 
 .c1:focus-within::after {
   border-color: #126AFA;
+  border-radius: 1rem;
+  border-width: 0.15rem;
+}
+
+.c1:focus-within {
+  border-radius: 1rem;
+  border-width: 0.15rem;
 }
 
 .c1 input {
@@ -8568,6 +8605,8 @@ exports[`TextField with fusion variant and with label should render focus state 
   transition: all 100ms ease-out;
   cursor: text;
   background-color: #F7F8F9;
+  border-radius: 1rem;
+  border-width: 0.15rem;
 }
 
 .c1 .c4 {
@@ -8602,15 +8641,25 @@ exports[`TextField with fusion variant and with label should render focus state 
   background-color: transparent;
   -webkit-transition: all 100ms ease-out;
   transition: all 100ms ease-out;
+  border-radius: 1rem;
+  border-width: 0.15rem;
   border: 0.1rem solid #b0bcc8;
 }
 
 .c1:hover::after {
+  border-width: 0.15rem;
   border-color: #607890;
 }
 
 .c1:focus-within::after {
   border-color: #126AFA;
+  border-radius: 1rem;
+  border-width: 0.15rem;
+}
+
+.c1:focus-within {
+  border-radius: 1rem;
+  border-width: 0.15rem;
 }
 
 .c1 input {
@@ -8625,6 +8674,7 @@ exports[`TextField with fusion variant and with label should render focus state 
 .c1:focus-within::after,
 .c1:focus-within:hover::after {
   border-color: #126AFA;
+  border-radius: 1rem;
 }
 
 .c1:focus-within .c4,
@@ -8910,6 +8960,8 @@ exports[`TextField with fusion variant and without label should render default s
   transition: all 100ms ease-out;
   cursor: text;
   background-color: #F7F8F9;
+  border-radius: 1rem;
+  border-width: 0.15rem;
 }
 
 .c1 .c4 {
@@ -8944,15 +8996,25 @@ exports[`TextField with fusion variant and without label should render default s
   background-color: transparent;
   -webkit-transition: all 100ms ease-out;
   transition: all 100ms ease-out;
+  border-radius: 1rem;
+  border-width: 0.15rem;
   border: 0.1rem solid #b0bcc8;
 }
 
 .c1:hover::after {
+  border-width: 0.15rem;
   border-color: #607890;
 }
 
 .c1:focus-within::after {
   border-color: #126AFA;
+  border-radius: 1rem;
+  border-width: 0.15rem;
+}
+
+.c1:focus-within {
+  border-radius: 1rem;
+  border-width: 0.15rem;
 }
 
 .c1 input {
@@ -8967,6 +9029,7 @@ exports[`TextField with fusion variant and without label should render default s
 .c1:focus-within::after,
 .c1:focus-within:hover::after {
   border-color: #126AFA;
+  border-radius: 1rem;
 }
 
 .c1:focus-within .c4,
@@ -9246,6 +9309,8 @@ exports[`TextField with fusion variant and without label should render disabled 
   transition: all 100ms ease-out;
   cursor: text;
   background-color: #F7F8F9;
+  border-radius: 1rem;
+  border-width: 0.15rem;
   cursor: not-allowed;
   background-color: #ffffff;
 }
@@ -9282,11 +9347,20 @@ exports[`TextField with fusion variant and without label should render disabled 
   background-color: transparent;
   -webkit-transition: all 100ms ease-out;
   transition: all 100ms ease-out;
+  border-radius: 1rem;
+  border-width: 0.15rem;
   border: 0.1rem solid #b0bcc8;
 }
 
 .c1:focus-within::after {
   border-color: #126AFA;
+  border-radius: 1rem;
+  border-width: 0.15rem;
+}
+
+.c1:focus-within {
+  border-radius: 1rem;
+  border-width: 0.15rem;
 }
 
 .c1 input {
@@ -9564,6 +9638,8 @@ exports[`TextField with fusion variant and without label should render focus sta
   transition: all 100ms ease-out;
   cursor: text;
   background-color: #F7F8F9;
+  border-radius: 1rem;
+  border-width: 0.15rem;
 }
 
 .c1 .c4 {
@@ -9598,15 +9674,25 @@ exports[`TextField with fusion variant and without label should render focus sta
   background-color: transparent;
   -webkit-transition: all 100ms ease-out;
   transition: all 100ms ease-out;
+  border-radius: 1rem;
+  border-width: 0.15rem;
   border: 0.1rem solid #b0bcc8;
 }
 
 .c1:hover::after {
+  border-width: 0.15rem;
   border-color: #607890;
 }
 
 .c1:focus-within::after {
   border-color: #126AFA;
+  border-radius: 1rem;
+  border-width: 0.15rem;
+}
+
+.c1:focus-within {
+  border-radius: 1rem;
+  border-width: 0.15rem;
 }
 
 .c1 input {
@@ -9621,6 +9707,7 @@ exports[`TextField with fusion variant and without label should render focus sta
 .c1:focus-within::after,
 .c1:focus-within:hover::after {
   border-color: #126AFA;
+  border-radius: 1rem;
 }
 
 .c1:focus-within .c4,
@@ -9911,6 +9998,8 @@ exports[`TextField with fusion variant should render error state properly  1`] =
   transition: all 100ms ease-out;
   cursor: text;
   background-color: #F7F8F9;
+  border-radius: 1rem;
+  border-width: 0.15rem;
 }
 
 .c1 .c4 {
@@ -9945,15 +10034,25 @@ exports[`TextField with fusion variant should render error state properly  1`] =
   background-color: transparent;
   -webkit-transition: all 100ms ease-out;
   transition: all 100ms ease-out;
+  border-radius: 1rem;
+  border-width: 0.15rem;
   border: 0.1rem solid #b0bcc8;
 }
 
 .c1:hover::after {
+  border-width: 0.15rem;
   border-color: #607890;
 }
 
 .c1:focus-within::after {
   border-color: #126AFA;
+  border-radius: 1rem;
+  border-width: 0.15rem;
+}
+
+.c1:focus-within {
+  border-radius: 1rem;
+  border-width: 0.15rem;
 }
 
 .c1 input {
@@ -10290,6 +10389,8 @@ exports[`TextField with fusion variant should render error state properly with a
   transition: all 100ms ease-out;
   cursor: text;
   background-color: #ffffff;
+  border-radius: 1rem;
+  border-width: 0.15rem;
 }
 
 .c1 .c4 {
@@ -10324,15 +10425,25 @@ exports[`TextField with fusion variant should render error state properly with a
   background-color: transparent;
   -webkit-transition: all 100ms ease-out;
   transition: all 100ms ease-out;
+  border-radius: 1rem;
+  border-width: 0.15rem;
   border: 0.1rem solid #b0bcc8;
 }
 
 .c1:hover::after {
+  border-width: 0.15rem;
   border-color: #607890;
 }
 
 .c1:focus-within::after {
   border-color: #126AFA;
+  border-radius: 1rem;
+  border-width: 0.15rem;
+}
+
+.c1:focus-within {
+  border-radius: 1rem;
+  border-width: 0.15rem;
 }
 
 .c1 input {
@@ -11104,6 +11215,8 @@ exports[`TextField with fusion variant should render properly with custom disabl
   transition: all 100ms ease-out;
   cursor: text;
   background-color: #F7F8F9;
+  border-radius: 1rem;
+  border-width: 0.15rem;
   cursor: text;
   background-color: #ffffff;
 }
@@ -11140,11 +11253,20 @@ exports[`TextField with fusion variant should render properly with custom disabl
   background-color: transparent;
   -webkit-transition: all 100ms ease-out;
   transition: all 100ms ease-out;
+  border-radius: 1rem;
+  border-width: 0.15rem;
   border: 0.1rem solid #b0bcc8;
 }
 
 .c1:focus-within::after {
   border-color: #126AFA;
+  border-radius: 1rem;
+  border-width: 0.15rem;
+}
+
+.c1:focus-within {
+  border-radius: 1rem;
+  border-width: 0.15rem;
 }
 
 .c1 input {
@@ -11441,6 +11563,8 @@ exports[`TextField with fusion variant should render properly with multiline 1`]
   transition: all 100ms ease-out;
   cursor: text;
   background-color: #F7F8F9;
+  border-radius: 1rem;
+  border-width: 0.15rem;
 }
 
 .c1 .c4 {
@@ -11475,15 +11599,25 @@ exports[`TextField with fusion variant should render properly with multiline 1`]
   background-color: transparent;
   -webkit-transition: all 100ms ease-out;
   transition: all 100ms ease-out;
+  border-radius: 1rem;
+  border-width: 0.15rem;
   border: 0.1rem solid #b0bcc8;
 }
 
 .c1:hover::after {
+  border-width: 0.15rem;
   border-color: #607890;
 }
 
 .c1:focus-within::after {
   border-color: #126AFA;
+  border-radius: 1rem;
+  border-width: 0.15rem;
+}
+
+.c1:focus-within {
+  border-radius: 1rem;
+  border-width: 0.15rem;
 }
 
 .c1 input {
@@ -11498,6 +11632,7 @@ exports[`TextField with fusion variant should render properly with multiline 1`]
 .c1:focus-within::after,
 .c1:focus-within:hover::after {
   border-color: #126AFA;
+  border-radius: 1rem;
 }
 
 .c1:focus-within .c4,
@@ -11799,6 +11934,8 @@ exports[`TextField with fusion variant should render properly with prefix 1`] = 
   transition: all 100ms ease-out;
   cursor: text;
   background-color: #F7F8F9;
+  border-radius: 1rem;
+  border-width: 0.15rem;
 }
 
 .c1 .c7 {
@@ -11833,15 +11970,25 @@ exports[`TextField with fusion variant should render properly with prefix 1`] = 
   background-color: transparent;
   -webkit-transition: all 100ms ease-out;
   transition: all 100ms ease-out;
+  border-radius: 1rem;
+  border-width: 0.15rem;
   border: 0.1rem solid #b0bcc8;
 }
 
 .c1:hover::after {
+  border-width: 0.15rem;
   border-color: #607890;
 }
 
 .c1:focus-within::after {
   border-color: #126AFA;
+  border-radius: 1rem;
+  border-width: 0.15rem;
+}
+
+.c1:focus-within {
+  border-radius: 1rem;
+  border-width: 0.15rem;
 }
 
 .c1 input {
@@ -11856,6 +12003,7 @@ exports[`TextField with fusion variant should render properly with prefix 1`] = 
 .c1:focus-within::after,
 .c1:focus-within:hover::after {
   border-color: #126AFA;
+  border-radius: 1rem;
 }
 
 .c1:focus-within .c7,
@@ -12174,6 +12322,8 @@ exports[`TextField with fusion variant should render properly with suffix 1`] = 
   transition: all 100ms ease-out;
   cursor: text;
   background-color: #F7F8F9;
+  border-radius: 1rem;
+  border-width: 0.15rem;
 }
 
 .c1 .c4 {
@@ -12208,15 +12358,25 @@ exports[`TextField with fusion variant should render properly with suffix 1`] = 
   background-color: transparent;
   -webkit-transition: all 100ms ease-out;
   transition: all 100ms ease-out;
+  border-radius: 1rem;
+  border-width: 0.15rem;
   border: 0.1rem solid #b0bcc8;
 }
 
 .c1:hover::after {
+  border-width: 0.15rem;
   border-color: #607890;
 }
 
 .c1:focus-within::after {
   border-color: #126AFA;
+  border-radius: 1rem;
+  border-width: 0.15rem;
+}
+
+.c1:focus-within {
+  border-radius: 1rem;
+  border-width: 0.15rem;
 }
 
 .c1 input {
@@ -12231,6 +12391,7 @@ exports[`TextField with fusion variant should render properly with suffix 1`] = 
 .c1:focus-within::after,
 .c1:focus-within:hover::after {
   border-color: #126AFA;
+  border-radius: 1rem;
 }
 
 .c1:focus-within .c4,
@@ -12524,6 +12685,7 @@ exports[`TextField with outlined variant and with label should render default st
   -webkit-transition: all 100ms ease-out;
   transition: all 100ms ease-out;
   cursor: text;
+  border-radius: 0.4rem;
   background-color: #ffffff;
 }
 
@@ -12563,6 +12725,8 @@ exports[`TextField with outlined variant and with label should render default st
   background-color: transparent;
   -webkit-transition: all 100ms ease-out;
   transition: all 100ms ease-out;
+  border-radius: 0.4rem;
+  border-width: 0.4rem;
   border: 0.1rem solid #98A7B7;
 }
 
@@ -12571,15 +12735,19 @@ exports[`TextField with outlined variant and with label should render default st
 }
 
 .c1:focus-within {
+  border-radius: 0.4rem;
   box-shadow: 0 0.2rem 0.8rem rgba(18,106,250,0.2);
 }
 
 .c1:hover::after {
   border-color: #607890;
+  border-width: 0.15rem;
 }
 
 .c1:focus-within::after {
   border-color: #126AFA;
+  border-radius: 0.4rem;
+  border-width: 0.15rem;
 }
 
 .c1:focus-within,
@@ -12590,6 +12758,7 @@ exports[`TextField with outlined variant and with label should render default st
 .c1:focus-within::after,
 .c1:focus-within:hover::after {
   border-color: #126AFA;
+  border-radius: 0.4rem;
 }
 
 .c1:focus-within .c4,
@@ -12855,6 +13024,7 @@ exports[`TextField with outlined variant and with label should render disabled s
   -webkit-transition: all 100ms ease-out;
   transition: all 100ms ease-out;
   cursor: text;
+  border-radius: 0.4rem;
   background-color: #ffffff;
   cursor: not-allowed;
   background-color: #ffffff;
@@ -12896,15 +13066,20 @@ exports[`TextField with outlined variant and with label should render disabled s
   background-color: transparent;
   -webkit-transition: all 100ms ease-out;
   transition: all 100ms ease-out;
+  border-radius: 0.4rem;
+  border-width: 0.4rem;
   border: 0.1rem solid #98A7B7;
 }
 
 .c1:focus-within {
+  border-radius: 0.4rem;
   box-shadow: 0 0.2rem 0.8rem rgba(18,106,250,0.2);
 }
 
 .c1:focus-within::after {
   border-color: #126AFA;
+  border-radius: 0.4rem;
+  border-width: 0.15rem;
 }
 
 .c1::after,
@@ -13164,6 +13339,7 @@ exports[`TextField with outlined variant and with label should render focus stat
   -webkit-transition: all 100ms ease-out;
   transition: all 100ms ease-out;
   cursor: text;
+  border-radius: 0.4rem;
   background-color: #ffffff;
 }
 
@@ -13203,6 +13379,8 @@ exports[`TextField with outlined variant and with label should render focus stat
   background-color: transparent;
   -webkit-transition: all 100ms ease-out;
   transition: all 100ms ease-out;
+  border-radius: 0.4rem;
+  border-width: 0.4rem;
   border: 0.1rem solid #98A7B7;
 }
 
@@ -13211,15 +13389,19 @@ exports[`TextField with outlined variant and with label should render focus stat
 }
 
 .c1:focus-within {
+  border-radius: 0.4rem;
   box-shadow: 0 0.2rem 0.8rem rgba(18,106,250,0.2);
 }
 
 .c1:hover::after {
   border-color: #607890;
+  border-width: 0.15rem;
 }
 
 .c1:focus-within::after {
   border-color: #126AFA;
+  border-radius: 0.4rem;
+  border-width: 0.15rem;
 }
 
 .c1:focus-within,
@@ -13230,6 +13412,7 @@ exports[`TextField with outlined variant and with label should render focus stat
 .c1:focus-within::after,
 .c1:focus-within:hover::after {
   border-color: #126AFA;
+  border-radius: 0.4rem;
 }
 
 .c1:focus-within .c4,
@@ -13495,6 +13678,7 @@ exports[`TextField with outlined variant and without label should render default
   -webkit-transition: all 100ms ease-out;
   transition: all 100ms ease-out;
   cursor: text;
+  border-radius: 0.4rem;
   background-color: #ffffff;
 }
 
@@ -13534,6 +13718,8 @@ exports[`TextField with outlined variant and without label should render default
   background-color: transparent;
   -webkit-transition: all 100ms ease-out;
   transition: all 100ms ease-out;
+  border-radius: 0.4rem;
+  border-width: 0.4rem;
   border: 0.1rem solid #98A7B7;
 }
 
@@ -13542,15 +13728,19 @@ exports[`TextField with outlined variant and without label should render default
 }
 
 .c1:focus-within {
+  border-radius: 0.4rem;
   box-shadow: 0 0.2rem 0.8rem rgba(18,106,250,0.2);
 }
 
 .c1:hover::after {
   border-color: #607890;
+  border-width: 0.15rem;
 }
 
 .c1:focus-within::after {
   border-color: #126AFA;
+  border-radius: 0.4rem;
+  border-width: 0.15rem;
 }
 
 .c1:focus-within,
@@ -13561,6 +13751,7 @@ exports[`TextField with outlined variant and without label should render default
 .c1:focus-within::after,
 .c1:focus-within:hover::after {
   border-color: #126AFA;
+  border-radius: 0.4rem;
 }
 
 .c1:focus-within .c4,
@@ -13820,6 +14011,7 @@ exports[`TextField with outlined variant and without label should render disable
   -webkit-transition: all 100ms ease-out;
   transition: all 100ms ease-out;
   cursor: text;
+  border-radius: 0.4rem;
   background-color: #ffffff;
   cursor: not-allowed;
   background-color: #ffffff;
@@ -13861,15 +14053,20 @@ exports[`TextField with outlined variant and without label should render disable
   background-color: transparent;
   -webkit-transition: all 100ms ease-out;
   transition: all 100ms ease-out;
+  border-radius: 0.4rem;
+  border-width: 0.4rem;
   border: 0.1rem solid #98A7B7;
 }
 
 .c1:focus-within {
+  border-radius: 0.4rem;
   box-shadow: 0 0.2rem 0.8rem rgba(18,106,250,0.2);
 }
 
 .c1:focus-within::after {
   border-color: #126AFA;
+  border-radius: 0.4rem;
+  border-width: 0.15rem;
 }
 
 .c1::after,
@@ -14123,6 +14320,7 @@ exports[`TextField with outlined variant and without label should render focus s
   -webkit-transition: all 100ms ease-out;
   transition: all 100ms ease-out;
   cursor: text;
+  border-radius: 0.4rem;
   background-color: #ffffff;
 }
 
@@ -14162,6 +14360,8 @@ exports[`TextField with outlined variant and without label should render focus s
   background-color: transparent;
   -webkit-transition: all 100ms ease-out;
   transition: all 100ms ease-out;
+  border-radius: 0.4rem;
+  border-width: 0.4rem;
   border: 0.1rem solid #98A7B7;
 }
 
@@ -14170,15 +14370,19 @@ exports[`TextField with outlined variant and without label should render focus s
 }
 
 .c1:focus-within {
+  border-radius: 0.4rem;
   box-shadow: 0 0.2rem 0.8rem rgba(18,106,250,0.2);
 }
 
 .c1:hover::after {
   border-color: #607890;
+  border-width: 0.15rem;
 }
 
 .c1:focus-within::after {
   border-color: #126AFA;
+  border-radius: 0.4rem;
+  border-width: 0.15rem;
 }
 
 .c1:focus-within,
@@ -14189,6 +14393,7 @@ exports[`TextField with outlined variant and without label should render focus s
 .c1:focus-within::after,
 .c1:focus-within:hover::after {
   border-color: #126AFA;
+  border-radius: 0.4rem;
 }
 
 .c1:focus-within .c4,
@@ -14459,6 +14664,7 @@ exports[`TextField with outlined variant should render error state properly  1`]
   -webkit-transition: all 100ms ease-out;
   transition: all 100ms ease-out;
   cursor: text;
+  border-radius: 0.4rem;
   background-color: #ffffff;
 }
 
@@ -14498,6 +14704,8 @@ exports[`TextField with outlined variant should render error state properly  1`]
   background-color: transparent;
   -webkit-transition: all 100ms ease-out;
   transition: all 100ms ease-out;
+  border-radius: 0.4rem;
+  border-width: 0.4rem;
   border: 0.1rem solid #98A7B7;
 }
 
@@ -14506,15 +14714,19 @@ exports[`TextField with outlined variant should render error state properly  1`]
 }
 
 .c1:focus-within {
+  border-radius: 0.4rem;
   box-shadow: 0 0.2rem 0.8rem rgba(204,0,0,0.2);
 }
 
 .c1:hover::after {
   border-color: #607890;
+  border-width: 0.15rem;
 }
 
 .c1:focus-within::after {
   border-color: #126AFA;
+  border-radius: 0.4rem;
+  border-width: 0.15rem;
 }
 
 .c1,
@@ -14838,6 +15050,7 @@ exports[`TextField with outlined variant should render error state properly with
   -webkit-transition: all 100ms ease-out;
   transition: all 100ms ease-out;
   cursor: text;
+  border-radius: 0.4rem;
   background-color: #ffffff;
 }
 
@@ -14877,6 +15090,8 @@ exports[`TextField with outlined variant should render error state properly with
   background-color: transparent;
   -webkit-transition: all 100ms ease-out;
   transition: all 100ms ease-out;
+  border-radius: 0.4rem;
+  border-width: 0.4rem;
   border: 0.1rem solid #98A7B7;
 }
 
@@ -14885,15 +15100,19 @@ exports[`TextField with outlined variant should render error state properly with
 }
 
 .c1:focus-within {
+  border-radius: 0.4rem;
   box-shadow: 0 0.2rem 0.8rem rgba(204,0,0,0.2);
 }
 
 .c1:hover::after {
   border-color: #607890;
+  border-width: 0.15rem;
 }
 
 .c1:focus-within::after {
   border-color: #126AFA;
+  border-radius: 0.4rem;
+  border-width: 0.15rem;
 }
 
 .c1,
@@ -15629,6 +15848,7 @@ exports[`TextField with outlined variant should render properly with custom disa
   -webkit-transition: all 100ms ease-out;
   transition: all 100ms ease-out;
   cursor: text;
+  border-radius: 0.4rem;
   background-color: #ffffff;
   cursor: text;
   background-color: #ffffff;
@@ -15670,15 +15890,20 @@ exports[`TextField with outlined variant should render properly with custom disa
   background-color: transparent;
   -webkit-transition: all 100ms ease-out;
   transition: all 100ms ease-out;
+  border-radius: 0.4rem;
+  border-width: 0.4rem;
   border: 0.1rem solid #98A7B7;
 }
 
 .c1:focus-within {
+  border-radius: 0.4rem;
   box-shadow: 0 0.2rem 0.8rem rgba(18,106,250,0.2);
 }
 
 .c1:focus-within::after {
   border-color: #126AFA;
+  border-radius: 0.4rem;
+  border-width: 0.15rem;
 }
 
 .c1::after,
@@ -15951,6 +16176,7 @@ exports[`TextField with outlined variant should render properly with multiline 1
   -webkit-transition: all 100ms ease-out;
   transition: all 100ms ease-out;
   cursor: text;
+  border-radius: 0.4rem;
   background-color: #ffffff;
 }
 
@@ -15990,6 +16216,8 @@ exports[`TextField with outlined variant should render properly with multiline 1
   background-color: transparent;
   -webkit-transition: all 100ms ease-out;
   transition: all 100ms ease-out;
+  border-radius: 0.4rem;
+  border-width: 0.4rem;
   border: 0.1rem solid #98A7B7;
 }
 
@@ -15998,15 +16226,19 @@ exports[`TextField with outlined variant should render properly with multiline 1
 }
 
 .c1:focus-within {
+  border-radius: 0.4rem;
   box-shadow: 0 0.2rem 0.8rem rgba(18,106,250,0.2);
 }
 
 .c1:hover::after {
   border-color: #607890;
+  border-width: 0.15rem;
 }
 
 .c1:focus-within::after {
   border-color: #126AFA;
+  border-radius: 0.4rem;
+  border-width: 0.15rem;
 }
 
 .c1:focus-within,
@@ -16017,6 +16249,7 @@ exports[`TextField with outlined variant should render properly with multiline 1
 .c1:focus-within::after,
 .c1:focus-within:hover::after {
   border-color: #126AFA;
+  border-radius: 0.4rem;
 }
 
 .c1:focus-within .c4,
@@ -16298,6 +16531,7 @@ exports[`TextField with outlined variant should render properly with prefix 1`] 
   -webkit-transition: all 100ms ease-out;
   transition: all 100ms ease-out;
   cursor: text;
+  border-radius: 0.4rem;
   background-color: #ffffff;
 }
 
@@ -16337,6 +16571,8 @@ exports[`TextField with outlined variant should render properly with prefix 1`] 
   background-color: transparent;
   -webkit-transition: all 100ms ease-out;
   transition: all 100ms ease-out;
+  border-radius: 0.4rem;
+  border-width: 0.4rem;
   border: 0.1rem solid #98A7B7;
 }
 
@@ -16345,15 +16581,19 @@ exports[`TextField with outlined variant should render properly with prefix 1`] 
 }
 
 .c1:focus-within {
+  border-radius: 0.4rem;
   box-shadow: 0 0.2rem 0.8rem rgba(18,106,250,0.2);
 }
 
 .c1:hover::after {
   border-color: #607890;
+  border-width: 0.15rem;
 }
 
 .c1:focus-within::after {
   border-color: #126AFA;
+  border-radius: 0.4rem;
+  border-width: 0.15rem;
 }
 
 .c1:focus-within,
@@ -16364,6 +16604,7 @@ exports[`TextField with outlined variant should render properly with prefix 1`] 
 .c1:focus-within::after,
 .c1:focus-within:hover::after {
   border-color: #126AFA;
+  border-radius: 0.4rem;
 }
 
 .c1:focus-within .c7,
@@ -16662,6 +16903,7 @@ exports[`TextField with outlined variant should render properly with suffix 1`] 
   -webkit-transition: all 100ms ease-out;
   transition: all 100ms ease-out;
   cursor: text;
+  border-radius: 0.4rem;
   background-color: #ffffff;
 }
 
@@ -16701,6 +16943,8 @@ exports[`TextField with outlined variant should render properly with suffix 1`] 
   background-color: transparent;
   -webkit-transition: all 100ms ease-out;
   transition: all 100ms ease-out;
+  border-radius: 0.4rem;
+  border-width: 0.4rem;
   border: 0.1rem solid #98A7B7;
 }
 
@@ -16709,15 +16953,19 @@ exports[`TextField with outlined variant should render properly with suffix 1`] 
 }
 
 .c1:focus-within {
+  border-radius: 0.4rem;
   box-shadow: 0 0.2rem 0.8rem rgba(18,106,250,0.2);
 }
 
 .c1:hover::after {
   border-color: #607890;
+  border-width: 0.15rem;
 }
 
 .c1:focus-within::after {
   border-color: #126AFA;
+  border-radius: 0.4rem;
+  border-width: 0.15rem;
 }
 
 .c1:focus-within,
@@ -16728,6 +16976,7 @@ exports[`TextField with outlined variant should render properly with suffix 1`] 
 .c1:focus-within::after,
 .c1:focus-within:hover::after {
   border-color: #126AFA;
+  border-radius: 0.4rem;
 }
 
 .c1:focus-within .c4,

--- a/packages/core/src/components/TextField/__snapshots__/TextField.test.tsx.snap
+++ b/packages/core/src/components/TextField/__snapshots__/TextField.test.tsx.snap
@@ -254,6 +254,10 @@ exports[`TextField character count should correctly render character count for S
   opacity: 1;
 }
 
+.c3:disabled {
+  color: #435465;
+}
+
 .c3:disabled ~ .c4,
 .c3:disabled ~ .sc-fznyAO {
   cursor: not-allowed;
@@ -412,7 +416,6 @@ exports[`TextField character count should correctly render character count for f
   -webkit-transition: all 100ms ease-out;
   transition: all 100ms ease-out;
   cursor: text;
-  border-radius: 1rem;
   background-color: #F7F8F9;
 }
 
@@ -448,14 +451,15 @@ exports[`TextField character count should correctly render character count for f
   background-color: transparent;
   -webkit-transition: all 100ms ease-out;
   transition: all 100ms ease-out;
-  border-radius: 1rem;
   border: 0.1rem solid #b0bcc8;
 }
 
-.c1:hover::after,
-.c1:focus-within::after {
-  border-width: 0.15rem;
+.c1:hover::after {
   border-color: #607890;
+}
+
+.c1:focus-within::after {
+  border-color: #126AFA;
 }
 
 .c1 input {
@@ -470,6 +474,7 @@ exports[`TextField character count should correctly render character count for f
 .c1:focus-within::after,
 .c1:focus-within:hover::after {
   border-color: #126AFA;
+  border-radius: undefined;
 }
 
 .c1:focus-within .c4,
@@ -595,6 +600,10 @@ exports[`TextField character count should correctly render character count for f
 
 .c3.c3.c3:focus::placeholder {
   opacity: 1;
+}
+
+.c3:disabled {
+  color: #546A7F;
 }
 
 .c3:disabled ~ .c4,
@@ -943,6 +952,10 @@ exports[`TextField character count should correctly render character count for m
   opacity: 1;
 }
 
+.c3:disabled {
+  color: #435465;
+}
+
 .c3:disabled ~ .c4,
 .c3:disabled ~ .sc-fznyAO {
   cursor: not-allowed;
@@ -1270,6 +1283,10 @@ exports[`TextField character count should correctly render character count if we
 
 .c3.c3.c3:focus::placeholder {
   opacity: 1;
+}
+
+.c3:disabled {
+  color: #435465;
 }
 
 .c3:disabled ~ .c4,
@@ -1600,6 +1617,10 @@ exports[`TextField character count should correctly render character count when 
 
 .c3.c3.c3:focus::placeholder {
   opacity: 1;
+}
+
+.c3:disabled {
+  color: #435465;
 }
 
 .c3:disabled ~ .c4,
@@ -1934,6 +1955,10 @@ exports[`TextField character count should correctly render character count when 
   opacity: 1;
 }
 
+.c3:disabled {
+  color: #435465;
+}
+
 .c3:disabled ~ .c4,
 .c3:disabled ~ .sc-fznyAO {
   cursor: not-allowed;
@@ -2254,6 +2279,10 @@ exports[`TextField should not call onClick function on click on helper text 1`] 
 
 .c3.c3.c3:focus::placeholder {
   opacity: 1;
+}
+
+.c3:disabled {
+  color: #435465;
 }
 
 .c3:disabled ~ .c4,
@@ -2682,6 +2711,10 @@ exports[`TextField should render properly with M size 1`] = `
   opacity: 1;
 }
 
+.c6:disabled {
+  color: #435465;
+}
+
 .c6:disabled ~ .c7,
 .c6:disabled ~ .sc-fznyAO {
   cursor: not-allowed;
@@ -3058,6 +3091,10 @@ exports[`TextField should render properly with S size 1`] = `
   opacity: 1;
 }
 
+.c6:disabled {
+  color: #435465;
+}
+
 .c6:disabled ~ .c7,
 .c6:disabled ~ .sc-fznyAO {
   cursor: not-allowed;
@@ -3405,6 +3442,10 @@ exports[`TextField should render properly with default props 1`] = `
   opacity: 1;
 }
 
+.c3:disabled {
+  color: #435465;
+}
+
 .c3:disabled ~ .c4,
 .c3:disabled ~ .sc-fznyAO {
   cursor: not-allowed;
@@ -3718,6 +3759,10 @@ exports[`TextField with filled variant and with label should render default stat
   opacity: 1;
 }
 
+.c3:disabled {
+  color: #435465;
+}
+
 .c3:disabled ~ .c4,
 .c3:disabled ~ .sc-fznyAO {
   cursor: not-allowed;
@@ -4008,6 +4053,10 @@ exports[`TextField with filled variant and with label should render disabled sta
 
 .c3.c3.c3:focus::placeholder {
   opacity: 1;
+}
+
+.c3:disabled {
+  color: #435465;
 }
 
 .c3:disabled ~ .c4,
@@ -4325,6 +4374,10 @@ exports[`TextField with filled variant and with label should render focus state 
   opacity: 1;
 }
 
+.c3:disabled {
+  color: #435465;
+}
+
 .c3:disabled ~ .c4,
 .c3:disabled ~ .sc-fznyAO {
   cursor: not-allowed;
@@ -4634,6 +4687,10 @@ exports[`TextField with filled variant and without label should render default s
   opacity: 1;
 }
 
+.c3:disabled {
+  color: #435465;
+}
+
 .c3:disabled ~ .c4,
 .c3:disabled ~ .sc-fznyAO {
   cursor: not-allowed;
@@ -4918,6 +4975,10 @@ exports[`TextField with filled variant and without label should render disabled 
 
 .c3.c3.c3:focus::placeholder {
   opacity: 1;
+}
+
+.c3:disabled {
+  color: #435465;
 }
 
 .c3:disabled ~ .c4,
@@ -5227,6 +5288,10 @@ exports[`TextField with filled variant and without label should render focus sta
 
 .c3.c3.c3:focus::placeholder {
   opacity: 1;
+}
+
+.c3:disabled {
+  color: #435465;
 }
 
 .c3:disabled ~ .c4,
@@ -5581,6 +5646,10 @@ exports[`TextField with filled variant should render error state properly  1`] =
 
 .c3.c3.c3:focus::placeholder {
   opacity: 1;
+}
+
+.c3:disabled {
+  color: #435465;
 }
 
 .c3:disabled ~ .c4,
@@ -5944,6 +6013,10 @@ exports[`TextField with filled variant should render error state properly with a
   opacity: 1;
 }
 
+.c3:disabled {
+  color: #435465;
+}
+
 .c3:disabled ~ .c4,
 .c3:disabled ~ .sc-fznyAO {
   cursor: not-allowed;
@@ -6074,6 +6147,337 @@ exports[`TextField with filled variant should render helper text properly 1`] = 
 >
   Some text
 </span>
+`;
+
+exports[`TextField with filled variant should render properly with custom border styles (themed) 1`] = `
+.c6 {
+  overflow: visible;
+  font-size: 2.4rem;
+  -webkit-transition: all 100ms linear;
+  transition: all 100ms linear;
+  cursor: inherit;
+}
+
+.c6 * {
+  fill-opacity: 1;
+  -webkit-transition: all 100ms linear;
+  transition: all 100ms linear;
+  fill: #607890;
+}
+
+.c5 {
+  top: 50%;
+  left: 0;
+  cursor: text;
+  -webkit-user-select: none;
+  -moz-user-select: none;
+  -ms-user-select: none;
+  user-select: none;
+  position: absolute;
+  pointer-events: none;
+  -webkit-transition: all 150ms cubic-bezier(0.4,0,0.2,1);
+  transition: all 150ms cubic-bezier(0.4,0,0.2,1);
+  font-size: 1.6rem;
+  font-weight: 400;
+  -webkit-letter-spacing: 0rem;
+  -moz-letter-spacing: 0rem;
+  -ms-letter-spacing: 0rem;
+  letter-spacing: 0rem;
+  line-height: 2.6rem;
+  font-family: Open Sans,Helvetica Neue,Helvetica,Arial,sans-serif;
+  -webkit-transform-origin: 0 0;
+  -ms-transform-origin: 0 0;
+  transform-origin: 0 0;
+  touch-action: manipulation;
+  -webkit-transform: translateY(-50%);
+  -ms-transform: translateY(-50%);
+  transform: translateY(-50%);
+  opacity: 1;
+  z-index: 1;
+  width: 100%;
+  max-width: -webkit-min-content;
+  max-width: -moz-min-content;
+  max-width: min-content;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
+.c8 {
+  pointer-events: none;
+  margin-left: 1.6rem;
+}
+
+.c1 {
+  position: relative;
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  -webkit-flex-direction: row;
+  -ms-flex-direction: row;
+  flex-direction: row;
+  box-sizing: border-box;
+  height: 5.6rem;
+  padding: 0 1.6rem;
+  -webkit-transition: all 100ms ease-out;
+  transition: all 100ms ease-out;
+  cursor: text;
+  border-radius: 0.4rem 0.4rem 0 0;
+  background-color: #eff2f4;
+  cursor: not-allowed;
+  background-color: #F7F8F9;
+}
+
+.c1 .c4 {
+  color: #546A7F;
+}
+
+.c1 .sc-fzozJi,
+.c1 .c7 {
+  color: #546A7F;
+}
+
+.c1 .sc-fzozJi *,
+.c1 .c7 * {
+  fill: #546A7F;
+}
+
+.c1 ~ .sc-Axmtr {
+  color: #546A7F;
+}
+
+.c1::after {
+  content: '';
+  width: 100%;
+  height: 0;
+  position: absolute;
+  bottom: 0;
+  left: 0;
+  box-sizing: border-box;
+  border-top: 0.1rem solid #546A7F;
+  -webkit-transition: all 100ms ease-out;
+  transition: all 100ms ease-out;
+}
+
+.c1 input {
+  box-shadow: 0 0 0 100000px #eff2f4 inset;
+}
+
+.c1::after,
+.c1:hover::after {
+  border-width: 0.1rem;
+  border-color: #C7D0D8;
+}
+
+.c1 input {
+  box-shadow: 0 0 0 100000px #F7F8F9 inset;
+}
+
+.c1 .c4 {
+  color: #b0bcc8;
+}
+
+.c1 .sc-AxheI {
+  color: #b0bcc8;
+}
+
+.c1 .sc-fzozJi,
+.c1 .c7 {
+  color: #b0bcc8;
+}
+
+.c1 .sc-fzozJi *,
+.c1 .c7 * {
+  fill: #b0bcc8;
+}
+
+.c1 ~ .sc-Axmtr {
+  color: #b0bcc8;
+}
+
+.c1 * {
+  cursor: not-allowed;
+}
+
+.c2 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  position: relative;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  background-color: transparent;
+  -webkit-flex: 1;
+  -ms-flex: 1;
+  flex: 1;
+  height: 100%;
+}
+
+.c0 {
+  position: relative;
+  -webkit-flex-direction: column;
+  -ms-flex-direction: column;
+  flex-direction: column;
+  display: -webkit-inline-box;
+  display: -webkit-inline-flex;
+  display: -ms-inline-flexbox;
+  display: inline-flex;
+  width: -webkit-min-content;
+  width: -moz-min-content;
+  width: min-content;
+  min-width: 20rem;
+  margin: 0.8rem 0.8rem 0.8rem 0;
+}
+
+.c3 {
+  color: #13181D;
+  width: 100%;
+  margin: 0;
+  padding: 0;
+  box-sizing: border-box;
+  -webkit-transition: all 100ms ease-out;
+  transition: all 100ms ease-out;
+  background-color: transparent;
+  border: none;
+  text-overflow: ellipsis;
+  resize: none;
+  z-index: 1;
+  -webkit-align-self: flex-end;
+  -ms-flex-item-align: end;
+  align-self: flex-end;
+  margin-bottom: 0.7rem;
+}
+
+.c3,
+.c3 ~ .sc-fznyAO {
+  font-size: 1.6rem;
+  font-weight: 400;
+  -webkit-letter-spacing: 0rem;
+  -moz-letter-spacing: 0rem;
+  -ms-letter-spacing: 0rem;
+  letter-spacing: 0rem;
+  line-height: 2.6rem;
+  font-family: Open Sans,Helvetica Neue,Helvetica,Arial,sans-serif;
+}
+
+.c3.c3.c3:focus {
+  outline: none;
+  box-shadow: unset;
+}
+
+.c3.c3.c3:focus::-webkit-input-placeholder {
+  opacity: 1;
+}
+
+.c3.c3.c3:focus::-moz-placeholder {
+  opacity: 1;
+}
+
+.c3.c3.c3:focus:-ms-input-placeholder {
+  opacity: 1;
+}
+
+.c3.c3.c3:focus::placeholder {
+  opacity: 1;
+}
+
+.c3:disabled {
+  color: #435465;
+}
+
+.c3:disabled ~ .c4,
+.c3:disabled ~ .sc-fznyAO {
+  cursor: not-allowed;
+}
+
+.c3::-webkit-input-placeholder {
+  opacity: 0;
+  -webkit-transition: all 100ms ease-out;
+  transition: all 100ms ease-out;
+}
+
+.c3::-moz-placeholder {
+  opacity: 0;
+  -webkit-transition: all 100ms ease-out;
+  transition: all 100ms ease-out;
+}
+
+.c3:-ms-input-placeholder {
+  opacity: 0;
+  -webkit-transition: all 100ms ease-out;
+  transition: all 100ms ease-out;
+}
+
+.c3::placeholder {
+  opacity: 0;
+  -webkit-transition: all 100ms ease-out;
+  transition: all 100ms ease-out;
+}
+
+.c3:not(:placeholder-shown) ~ .c4,
+.c3:focus ~ .c4 {
+  -webkit-transform: translateY(-87%) scale(0.75);
+  -ms-transform: translateY(-87%) scale(0.75);
+  transform: translateY(-87%) scale(0.75);
+}
+
+.c3:not(:placeholder-shown) ~ .sc-fznyAO {
+  opacity: 1;
+}
+
+<div>
+  <div
+    class="c0"
+    id="medly-textField-input-wrapper"
+  >
+    <div
+      class="c1"
+      disabled=""
+    >
+      <div
+        class="c2"
+      >
+        <input
+          aria-describedby="medly-textField-helper-text"
+          class="c3"
+          disabled=""
+          id="medly-textField-input"
+          placeholder=" "
+          type="text"
+          value=""
+        />
+        <label
+          class="c4 c5"
+          for="medly-textField-input"
+        >
+          Name
+        </label>
+      </div>
+      <svg
+        class="c6 c7 c8"
+        fill="none"
+        height="1em"
+        viewBox="0 0 24 24"
+        width="1em"
+        xmlns="http://www.w3.org/2000/svg"
+      >
+        <path
+          d="M8.795 15.875l-3.47-3.47a.996.996 0 0 0-1.41 0 .996.996 0 0 0 0 1.41l4.18 4.18c.39.39 1.02.39 1.41 0l10.58-10.58a.996.996 0 1 0-1.41-1.41l-9.88 9.87z"
+          fill="green"
+        />
+      </svg>
+    </div>
+    
+  </div>
+</div>
 `;
 
 exports[`TextField with filled variant should render properly with custom disabled cursor (themed) 1`] = `
@@ -6314,6 +6718,10 @@ exports[`TextField with filled variant should render properly with custom disabl
 
 .c3.c3.c3:focus::placeholder {
   opacity: 1;
+}
+
+.c3:disabled {
+  color: #435465;
 }
 
 .c3:disabled ~ .c4,
@@ -6639,6 +7047,10 @@ exports[`TextField with filled variant should render properly with multiline 1`]
 
 .c3.c3.c3:focus::placeholder {
   opacity: 1;
+}
+
+.c3:disabled {
+  color: #435465;
 }
 
 .c3:disabled ~ .c4,
@@ -6971,6 +7383,10 @@ exports[`TextField with filled variant should render properly with prefix 1`] = 
 
 .c6.c6.c6:focus::placeholder {
   opacity: 1;
+}
+
+.c6:disabled {
+  color: #435465;
 }
 
 .c6:disabled ~ .c7,
@@ -7319,6 +7735,10 @@ exports[`TextField with filled variant should render properly with suffix 1`] = 
   opacity: 1;
 }
 
+.c3:disabled {
+  color: #435465;
+}
+
 .c3:disabled ~ .c4,
 .c3:disabled ~ .sc-fznyAO {
   cursor: not-allowed;
@@ -7466,7 +7886,6 @@ exports[`TextField with fusion variant and with label should render default stat
   -webkit-transition: all 100ms ease-out;
   transition: all 100ms ease-out;
   cursor: text;
-  border-radius: 1rem;
   background-color: #F7F8F9;
 }
 
@@ -7502,14 +7921,15 @@ exports[`TextField with fusion variant and with label should render default stat
   background-color: transparent;
   -webkit-transition: all 100ms ease-out;
   transition: all 100ms ease-out;
-  border-radius: 1rem;
   border: 0.1rem solid #b0bcc8;
 }
 
-.c1:hover::after,
-.c1:focus-within::after {
-  border-width: 0.15rem;
+.c1:hover::after {
   border-color: #607890;
+}
+
+.c1:focus-within::after {
+  border-color: #126AFA;
 }
 
 .c1 input {
@@ -7524,6 +7944,7 @@ exports[`TextField with fusion variant and with label should render default stat
 .c1:focus-within::after,
 .c1:focus-within:hover::after {
   border-color: #126AFA;
+  border-radius: undefined;
 }
 
 .c1:focus-within .c4,
@@ -7653,6 +8074,10 @@ exports[`TextField with fusion variant and with label should render default stat
 
 .c3.c3.c3:focus::placeholder {
   opacity: 1;
+}
+
+.c3:disabled {
+  color: #546A7F;
 }
 
 .c3:disabled ~ .c4,
@@ -7804,7 +8229,6 @@ exports[`TextField with fusion variant and with label should render disabled sta
   -webkit-transition: all 100ms ease-out;
   transition: all 100ms ease-out;
   cursor: text;
-  border-radius: 1rem;
   background-color: #F7F8F9;
   cursor: not-allowed;
   background-color: #ffffff;
@@ -7842,7 +8266,6 @@ exports[`TextField with fusion variant and with label should render disabled sta
   background-color: transparent;
   -webkit-transition: all 100ms ease-out;
   transition: all 100ms ease-out;
-  border-radius: 1rem;
   border: 0.1rem solid #b0bcc8;
 }
 
@@ -7969,6 +8392,10 @@ exports[`TextField with fusion variant and with label should render disabled sta
 
 .c3.c3.c3:focus::placeholder {
   opacity: 1;
+}
+
+.c3:disabled {
+  color: #546A7F;
 }
 
 .c3:disabled ~ .c4,
@@ -8122,7 +8549,6 @@ exports[`TextField with fusion variant and with label should render focus state 
   -webkit-transition: all 100ms ease-out;
   transition: all 100ms ease-out;
   cursor: text;
-  border-radius: 1rem;
   background-color: #F7F8F9;
 }
 
@@ -8158,14 +8584,15 @@ exports[`TextField with fusion variant and with label should render focus state 
   background-color: transparent;
   -webkit-transition: all 100ms ease-out;
   transition: all 100ms ease-out;
-  border-radius: 1rem;
   border: 0.1rem solid #b0bcc8;
 }
 
-.c1:hover::after,
-.c1:focus-within::after {
-  border-width: 0.15rem;
+.c1:hover::after {
   border-color: #607890;
+}
+
+.c1:focus-within::after {
+  border-color: #126AFA;
 }
 
 .c1 input {
@@ -8180,6 +8607,7 @@ exports[`TextField with fusion variant and with label should render focus state 
 .c1:focus-within::after,
 .c1:focus-within:hover::after {
   border-color: #126AFA;
+  border-radius: undefined;
 }
 
 .c1:focus-within .c4,
@@ -8309,6 +8737,10 @@ exports[`TextField with fusion variant and with label should render focus state 
 
 .c3.c3.c3:focus::placeholder {
   opacity: 1;
+}
+
+.c3:disabled {
+  color: #546A7F;
 }
 
 .c3:disabled ~ .c4,
@@ -8460,7 +8892,6 @@ exports[`TextField with fusion variant and without label should render default s
   -webkit-transition: all 100ms ease-out;
   transition: all 100ms ease-out;
   cursor: text;
-  border-radius: 1rem;
   background-color: #F7F8F9;
 }
 
@@ -8496,14 +8927,15 @@ exports[`TextField with fusion variant and without label should render default s
   background-color: transparent;
   -webkit-transition: all 100ms ease-out;
   transition: all 100ms ease-out;
-  border-radius: 1rem;
   border: 0.1rem solid #b0bcc8;
 }
 
-.c1:hover::after,
-.c1:focus-within::after {
-  border-width: 0.15rem;
+.c1:hover::after {
   border-color: #607890;
+}
+
+.c1:focus-within::after {
+  border-color: #126AFA;
 }
 
 .c1 input {
@@ -8518,6 +8950,7 @@ exports[`TextField with fusion variant and without label should render default s
 .c1:focus-within::after,
 .c1:focus-within:hover::after {
   border-color: #126AFA;
+  border-radius: undefined;
 }
 
 .c1:focus-within .c4,
@@ -8643,6 +9076,10 @@ exports[`TextField with fusion variant and without label should render default s
 
 .c3.c3.c3:focus::placeholder {
   opacity: 1;
+}
+
+.c3:disabled {
+  color: #546A7F;
 }
 
 .c3:disabled ~ .c4,
@@ -8792,7 +9229,6 @@ exports[`TextField with fusion variant and without label should render disabled 
   -webkit-transition: all 100ms ease-out;
   transition: all 100ms ease-out;
   cursor: text;
-  border-radius: 1rem;
   background-color: #F7F8F9;
   cursor: not-allowed;
   background-color: #ffffff;
@@ -8830,7 +9266,6 @@ exports[`TextField with fusion variant and without label should render disabled 
   background-color: transparent;
   -webkit-transition: all 100ms ease-out;
   transition: all 100ms ease-out;
-  border-radius: 1rem;
   border: 0.1rem solid #b0bcc8;
 }
 
@@ -8953,6 +9388,10 @@ exports[`TextField with fusion variant and without label should render disabled 
 
 .c3.c3.c3:focus::placeholder {
   opacity: 1;
+}
+
+.c3:disabled {
+  color: #546A7F;
 }
 
 .c3:disabled ~ .c4,
@@ -9104,7 +9543,6 @@ exports[`TextField with fusion variant and without label should render focus sta
   -webkit-transition: all 100ms ease-out;
   transition: all 100ms ease-out;
   cursor: text;
-  border-radius: 1rem;
   background-color: #F7F8F9;
 }
 
@@ -9140,14 +9578,15 @@ exports[`TextField with fusion variant and without label should render focus sta
   background-color: transparent;
   -webkit-transition: all 100ms ease-out;
   transition: all 100ms ease-out;
-  border-radius: 1rem;
   border: 0.1rem solid #b0bcc8;
 }
 
-.c1:hover::after,
-.c1:focus-within::after {
-  border-width: 0.15rem;
+.c1:hover::after {
   border-color: #607890;
+}
+
+.c1:focus-within::after {
+  border-color: #126AFA;
 }
 
 .c1 input {
@@ -9162,6 +9601,7 @@ exports[`TextField with fusion variant and without label should render focus sta
 .c1:focus-within::after,
 .c1:focus-within:hover::after {
   border-color: #126AFA;
+  border-radius: undefined;
 }
 
 .c1:focus-within .c4,
@@ -9287,6 +9727,10 @@ exports[`TextField with fusion variant and without label should render focus sta
 
 .c3.c3.c3:focus::placeholder {
   opacity: 1;
+}
+
+.c3:disabled {
+  color: #546A7F;
 }
 
 .c3:disabled ~ .c4,
@@ -9447,7 +9891,6 @@ exports[`TextField with fusion variant should render error state properly  1`] =
   -webkit-transition: all 100ms ease-out;
   transition: all 100ms ease-out;
   cursor: text;
-  border-radius: 1rem;
   background-color: #F7F8F9;
 }
 
@@ -9483,14 +9926,15 @@ exports[`TextField with fusion variant should render error state properly  1`] =
   background-color: transparent;
   -webkit-transition: all 100ms ease-out;
   transition: all 100ms ease-out;
-  border-radius: 1rem;
   border: 0.1rem solid #b0bcc8;
 }
 
-.c1:hover::after,
-.c1:focus-within::after {
-  border-width: 0.15rem;
+.c1:hover::after {
   border-color: #607890;
+}
+
+.c1:focus-within::after {
+  border-color: #126AFA;
 }
 
 .c1 input {
@@ -9655,6 +10099,10 @@ exports[`TextField with fusion variant should render error state properly  1`] =
 
 .c3.c3.c3:focus::placeholder {
   opacity: 1;
+}
+
+.c3:disabled {
+  color: #546A7F;
 }
 
 .c3:disabled ~ .c4,
@@ -9822,7 +10270,6 @@ exports[`TextField with fusion variant should render error state properly with a
   -webkit-transition: all 100ms ease-out;
   transition: all 100ms ease-out;
   cursor: text;
-  border-radius: 1rem;
   background-color: #ffffff;
 }
 
@@ -9858,14 +10305,15 @@ exports[`TextField with fusion variant should render error state properly with a
   background-color: transparent;
   -webkit-transition: all 100ms ease-out;
   transition: all 100ms ease-out;
-  border-radius: 1rem;
   border: 0.1rem solid #b0bcc8;
 }
 
-.c1:hover::after,
-.c1:focus-within::after {
-  border-width: 0.15rem;
+.c1:hover::after {
   border-color: #607890;
+}
+
+.c1:focus-within::after {
+  border-color: #126AFA;
 }
 
 .c1 input {
@@ -10037,6 +10485,10 @@ exports[`TextField with fusion variant should render error state properly with a
   opacity: 1;
 }
 
+.c3:disabled {
+  color: #546A7F;
+}
+
 .c3:disabled ~ .c4,
 .c3:disabled ~ .sc-fznyAO {
   cursor: not-allowed;
@@ -10182,6 +10634,368 @@ exports[`TextField with fusion variant should render helper text properly 1`] = 
 </span>
 `;
 
+exports[`TextField with fusion variant should render properly with custom border styles (themed) 1`] = `
+.c6 {
+  overflow: visible;
+  font-size: 2.4rem;
+  -webkit-transition: all 100ms linear;
+  transition: all 100ms linear;
+  cursor: inherit;
+}
+
+.c6 * {
+  fill-opacity: 1;
+  -webkit-transition: all 100ms linear;
+  transition: all 100ms linear;
+  fill: #607890;
+}
+
+.c5 {
+  top: 50%;
+  left: 0;
+  cursor: text;
+  -webkit-user-select: none;
+  -moz-user-select: none;
+  -ms-user-select: none;
+  user-select: none;
+  position: absolute;
+  pointer-events: none;
+  -webkit-transition: all 150ms cubic-bezier(0.4,0,0.2,1);
+  transition: all 150ms cubic-bezier(0.4,0,0.2,1);
+  font-size: 1.6rem;
+  font-weight: 400;
+  -webkit-letter-spacing: 0rem;
+  -moz-letter-spacing: 0rem;
+  -ms-letter-spacing: 0rem;
+  letter-spacing: 0rem;
+  line-height: 2.6rem;
+  font-family: Open Sans,Helvetica Neue,Helvetica,Arial,sans-serif;
+  -webkit-transform-origin: 0 0;
+  -ms-transform-origin: 0 0;
+  transform-origin: 0 0;
+  touch-action: manipulation;
+  -webkit-transform: translateY(-50%);
+  -ms-transform: translateY(-50%);
+  transform: translateY(-50%);
+  opacity: 1;
+  z-index: 1;
+  width: 100%;
+  max-width: -webkit-min-content;
+  max-width: -moz-min-content;
+  max-width: min-content;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
+.c5::after {
+  content: ' (optional)';
+}
+
+.c8 {
+  pointer-events: none;
+  margin-left: 1.6rem;
+}
+
+.c1 {
+  position: relative;
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  -webkit-flex-direction: row;
+  -ms-flex-direction: row;
+  flex-direction: row;
+  box-sizing: border-box;
+  height: 5.6rem;
+  padding: 0 1.6rem;
+  -webkit-transition: all 100ms ease-out;
+  transition: all 100ms ease-out;
+  cursor: text;
+  background-color: #F7F8F9;
+  border-radius: 0.25rem;
+  border-width: 0.2rem;
+  cursor: not-allowed;
+  background-color: #ffffff;
+}
+
+.c1 .c4 {
+  color: #546A7F;
+}
+
+.c1 .sc-fzozJi,
+.c1 .c7 {
+  color: #546A7F;
+}
+
+.c1 .sc-fzozJi *,
+.c1 .c7 * {
+  fill: #546A7F;
+}
+
+.c1 ~ .sc-Axmtr {
+  color: #546A7F;
+}
+
+.c1::after {
+  content: '';
+  box-sizing: border-box;
+  width: 100%;
+  height: 100%;
+  position: absolute;
+  top: 0;
+  right: 0;
+  bottom: 0;
+  left: 0;
+  pointer-events: none;
+  background-color: transparent;
+  -webkit-transition: all 100ms ease-out;
+  transition: all 100ms ease-out;
+  border-radius: 0.25rem;
+  border-width: 0.2rem;
+  border: 0.1rem solid #b0bcc8;
+}
+
+.c1:focus-within {
+  border-radius: 0.25rem;
+  border-width: 0.2rem;
+}
+
+.c1 input {
+  box-shadow: 0 0 0 100000px #F7F8F9 inset;
+}
+
+.c1::after,
+.c1:hover::after {
+  border-width: 0.1rem;
+  border-color: #C7D0D8;
+}
+
+.c1 input {
+  box-shadow: 0 0 0 100000px #ffffff inset;
+}
+
+.c1 .c4 {
+  color: #b0bcc8;
+}
+
+.c1 .sc-AxheI {
+  color: #b0bcc8;
+}
+
+.c1 .sc-fzozJi,
+.c1 .c7 {
+  color: #b0bcc8;
+}
+
+.c1 .sc-fzozJi *,
+.c1 .c7 * {
+  fill: #b0bcc8;
+}
+
+.c1 ~ .sc-Axmtr {
+  color: #b0bcc8;
+}
+
+.c1 * {
+  cursor: not-allowed;
+}
+
+.c2 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  position: relative;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  background-color: transparent;
+  -webkit-flex: 1;
+  -ms-flex: 1;
+  flex: 1;
+  height: 100%;
+}
+
+.c0 {
+  position: relative;
+  -webkit-flex-direction: column;
+  -ms-flex-direction: column;
+  flex-direction: column;
+  display: -webkit-inline-box;
+  display: -webkit-inline-flex;
+  display: -ms-inline-flexbox;
+  display: inline-flex;
+  width: -webkit-min-content;
+  width: -moz-min-content;
+  width: min-content;
+  min-width: 20rem;
+  margin: 0.8rem 0.8rem 0.8rem 0;
+}
+
+.c3 {
+  color: #13181D;
+  width: 100%;
+  margin: 0;
+  padding: 0;
+  box-sizing: border-box;
+  -webkit-transition: all 100ms ease-out;
+  transition: all 100ms ease-out;
+  background-color: transparent;
+  border: none;
+  text-overflow: ellipsis;
+  resize: none;
+  z-index: 1;
+  -webkit-align-self: flex-end;
+  -ms-flex-item-align: end;
+  align-self: flex-end;
+  margin-bottom: 1.3rem;
+}
+
+.c3,
+.c3 ~ .sc-fznyAO {
+  font-size: 1.6rem;
+  font-weight: 400;
+  -webkit-letter-spacing: 0rem;
+  -moz-letter-spacing: 0rem;
+  -ms-letter-spacing: 0rem;
+  letter-spacing: 0rem;
+  line-height: 2.6rem;
+  font-family: Open Sans,Helvetica Neue,Helvetica,Arial,sans-serif;
+}
+
+.c3.c3.c3:focus {
+  outline: none;
+  box-shadow: unset;
+}
+
+.c3.c3.c3:focus::-webkit-input-placeholder {
+  opacity: 1;
+}
+
+.c3.c3.c3:focus::-moz-placeholder {
+  opacity: 1;
+}
+
+.c3.c3.c3:focus:-ms-input-placeholder {
+  opacity: 1;
+}
+
+.c3.c3.c3:focus::placeholder {
+  opacity: 1;
+}
+
+.c3:disabled {
+  color: #546A7F;
+}
+
+.c3:disabled ~ .c4,
+.c3:disabled ~ .sc-fznyAO {
+  cursor: not-allowed;
+}
+
+.c3::-webkit-input-placeholder {
+  opacity: 0;
+  -webkit-transition: all 100ms ease-out;
+  transition: all 100ms ease-out;
+}
+
+.c3::-moz-placeholder {
+  opacity: 0;
+  -webkit-transition: all 100ms ease-out;
+  transition: all 100ms ease-out;
+}
+
+.c3:-ms-input-placeholder {
+  opacity: 0;
+  -webkit-transition: all 100ms ease-out;
+  transition: all 100ms ease-out;
+}
+
+.c3::placeholder {
+  opacity: 0;
+  -webkit-transition: all 100ms ease-out;
+  transition: all 100ms ease-out;
+}
+
+.c3:not(:placeholder-shown) ~ .c4,
+.c3:focus ~ .c4 {
+  background-color: white;
+  padding: 0 0.5rem;
+  -webkit-transform: translateX(-0.4rem) translateY(-140%) scale(0.67);
+  -ms-transform: translateX(-0.4rem) translateY(-140%) scale(0.67);
+  transform: translateX(-0.4rem) translateY(-140%) scale(0.67);
+}
+
+.c3:not(:placeholder-shown) ~ .sc-AxheI,
+.c3:focus ~ .sc-AxheI {
+  background-color: white;
+  padding: 0 0.5rem;
+  -webkit-transform: translateY(-167%);
+  -ms-transform: translateY(-167%);
+  transform: translateY(-167%);
+}
+
+.c3:focus ~ .c4 {
+  font-weight: 600;
+}
+
+.c3:not(:placeholder-shown) ~ .sc-fznyAO {
+  opacity: 1;
+}
+
+<div>
+  <div
+    class="c0"
+    id="medly-textField-input-wrapper"
+  >
+    <div
+      class="c1"
+      disabled=""
+    >
+      <div
+        class="c2"
+      >
+        <input
+          aria-describedby="medly-textField-helper-text"
+          class="c3"
+          disabled=""
+          id="medly-textField-input"
+          placeholder=" "
+          type="text"
+          value=""
+        />
+        <label
+          class="c4 c5"
+          for="medly-textField-input"
+        >
+          Name
+        </label>
+      </div>
+      <svg
+        class="c6 c7 c8"
+        fill="none"
+        height="1em"
+        viewBox="0 0 24 24"
+        width="1em"
+        xmlns="http://www.w3.org/2000/svg"
+      >
+        <path
+          d="M8.795 15.875l-3.47-3.47a.996.996 0 0 0-1.41 0 .996.996 0 0 0 0 1.41l4.18 4.18c.39.39 1.02.39 1.41 0l10.58-10.58a.996.996 0 1 0-1.41-1.41l-9.88 9.87z"
+          fill="green"
+        />
+      </svg>
+    </div>
+    
+  </div>
+</div>
+`;
+
 exports[`TextField with fusion variant should render properly with custom disabled cursor (themed) 1`] = `
 .c6 {
   overflow: visible;
@@ -10264,7 +11078,6 @@ exports[`TextField with fusion variant should render properly with custom disabl
   -webkit-transition: all 100ms ease-out;
   transition: all 100ms ease-out;
   cursor: text;
-  border-radius: 1rem;
   background-color: #F7F8F9;
   cursor: text;
   background-color: #ffffff;
@@ -10302,7 +11115,6 @@ exports[`TextField with fusion variant should render properly with custom disabl
   background-color: transparent;
   -webkit-transition: all 100ms ease-out;
   transition: all 100ms ease-out;
-  border-radius: 1rem;
   border: 0.1rem solid #b0bcc8;
 }
 
@@ -10429,6 +11241,10 @@ exports[`TextField with fusion variant should render properly with custom disabl
 
 .c3.c3.c3:focus::placeholder {
   opacity: 1;
+}
+
+.c3:disabled {
+  color: #546A7F;
 }
 
 .c3:disabled ~ .c4,
@@ -10595,7 +11411,6 @@ exports[`TextField with fusion variant should render properly with multiline 1`]
   -webkit-transition: all 100ms ease-out;
   transition: all 100ms ease-out;
   cursor: text;
-  border-radius: 1rem;
   background-color: #F7F8F9;
 }
 
@@ -10631,14 +11446,15 @@ exports[`TextField with fusion variant should render properly with multiline 1`]
   background-color: transparent;
   -webkit-transition: all 100ms ease-out;
   transition: all 100ms ease-out;
-  border-radius: 1rem;
   border: 0.1rem solid #b0bcc8;
 }
 
-.c1:hover::after,
-.c1:focus-within::after {
-  border-width: 0.15rem;
+.c1:hover::after {
   border-color: #607890;
+}
+
+.c1:focus-within::after {
+  border-color: #126AFA;
 }
 
 .c1 input {
@@ -10653,6 +11469,7 @@ exports[`TextField with fusion variant should render properly with multiline 1`]
 .c1:focus-within::after,
 .c1:focus-within:hover::after {
   border-color: #126AFA;
+  border-radius: undefined;
 }
 
 .c1:focus-within .c4,
@@ -10779,6 +11596,10 @@ exports[`TextField with fusion variant should render properly with multiline 1`]
 
 .c3.c3.c3:focus::placeholder {
   opacity: 1;
+}
+
+.c3:disabled {
+  color: #546A7F;
 }
 
 .c3:disabled ~ .c4,
@@ -10949,7 +11770,6 @@ exports[`TextField with fusion variant should render properly with prefix 1`] = 
   -webkit-transition: all 100ms ease-out;
   transition: all 100ms ease-out;
   cursor: text;
-  border-radius: 1rem;
   background-color: #F7F8F9;
 }
 
@@ -10985,14 +11805,15 @@ exports[`TextField with fusion variant should render properly with prefix 1`] = 
   background-color: transparent;
   -webkit-transition: all 100ms ease-out;
   transition: all 100ms ease-out;
-  border-radius: 1rem;
   border: 0.1rem solid #b0bcc8;
 }
 
-.c1:hover::after,
-.c1:focus-within::after {
-  border-width: 0.15rem;
+.c1:hover::after {
   border-color: #607890;
+}
+
+.c1:focus-within::after {
+  border-color: #126AFA;
 }
 
 .c1 input {
@@ -11007,6 +11828,7 @@ exports[`TextField with fusion variant should render properly with prefix 1`] = 
 .c1:focus-within::after,
 .c1:focus-within:hover::after {
   border-color: #126AFA;
+  border-radius: undefined;
 }
 
 .c1:focus-within .c7,
@@ -11136,6 +11958,10 @@ exports[`TextField with fusion variant should render properly with prefix 1`] = 
 
 .c6.c6.c6:focus::placeholder {
   opacity: 1;
+}
+
+.c6:disabled {
+  color: #546A7F;
 }
 
 .c6:disabled ~ .c7,
@@ -11320,7 +12146,6 @@ exports[`TextField with fusion variant should render properly with suffix 1`] = 
   -webkit-transition: all 100ms ease-out;
   transition: all 100ms ease-out;
   cursor: text;
-  border-radius: 1rem;
   background-color: #F7F8F9;
 }
 
@@ -11356,14 +12181,15 @@ exports[`TextField with fusion variant should render properly with suffix 1`] = 
   background-color: transparent;
   -webkit-transition: all 100ms ease-out;
   transition: all 100ms ease-out;
-  border-radius: 1rem;
   border: 0.1rem solid #b0bcc8;
 }
 
-.c1:hover::after,
-.c1:focus-within::after {
-  border-width: 0.15rem;
+.c1:hover::after {
   border-color: #607890;
+}
+
+.c1:focus-within::after {
+  border-color: #126AFA;
 }
 
 .c1 input {
@@ -11378,6 +12204,7 @@ exports[`TextField with fusion variant should render properly with suffix 1`] = 
 .c1:focus-within::after,
 .c1:focus-within:hover::after {
   border-color: #126AFA;
+  border-radius: undefined;
 }
 
 .c1:focus-within .c4,
@@ -11507,6 +12334,10 @@ exports[`TextField with fusion variant should render properly with suffix 1`] = 
 
 .c3.c3.c3:focus::placeholder {
   opacity: 1;
+}
+
+.c3:disabled {
+  color: #546A7F;
 }
 
 .c3:disabled ~ .c4,
@@ -11667,7 +12498,6 @@ exports[`TextField with outlined variant and with label should render default st
   -webkit-transition: all 100ms ease-out;
   transition: all 100ms ease-out;
   cursor: text;
-  border-radius: 0.4rem;
   background-color: #ffffff;
 }
 
@@ -11707,7 +12537,6 @@ exports[`TextField with outlined variant and with label should render default st
   background-color: transparent;
   -webkit-transition: all 100ms ease-out;
   transition: all 100ms ease-out;
-  border-radius: 0.4rem;
   border: 0.1rem solid #98A7B7;
 }
 
@@ -11719,10 +12548,12 @@ exports[`TextField with outlined variant and with label should render default st
   box-shadow: 0px 0.2rem 0.8rem rgba(18,106,250,0.2);
 }
 
-.c1:hover::after,
-.c1:focus-within::after {
-  border-width: 0.15rem;
+.c1:hover::after {
   border-color: #607890;
+}
+
+.c1:focus-within::after {
+  border-color: #126AFA;
 }
 
 .c1:focus-within,
@@ -11733,6 +12564,7 @@ exports[`TextField with outlined variant and with label should render default st
 .c1:focus-within::after,
 .c1:focus-within:hover::after {
   border-color: #126AFA;
+  border-radius: undefined;
 }
 
 .c1:focus-within .c4,
@@ -11862,6 +12694,10 @@ exports[`TextField with outlined variant and with label should render default st
 
 .c3.c3.c3:focus::placeholder {
   opacity: 1;
+}
+
+.c3:disabled {
+  color: #435465;
 }
 
 .c3:disabled ~ .c4,
@@ -11994,7 +12830,6 @@ exports[`TextField with outlined variant and with label should render disabled s
   -webkit-transition: all 100ms ease-out;
   transition: all 100ms ease-out;
   cursor: text;
-  border-radius: 0.4rem;
   background-color: #ffffff;
   cursor: not-allowed;
   background-color: #ffffff;
@@ -12036,7 +12871,6 @@ exports[`TextField with outlined variant and with label should render disabled s
   background-color: transparent;
   -webkit-transition: all 100ms ease-out;
   transition: all 100ms ease-out;
-  border-radius: 0.4rem;
   border: 0.1rem solid #98A7B7;
 }
 
@@ -12159,6 +12993,10 @@ exports[`TextField with outlined variant and with label should render disabled s
 
 .c3.c3.c3:focus::placeholder {
   opacity: 1;
+}
+
+.c3:disabled {
+  color: #435465;
 }
 
 .c3:disabled ~ .c4,
@@ -12293,7 +13131,6 @@ exports[`TextField with outlined variant and with label should render focus stat
   -webkit-transition: all 100ms ease-out;
   transition: all 100ms ease-out;
   cursor: text;
-  border-radius: 0.4rem;
   background-color: #ffffff;
 }
 
@@ -12333,7 +13170,6 @@ exports[`TextField with outlined variant and with label should render focus stat
   background-color: transparent;
   -webkit-transition: all 100ms ease-out;
   transition: all 100ms ease-out;
-  border-radius: 0.4rem;
   border: 0.1rem solid #98A7B7;
 }
 
@@ -12345,10 +13181,12 @@ exports[`TextField with outlined variant and with label should render focus stat
   box-shadow: 0px 0.2rem 0.8rem rgba(18,106,250,0.2);
 }
 
-.c1:hover::after,
-.c1:focus-within::after {
-  border-width: 0.15rem;
+.c1:hover::after {
   border-color: #607890;
+}
+
+.c1:focus-within::after {
+  border-color: #126AFA;
 }
 
 .c1:focus-within,
@@ -12359,6 +13197,7 @@ exports[`TextField with outlined variant and with label should render focus stat
 .c1:focus-within::after,
 .c1:focus-within:hover::after {
   border-color: #126AFA;
+  border-radius: undefined;
 }
 
 .c1:focus-within .c4,
@@ -12488,6 +13327,10 @@ exports[`TextField with outlined variant and with label should render focus stat
 
 .c3.c3.c3:focus::placeholder {
   opacity: 1;
+}
+
+.c3:disabled {
+  color: #435465;
 }
 
 .c3:disabled ~ .c4,
@@ -12620,7 +13463,6 @@ exports[`TextField with outlined variant and without label should render default
   -webkit-transition: all 100ms ease-out;
   transition: all 100ms ease-out;
   cursor: text;
-  border-radius: 0.4rem;
   background-color: #ffffff;
 }
 
@@ -12660,7 +13502,6 @@ exports[`TextField with outlined variant and without label should render default
   background-color: transparent;
   -webkit-transition: all 100ms ease-out;
   transition: all 100ms ease-out;
-  border-radius: 0.4rem;
   border: 0.1rem solid #98A7B7;
 }
 
@@ -12672,10 +13513,12 @@ exports[`TextField with outlined variant and without label should render default
   box-shadow: 0px 0.2rem 0.8rem rgba(18,106,250,0.2);
 }
 
-.c1:hover::after,
-.c1:focus-within::after {
-  border-width: 0.15rem;
+.c1:hover::after {
   border-color: #607890;
+}
+
+.c1:focus-within::after {
+  border-color: #126AFA;
 }
 
 .c1:focus-within,
@@ -12686,6 +13529,7 @@ exports[`TextField with outlined variant and without label should render default
 .c1:focus-within::after,
 .c1:focus-within:hover::after {
   border-color: #126AFA;
+  border-radius: undefined;
 }
 
 .c1:focus-within .c4,
@@ -12811,6 +13655,10 @@ exports[`TextField with outlined variant and without label should render default
 
 .c3.c3.c3:focus::placeholder {
   opacity: 1;
+}
+
+.c3:disabled {
+  color: #435465;
 }
 
 .c3:disabled ~ .c4,
@@ -12941,7 +13789,6 @@ exports[`TextField with outlined variant and without label should render disable
   -webkit-transition: all 100ms ease-out;
   transition: all 100ms ease-out;
   cursor: text;
-  border-radius: 0.4rem;
   background-color: #ffffff;
   cursor: not-allowed;
   background-color: #ffffff;
@@ -12983,7 +13830,6 @@ exports[`TextField with outlined variant and without label should render disable
   background-color: transparent;
   -webkit-transition: all 100ms ease-out;
   transition: all 100ms ease-out;
-  border-radius: 0.4rem;
   border: 0.1rem solid #98A7B7;
 }
 
@@ -13102,6 +13948,10 @@ exports[`TextField with outlined variant and without label should render disable
 
 .c3.c3.c3:focus::placeholder {
   opacity: 1;
+}
+
+.c3:disabled {
+  color: #435465;
 }
 
 .c3:disabled ~ .c4,
@@ -13234,7 +14084,6 @@ exports[`TextField with outlined variant and without label should render focus s
   -webkit-transition: all 100ms ease-out;
   transition: all 100ms ease-out;
   cursor: text;
-  border-radius: 0.4rem;
   background-color: #ffffff;
 }
 
@@ -13274,7 +14123,6 @@ exports[`TextField with outlined variant and without label should render focus s
   background-color: transparent;
   -webkit-transition: all 100ms ease-out;
   transition: all 100ms ease-out;
-  border-radius: 0.4rem;
   border: 0.1rem solid #98A7B7;
 }
 
@@ -13286,10 +14134,12 @@ exports[`TextField with outlined variant and without label should render focus s
   box-shadow: 0px 0.2rem 0.8rem rgba(18,106,250,0.2);
 }
 
-.c1:hover::after,
-.c1:focus-within::after {
-  border-width: 0.15rem;
+.c1:hover::after {
   border-color: #607890;
+}
+
+.c1:focus-within::after {
+  border-color: #126AFA;
 }
 
 .c1:focus-within,
@@ -13300,6 +14150,7 @@ exports[`TextField with outlined variant and without label should render focus s
 .c1:focus-within::after,
 .c1:focus-within:hover::after {
   border-color: #126AFA;
+  border-radius: undefined;
 }
 
 .c1:focus-within .c4,
@@ -13425,6 +14276,10 @@ exports[`TextField with outlined variant and without label should render focus s
 
 .c3.c3.c3:focus::placeholder {
   opacity: 1;
+}
+
+.c3:disabled {
+  color: #435465;
 }
 
 .c3:disabled ~ .c4,
@@ -13566,7 +14421,6 @@ exports[`TextField with outlined variant should render error state properly  1`]
   -webkit-transition: all 100ms ease-out;
   transition: all 100ms ease-out;
   cursor: text;
-  border-radius: 0.4rem;
   background-color: #ffffff;
 }
 
@@ -13606,7 +14460,6 @@ exports[`TextField with outlined variant should render error state properly  1`]
   background-color: transparent;
   -webkit-transition: all 100ms ease-out;
   transition: all 100ms ease-out;
-  border-radius: 0.4rem;
   border: 0.1rem solid #98A7B7;
 }
 
@@ -13618,10 +14471,12 @@ exports[`TextField with outlined variant should render error state properly  1`]
   box-shadow: 0px 0.2rem 0.8rem rgba(204,0,0,0.2);
 }
 
-.c1:hover::after,
-.c1:focus-within::after {
-  border-width: 0.15rem;
+.c1:hover::after {
   border-color: #607890;
+}
+
+.c1:focus-within::after {
+  border-color: #126AFA;
 }
 
 .c1,
@@ -13793,6 +14648,10 @@ exports[`TextField with outlined variant should render error state properly  1`]
 
 .c3.c3.c3:focus::placeholder {
   opacity: 1;
+}
+
+.c3:disabled {
+  color: #435465;
 }
 
 .c3:disabled ~ .c4,
@@ -13941,7 +14800,6 @@ exports[`TextField with outlined variant should render error state properly with
   -webkit-transition: all 100ms ease-out;
   transition: all 100ms ease-out;
   cursor: text;
-  border-radius: 0.4rem;
   background-color: #ffffff;
 }
 
@@ -13981,7 +14839,6 @@ exports[`TextField with outlined variant should render error state properly with
   background-color: transparent;
   -webkit-transition: all 100ms ease-out;
   transition: all 100ms ease-out;
-  border-radius: 0.4rem;
   border: 0.1rem solid #98A7B7;
 }
 
@@ -13993,10 +14850,12 @@ exports[`TextField with outlined variant should render error state properly with
   box-shadow: 0px 0.2rem 0.8rem rgba(204,0,0,0.2);
 }
 
-.c1:hover::after,
-.c1:focus-within::after {
-  border-width: 0.15rem;
+.c1:hover::after {
   border-color: #607890;
+}
+
+.c1:focus-within::after {
+  border-color: #126AFA;
 }
 
 .c1,
@@ -14170,6 +15029,10 @@ exports[`TextField with outlined variant should render error state properly with
   opacity: 1;
 }
 
+.c3:disabled {
+  color: #435465;
+}
+
 .c3:disabled ~ .c4,
 .c3:disabled ~ .sc-fznyAO {
   cursor: not-allowed;
@@ -14302,6 +15165,347 @@ exports[`TextField with outlined variant should render helper text properly 1`] 
 </span>
 `;
 
+exports[`TextField with outlined variant should render properly with custom border styles (themed) 1`] = `
+.c6 {
+  overflow: visible;
+  font-size: 2.4rem;
+  -webkit-transition: all 100ms linear;
+  transition: all 100ms linear;
+  cursor: inherit;
+}
+
+.c6 * {
+  fill-opacity: 1;
+  -webkit-transition: all 100ms linear;
+  transition: all 100ms linear;
+  fill: #607890;
+}
+
+.c5 {
+  top: 50%;
+  left: 0;
+  cursor: text;
+  -webkit-user-select: none;
+  -moz-user-select: none;
+  -ms-user-select: none;
+  user-select: none;
+  position: absolute;
+  pointer-events: none;
+  -webkit-transition: all 150ms cubic-bezier(0.4,0,0.2,1);
+  transition: all 150ms cubic-bezier(0.4,0,0.2,1);
+  font-size: 1.6rem;
+  font-weight: 400;
+  -webkit-letter-spacing: 0rem;
+  -moz-letter-spacing: 0rem;
+  -ms-letter-spacing: 0rem;
+  letter-spacing: 0rem;
+  line-height: 2.6rem;
+  font-family: Open Sans,Helvetica Neue,Helvetica,Arial,sans-serif;
+  -webkit-transform-origin: 0 0;
+  -ms-transform-origin: 0 0;
+  transform-origin: 0 0;
+  touch-action: manipulation;
+  -webkit-transform: translateY(-50%);
+  -ms-transform: translateY(-50%);
+  transform: translateY(-50%);
+  opacity: 1;
+  z-index: 1;
+  width: 100%;
+  max-width: -webkit-min-content;
+  max-width: -moz-min-content;
+  max-width: min-content;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
+.c8 {
+  pointer-events: none;
+  margin-left: 1.6rem;
+}
+
+.c1 {
+  position: relative;
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  -webkit-flex-direction: row;
+  -ms-flex-direction: row;
+  flex-direction: row;
+  box-sizing: border-box;
+  height: 5.6rem;
+  padding: 0 1.6rem;
+  -webkit-transition: all 100ms ease-out;
+  transition: all 100ms ease-out;
+  cursor: text;
+  border-radius: 0.25rem;
+  background-color: #ffffff;
+  cursor: not-allowed;
+  background-color: #ffffff;
+}
+
+.c1 .c4 {
+  color: #607890;
+}
+
+.c1 .sc-fzozJi,
+.c1 .c7 {
+  color: #607890;
+}
+
+.c1 .sc-fzozJi *,
+.c1 .c7 * {
+  fill: #607890;
+}
+
+.c1 ~ .sc-Axmtr {
+  color: #546A7F;
+}
+
+.c1 input {
+  box-shadow: 0 0 0 100000px #ffffff inset;
+}
+
+.c1::after {
+  content: '';
+  box-sizing: border-box;
+  width: 100%;
+  height: 100%;
+  position: absolute;
+  top: 0;
+  right: 0;
+  bottom: 0;
+  left: 0;
+  pointer-events: none;
+  background-color: transparent;
+  -webkit-transition: all 100ms ease-out;
+  transition: all 100ms ease-out;
+  border-radius: 0.25rem;
+  border-width: 0.25rem;
+  border: 0.1rem solid #98A7B7;
+}
+
+.c1:focus-within {
+  border-radius: 0.25rem;
+}
+
+.c1::after,
+.c1:hover::after {
+  border-width: 0.1rem;
+  border-color: #C7D0D8;
+}
+
+.c1 input {
+  box-shadow: 0 0 0 100000px #ffffff inset;
+}
+
+.c1 .c4 {
+  color: #b0bcc8;
+}
+
+.c1 .sc-AxheI {
+  color: #b0bcc8;
+}
+
+.c1 .sc-fzozJi,
+.c1 .c7 {
+  color: #b0bcc8;
+}
+
+.c1 .sc-fzozJi *,
+.c1 .c7 * {
+  fill: #b0bcc8;
+}
+
+.c1 ~ .sc-Axmtr {
+  color: #b0bcc8;
+}
+
+.c1 * {
+  cursor: not-allowed;
+}
+
+.c2 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  position: relative;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  background-color: transparent;
+  -webkit-flex: 1;
+  -ms-flex: 1;
+  flex: 1;
+  height: 100%;
+}
+
+.c0 {
+  position: relative;
+  -webkit-flex-direction: column;
+  -ms-flex-direction: column;
+  flex-direction: column;
+  display: -webkit-inline-box;
+  display: -webkit-inline-flex;
+  display: -ms-inline-flexbox;
+  display: inline-flex;
+  width: -webkit-min-content;
+  width: -moz-min-content;
+  width: min-content;
+  min-width: 20rem;
+  margin: 0.8rem 0.8rem 0.8rem 0;
+}
+
+.c3 {
+  color: #13181D;
+  width: 100%;
+  margin: 0;
+  padding: 0;
+  box-sizing: border-box;
+  -webkit-transition: all 100ms ease-out;
+  transition: all 100ms ease-out;
+  background-color: transparent;
+  border: none;
+  text-overflow: ellipsis;
+  resize: none;
+  z-index: 1;
+  -webkit-align-self: flex-end;
+  -ms-flex-item-align: end;
+  align-self: flex-end;
+  margin-bottom: 0.6rem;
+}
+
+.c3,
+.c3 ~ .sc-fznyAO {
+  font-size: 1.6rem;
+  font-weight: 400;
+  -webkit-letter-spacing: 0rem;
+  -moz-letter-spacing: 0rem;
+  -ms-letter-spacing: 0rem;
+  letter-spacing: 0rem;
+  line-height: 2.6rem;
+  font-family: Open Sans,Helvetica Neue,Helvetica,Arial,sans-serif;
+}
+
+.c3.c3.c3:focus {
+  outline: none;
+  box-shadow: unset;
+}
+
+.c3.c3.c3:focus::-webkit-input-placeholder {
+  opacity: 1;
+}
+
+.c3.c3.c3:focus::-moz-placeholder {
+  opacity: 1;
+}
+
+.c3.c3.c3:focus:-ms-input-placeholder {
+  opacity: 1;
+}
+
+.c3.c3.c3:focus::placeholder {
+  opacity: 1;
+}
+
+.c3:disabled {
+  color: #435465;
+}
+
+.c3:disabled ~ .c4,
+.c3:disabled ~ .sc-fznyAO {
+  cursor: not-allowed;
+}
+
+.c3::-webkit-input-placeholder {
+  opacity: 0;
+  -webkit-transition: all 100ms ease-out;
+  transition: all 100ms ease-out;
+}
+
+.c3::-moz-placeholder {
+  opacity: 0;
+  -webkit-transition: all 100ms ease-out;
+  transition: all 100ms ease-out;
+}
+
+.c3:-ms-input-placeholder {
+  opacity: 0;
+  -webkit-transition: all 100ms ease-out;
+  transition: all 100ms ease-out;
+}
+
+.c3::placeholder {
+  opacity: 0;
+  -webkit-transition: all 100ms ease-out;
+  transition: all 100ms ease-out;
+}
+
+.c3:not(:placeholder-shown) ~ .c4,
+.c3:focus ~ .c4 {
+  -webkit-transform: translateY(-87%) scale(0.75);
+  -ms-transform: translateY(-87%) scale(0.75);
+  transform: translateY(-87%) scale(0.75);
+}
+
+.c3:not(:placeholder-shown) ~ .sc-fznyAO {
+  opacity: 1;
+}
+
+<div>
+  <div
+    class="c0"
+    id="medly-textField-input-wrapper"
+  >
+    <div
+      class="c1"
+      disabled=""
+    >
+      <div
+        class="c2"
+      >
+        <input
+          aria-describedby="medly-textField-helper-text"
+          class="c3"
+          disabled=""
+          id="medly-textField-input"
+          placeholder=" "
+          type="text"
+          value=""
+        />
+        <label
+          class="c4 c5"
+          for="medly-textField-input"
+        >
+          Name
+        </label>
+      </div>
+      <svg
+        class="c6 c7 c8"
+        fill="none"
+        height="1em"
+        viewBox="0 0 24 24"
+        width="1em"
+        xmlns="http://www.w3.org/2000/svg"
+      >
+        <path
+          d="M8.795 15.875l-3.47-3.47a.996.996 0 0 0-1.41 0 .996.996 0 0 0 0 1.41l4.18 4.18c.39.39 1.02.39 1.41 0l10.58-10.58a.996.996 0 1 0-1.41-1.41l-9.88 9.87z"
+          fill="green"
+        />
+      </svg>
+    </div>
+    
+  </div>
+</div>
+`;
+
 exports[`TextField with outlined variant should render properly with custom disabled cursor (themed) 1`] = `
 .c6 {
   overflow: visible;
@@ -14380,7 +15584,6 @@ exports[`TextField with outlined variant should render properly with custom disa
   -webkit-transition: all 100ms ease-out;
   transition: all 100ms ease-out;
   cursor: text;
-  border-radius: 0.4rem;
   background-color: #ffffff;
   cursor: text;
   background-color: #ffffff;
@@ -14422,7 +15625,6 @@ exports[`TextField with outlined variant should render properly with custom disa
   background-color: transparent;
   -webkit-transition: all 100ms ease-out;
   transition: all 100ms ease-out;
-  border-radius: 0.4rem;
   border: 0.1rem solid #98A7B7;
 }
 
@@ -14545,6 +15747,10 @@ exports[`TextField with outlined variant should render properly with custom disa
 
 .c3.c3.c3:focus::placeholder {
   opacity: 1;
+}
+
+.c3:disabled {
+  color: #435465;
 }
 
 .c3:disabled ~ .c4,
@@ -14692,7 +15898,6 @@ exports[`TextField with outlined variant should render properly with multiline 1
   -webkit-transition: all 100ms ease-out;
   transition: all 100ms ease-out;
   cursor: text;
-  border-radius: 0.4rem;
   background-color: #ffffff;
 }
 
@@ -14732,7 +15937,6 @@ exports[`TextField with outlined variant should render properly with multiline 1
   background-color: transparent;
   -webkit-transition: all 100ms ease-out;
   transition: all 100ms ease-out;
-  border-radius: 0.4rem;
   border: 0.1rem solid #98A7B7;
 }
 
@@ -14744,10 +15948,12 @@ exports[`TextField with outlined variant should render properly with multiline 1
   box-shadow: 0px 0.2rem 0.8rem rgba(18,106,250,0.2);
 }
 
-.c1:hover::after,
-.c1:focus-within::after {
-  border-width: 0.15rem;
+.c1:hover::after {
   border-color: #607890;
+}
+
+.c1:focus-within::after {
+  border-color: #126AFA;
 }
 
 .c1:focus-within,
@@ -14758,6 +15964,7 @@ exports[`TextField with outlined variant should render properly with multiline 1
 .c1:focus-within::after,
 .c1:focus-within:hover::after {
   border-color: #126AFA;
+  border-radius: undefined;
 }
 
 .c1:focus-within .c4,
@@ -14884,6 +16091,10 @@ exports[`TextField with outlined variant should render properly with multiline 1
 
 .c3.c3.c3:focus::placeholder {
   opacity: 1;
+}
+
+.c3:disabled {
+  color: #435465;
 }
 
 .c3:disabled ~ .c4,
@@ -15035,7 +16246,6 @@ exports[`TextField with outlined variant should render properly with prefix 1`] 
   -webkit-transition: all 100ms ease-out;
   transition: all 100ms ease-out;
   cursor: text;
-  border-radius: 0.4rem;
   background-color: #ffffff;
 }
 
@@ -15075,7 +16285,6 @@ exports[`TextField with outlined variant should render properly with prefix 1`] 
   background-color: transparent;
   -webkit-transition: all 100ms ease-out;
   transition: all 100ms ease-out;
-  border-radius: 0.4rem;
   border: 0.1rem solid #98A7B7;
 }
 
@@ -15087,10 +16296,12 @@ exports[`TextField with outlined variant should render properly with prefix 1`] 
   box-shadow: 0px 0.2rem 0.8rem rgba(18,106,250,0.2);
 }
 
-.c1:hover::after,
-.c1:focus-within::after {
-  border-width: 0.15rem;
+.c1:hover::after {
   border-color: #607890;
+}
+
+.c1:focus-within::after {
+  border-color: #126AFA;
 }
 
 .c1:focus-within,
@@ -15101,6 +16312,7 @@ exports[`TextField with outlined variant should render properly with prefix 1`] 
 .c1:focus-within::after,
 .c1:focus-within:hover::after {
   border-color: #126AFA;
+  border-radius: undefined;
 }
 
 .c1:focus-within .c7,
@@ -15230,6 +16442,10 @@ exports[`TextField with outlined variant should render properly with prefix 1`] 
 
 .c6.c6.c6:focus::placeholder {
   opacity: 1;
+}
+
+.c6:disabled {
+  color: #435465;
 }
 
 .c6:disabled ~ .c7,
@@ -15395,7 +16611,6 @@ exports[`TextField with outlined variant should render properly with suffix 1`] 
   -webkit-transition: all 100ms ease-out;
   transition: all 100ms ease-out;
   cursor: text;
-  border-radius: 0.4rem;
   background-color: #ffffff;
 }
 
@@ -15435,7 +16650,6 @@ exports[`TextField with outlined variant should render properly with suffix 1`] 
   background-color: transparent;
   -webkit-transition: all 100ms ease-out;
   transition: all 100ms ease-out;
-  border-radius: 0.4rem;
   border: 0.1rem solid #98A7B7;
 }
 
@@ -15447,10 +16661,12 @@ exports[`TextField with outlined variant should render properly with suffix 1`] 
   box-shadow: 0px 0.2rem 0.8rem rgba(18,106,250,0.2);
 }
 
-.c1:hover::after,
-.c1:focus-within::after {
-  border-width: 0.15rem;
+.c1:hover::after {
   border-color: #607890;
+}
+
+.c1:focus-within::after {
+  border-color: #126AFA;
 }
 
 .c1:focus-within,
@@ -15461,6 +16677,7 @@ exports[`TextField with outlined variant should render properly with suffix 1`] 
 .c1:focus-within::after,
 .c1:focus-within:hover::after {
   border-color: #126AFA;
+  border-radius: undefined;
 }
 
 .c1:focus-within .c4,
@@ -15590,6 +16807,10 @@ exports[`TextField with outlined variant should render properly with suffix 1`] 
 
 .c3.c3.c3:focus::placeholder {
   opacity: 1;
+}
+
+.c3:disabled {
+  color: #435465;
 }
 
 .c3:disabled ~ .c4,
@@ -15914,6 +17135,10 @@ exports[`TextField without label should render default state properly 1`] = `
   opacity: 1;
 }
 
+.c3:disabled {
+  color: #435465;
+}
+
 .c3:disabled ~ .c4,
 .c3:disabled ~ .sc-fznyAO {
   cursor: not-allowed;
@@ -16223,6 +17448,10 @@ exports[`TextField without label should render focus state properly  1`] = `
 
 .c3.c3.c3:focus::placeholder {
   opacity: 1;
+}
+
+.c3:disabled {
+  color: #435465;
 }
 
 .c3:disabled ~ .c4,

--- a/packages/core/src/components/TextField/__snapshots__/TextField.test.tsx.snap
+++ b/packages/core/src/components/TextField/__snapshots__/TextField.test.tsx.snap
@@ -127,6 +127,7 @@ exports[`TextField character count should correctly render character count for S
 .c1:focus-within::after,
 .c1:focus-within:hover::after {
   border-color: #126AFA;
+  border-radius: 0;
 }
 
 .c1:focus-within .c4,
@@ -474,7 +475,6 @@ exports[`TextField character count should correctly render character count for f
 .c1:focus-within::after,
 .c1:focus-within:hover::after {
   border-color: #126AFA;
-  border-radius: undefined;
 }
 
 .c1:focus-within .c4,
@@ -824,6 +824,7 @@ exports[`TextField character count should correctly render character count for m
 .c1:focus-within::after,
 .c1:focus-within:hover::after {
   border-color: #126AFA;
+  border-radius: 0;
 }
 
 .c1:focus-within .c4,
@@ -1158,6 +1159,7 @@ exports[`TextField character count should correctly render character count if we
 .c1:focus-within::after,
 .c1:focus-within:hover::after {
   border-color: #126AFA;
+  border-radius: 0;
 }
 
 .c1:focus-within .c4,
@@ -1492,6 +1494,7 @@ exports[`TextField character count should correctly render character count when 
 .c1:focus-within::after,
 .c1:focus-within:hover::after {
   border-color: #126AFA;
+  border-radius: 0;
 }
 
 .c1:focus-within .c4,
@@ -1828,6 +1831,7 @@ exports[`TextField character count should correctly render character count when 
 .c1:focus-within::after,
 .c1:focus-within:hover::after {
   border-color: #126AFA;
+  border-radius: 0;
 }
 
 .c1:focus-within .c4,
@@ -2150,6 +2154,7 @@ exports[`TextField should not call onClick function on click on helper text 1`] 
 .c1:focus-within::after,
 .c1:focus-within:hover::after {
   border-color: #126AFA;
+  border-radius: 0;
 }
 
 .c1:focus-within .c4,
@@ -2580,6 +2585,7 @@ exports[`TextField should render properly with M size 1`] = `
 .c1:focus-within::after,
 .c1:focus-within:hover::after {
   border-color: #126AFA;
+  border-radius: 0;
 }
 
 .c1:focus-within .c7,
@@ -2964,6 +2970,7 @@ exports[`TextField should render properly with S size 1`] = `
 .c1:focus-within::after,
 .c1:focus-within:hover::after {
   border-color: #126AFA;
+  border-radius: 0;
 }
 
 .c1:focus-within .c7,
@@ -3311,6 +3318,7 @@ exports[`TextField should render properly with default props 1`] = `
 .c1:focus-within::after,
 .c1:focus-within:hover::after {
   border-color: #126AFA;
+  border-radius: 0;
 }
 
 .c1:focus-within .c4,
@@ -3628,6 +3636,7 @@ exports[`TextField with filled variant and with label should render default stat
 .c1:focus-within::after,
 .c1:focus-within:hover::after {
   border-color: #126AFA;
+  border-radius: 0;
 }
 
 .c1:focus-within .c4,
@@ -4243,6 +4252,7 @@ exports[`TextField with filled variant and with label should render focus state 
 .c1:focus-within::after,
 .c1:focus-within:hover::after {
   border-color: #126AFA;
+  border-radius: 0;
 }
 
 .c1:focus-within .c4,
@@ -4560,6 +4570,7 @@ exports[`TextField with filled variant and without label should render default s
 .c1:focus-within::after,
 .c1:focus-within:hover::after {
   border-color: #126AFA;
+  border-radius: 0;
 }
 
 .c1:focus-within .c4,
@@ -5163,6 +5174,7 @@ exports[`TextField with filled variant and without label should render focus sta
 .c1:focus-within::after,
 .c1:focus-within:hover::after {
   border-color: #126AFA;
+  border-radius: 0;
 }
 
 .c1:focus-within .c4,
@@ -6921,6 +6933,7 @@ exports[`TextField with filled variant should render properly with multiline 1`]
 .c1:focus-within::after,
 .c1:focus-within:hover::after {
   border-color: #126AFA;
+  border-radius: 0;
 }
 
 .c1:focus-within .c4,
@@ -7254,6 +7267,7 @@ exports[`TextField with filled variant should render properly with prefix 1`] = 
 .c1:focus-within::after,
 .c1:focus-within:hover::after {
   border-color: #126AFA;
+  border-radius: 0;
 }
 
 .c1:focus-within .c7,
@@ -7604,6 +7618,7 @@ exports[`TextField with filled variant should render properly with suffix 1`] = 
 .c1:focus-within::after,
 .c1:focus-within:hover::after {
   border-color: #126AFA;
+  border-radius: 0;
 }
 
 .c1:focus-within .c4,
@@ -7944,7 +7959,6 @@ exports[`TextField with fusion variant and with label should render default stat
 .c1:focus-within::after,
 .c1:focus-within:hover::after {
   border-color: #126AFA;
-  border-radius: undefined;
 }
 
 .c1:focus-within .c4,
@@ -8611,7 +8625,6 @@ exports[`TextField with fusion variant and with label should render focus state 
 .c1:focus-within::after,
 .c1:focus-within:hover::after {
   border-color: #126AFA;
-  border-radius: undefined;
 }
 
 .c1:focus-within .c4,
@@ -8954,7 +8967,6 @@ exports[`TextField with fusion variant and without label should render default s
 .c1:focus-within::after,
 .c1:focus-within:hover::after {
   border-color: #126AFA;
-  border-radius: undefined;
 }
 
 .c1:focus-within .c4,
@@ -9609,7 +9621,6 @@ exports[`TextField with fusion variant and without label should render focus sta
 .c1:focus-within::after,
 .c1:focus-within:hover::after {
   border-color: #126AFA;
-  border-radius: undefined;
 }
 
 .c1:focus-within .c4,
@@ -11487,7 +11498,6 @@ exports[`TextField with fusion variant should render properly with multiline 1`]
 .c1:focus-within::after,
 .c1:focus-within:hover::after {
   border-color: #126AFA;
-  border-radius: undefined;
 }
 
 .c1:focus-within .c4,
@@ -11846,7 +11856,6 @@ exports[`TextField with fusion variant should render properly with prefix 1`] = 
 .c1:focus-within::after,
 .c1:focus-within:hover::after {
   border-color: #126AFA;
-  border-radius: undefined;
 }
 
 .c1:focus-within .c7,
@@ -12222,7 +12231,6 @@ exports[`TextField with fusion variant should render properly with suffix 1`] = 
 .c1:focus-within::after,
 .c1:focus-within:hover::after {
   border-color: #126AFA;
-  border-radius: undefined;
 }
 
 .c1:focus-within .c4,
@@ -12582,7 +12590,6 @@ exports[`TextField with outlined variant and with label should render default st
 .c1:focus-within::after,
 .c1:focus-within:hover::after {
   border-color: #126AFA;
-  border-radius: undefined;
 }
 
 .c1:focus-within .c4,
@@ -13223,7 +13230,6 @@ exports[`TextField with outlined variant and with label should render focus stat
 .c1:focus-within::after,
 .c1:focus-within:hover::after {
   border-color: #126AFA;
-  border-radius: undefined;
 }
 
 .c1:focus-within .c4,
@@ -13555,7 +13561,6 @@ exports[`TextField with outlined variant and without label should render default
 .c1:focus-within::after,
 .c1:focus-within:hover::after {
   border-color: #126AFA;
-  border-radius: undefined;
 }
 
 .c1:focus-within .c4,
@@ -14184,7 +14189,6 @@ exports[`TextField with outlined variant and without label should render focus s
 .c1:focus-within::after,
 .c1:focus-within:hover::after {
   border-color: #126AFA;
-  border-radius: undefined;
 }
 
 .c1:focus-within .c4,
@@ -16013,7 +16017,6 @@ exports[`TextField with outlined variant should render properly with multiline 1
 .c1:focus-within::after,
 .c1:focus-within:hover::after {
   border-color: #126AFA;
-  border-radius: undefined;
 }
 
 .c1:focus-within .c4,
@@ -16361,7 +16364,6 @@ exports[`TextField with outlined variant should render properly with prefix 1`] 
 .c1:focus-within::after,
 .c1:focus-within:hover::after {
   border-color: #126AFA;
-  border-radius: undefined;
 }
 
 .c1:focus-within .c7,
@@ -16726,7 +16728,6 @@ exports[`TextField with outlined variant should render properly with suffix 1`] 
 .c1:focus-within::after,
 .c1:focus-within:hover::after {
   border-color: #126AFA;
-  border-radius: undefined;
 }
 
 .c1:focus-within .c4,
@@ -17057,6 +17058,7 @@ exports[`TextField without label should render default state properly 1`] = `
 .c1:focus-within::after,
 .c1:focus-within:hover::after {
   border-color: #126AFA;
+  border-radius: 0;
 }
 
 .c1:focus-within .c4,
@@ -17368,6 +17370,7 @@ exports[`TextField without label should render focus state properly  1`] = `
 .c1:focus-within::after,
 .c1:focus-within:hover::after {
   border-color: #126AFA;
+  border-radius: 0;
 }
 
 .c1:focus-within .c4,

--- a/packages/core/src/components/TextField/__snapshots__/TextField.test.tsx.snap
+++ b/packages/core/src/components/TextField/__snapshots__/TextField.test.tsx.snap
@@ -8269,6 +8269,10 @@ exports[`TextField with fusion variant and with label should render disabled sta
   border: 0.1rem solid #b0bcc8;
 }
 
+.c1:focus-within::after {
+  border-color: #126AFA;
+}
+
 .c1 input {
   box-shadow: 0 0 0 100000px #F7F8F9 inset;
 }
@@ -9267,6 +9271,10 @@ exports[`TextField with fusion variant and without label should render disabled 
   -webkit-transition: all 100ms ease-out;
   transition: all 100ms ease-out;
   border: 0.1rem solid #b0bcc8;
+}
+
+.c1:focus-within::after {
+  border-color: #126AFA;
 }
 
 .c1 input {
@@ -10760,6 +10768,12 @@ exports[`TextField with fusion variant should render properly with custom border
   border: 0.1rem solid #b0bcc8;
 }
 
+.c1:focus-within::after {
+  border-color: #126AFA;
+  border-radius: 0.25rem;
+  border-width: 0.2rem;
+}
+
 .c1:focus-within {
   border-radius: 0.25rem;
   border-width: 0.2rem;
@@ -11116,6 +11130,10 @@ exports[`TextField with fusion variant should render properly with custom disabl
   -webkit-transition: all 100ms ease-out;
   transition: all 100ms ease-out;
   border: 0.1rem solid #b0bcc8;
+}
+
+.c1:focus-within::after {
+  border-color: #126AFA;
 }
 
 .c1 input {
@@ -12545,7 +12563,7 @@ exports[`TextField with outlined variant and with label should render default st
 }
 
 .c1:focus-within {
-  box-shadow: 0px 0.2rem 0.8rem rgba(18,106,250,0.2);
+  box-shadow: 0 0.2rem 0.8rem rgba(18,106,250,0.2);
 }
 
 .c1:hover::after {
@@ -12874,6 +12892,14 @@ exports[`TextField with outlined variant and with label should render disabled s
   border: 0.1rem solid #98A7B7;
 }
 
+.c1:focus-within {
+  box-shadow: 0 0.2rem 0.8rem rgba(18,106,250,0.2);
+}
+
+.c1:focus-within::after {
+  border-color: #126AFA;
+}
+
 .c1::after,
 .c1:hover::after {
   border-width: 0.1rem;
@@ -13178,7 +13204,7 @@ exports[`TextField with outlined variant and with label should render focus stat
 }
 
 .c1:focus-within {
-  box-shadow: 0px 0.2rem 0.8rem rgba(18,106,250,0.2);
+  box-shadow: 0 0.2rem 0.8rem rgba(18,106,250,0.2);
 }
 
 .c1:hover::after {
@@ -13510,7 +13536,7 @@ exports[`TextField with outlined variant and without label should render default
 }
 
 .c1:focus-within {
-  box-shadow: 0px 0.2rem 0.8rem rgba(18,106,250,0.2);
+  box-shadow: 0 0.2rem 0.8rem rgba(18,106,250,0.2);
 }
 
 .c1:hover::after {
@@ -13833,6 +13859,14 @@ exports[`TextField with outlined variant and without label should render disable
   border: 0.1rem solid #98A7B7;
 }
 
+.c1:focus-within {
+  box-shadow: 0 0.2rem 0.8rem rgba(18,106,250,0.2);
+}
+
+.c1:focus-within::after {
+  border-color: #126AFA;
+}
+
 .c1::after,
 .c1:hover::after {
   border-width: 0.1rem;
@@ -14131,7 +14165,7 @@ exports[`TextField with outlined variant and without label should render focus s
 }
 
 .c1:focus-within {
-  box-shadow: 0px 0.2rem 0.8rem rgba(18,106,250,0.2);
+  box-shadow: 0 0.2rem 0.8rem rgba(18,106,250,0.2);
 }
 
 .c1:hover::after {
@@ -14468,7 +14502,7 @@ exports[`TextField with outlined variant should render error state properly  1`]
 }
 
 .c1:focus-within {
-  box-shadow: 0px 0.2rem 0.8rem rgba(204,0,0,0.2);
+  box-shadow: 0 0.2rem 0.8rem rgba(204,0,0,0.2);
 }
 
 .c1:hover::after {
@@ -14847,7 +14881,7 @@ exports[`TextField with outlined variant should render error state properly with
 }
 
 .c1:focus-within {
-  box-shadow: 0px 0.2rem 0.8rem rgba(204,0,0,0.2);
+  box-shadow: 0 0.2rem 0.8rem rgba(204,0,0,0.2);
 }
 
 .c1:hover::after {
@@ -15292,6 +15326,13 @@ exports[`TextField with outlined variant should render properly with custom bord
 
 .c1:focus-within {
   border-radius: 0.25rem;
+  box-shadow: 0 0.2rem 0.8rem rgba(18,106,250,0.2);
+}
+
+.c1:focus-within::after {
+  border-color: #126AFA;
+  border-radius: 0.25rem;
+  border-width: 0.2rem;
 }
 
 .c1::after,
@@ -15628,6 +15669,14 @@ exports[`TextField with outlined variant should render properly with custom disa
   border: 0.1rem solid #98A7B7;
 }
 
+.c1:focus-within {
+  box-shadow: 0 0.2rem 0.8rem rgba(18,106,250,0.2);
+}
+
+.c1:focus-within::after {
+  border-color: #126AFA;
+}
+
 .c1::after,
 .c1:hover::after {
   border-width: 0.1rem;
@@ -15945,7 +15994,7 @@ exports[`TextField with outlined variant should render properly with multiline 1
 }
 
 .c1:focus-within {
-  box-shadow: 0px 0.2rem 0.8rem rgba(18,106,250,0.2);
+  box-shadow: 0 0.2rem 0.8rem rgba(18,106,250,0.2);
 }
 
 .c1:hover::after {
@@ -16293,7 +16342,7 @@ exports[`TextField with outlined variant should render properly with prefix 1`] 
 }
 
 .c1:focus-within {
-  box-shadow: 0px 0.2rem 0.8rem rgba(18,106,250,0.2);
+  box-shadow: 0 0.2rem 0.8rem rgba(18,106,250,0.2);
 }
 
 .c1:hover::after {
@@ -16658,7 +16707,7 @@ exports[`TextField with outlined variant should render properly with suffix 1`] 
 }
 
 .c1:focus-within {
-  box-shadow: 0px 0.2rem 0.8rem rgba(18,106,250,0.2);
+  box-shadow: 0 0.2rem 0.8rem rgba(18,106,250,0.2);
 }
 
 .c1:hover::after {

--- a/packages/forms/src/components/Form/__snapshots__/Form.test.tsx.snap
+++ b/packages/forms/src/components/Form/__snapshots__/Form.test.tsx.snap
@@ -730,6 +730,7 @@ exports[`Form should render properly with initial state 1`] = `
 .c5:focus-within::after,
 .c5:focus-within:hover::after {
   border-color: #126AFA;
+  border-radius: 0;
 }
 
 .c5:focus-within .c8,
@@ -887,6 +888,10 @@ exports[`Form should render properly with initial state 1`] = `
 
 .c7.c7.c7:focus::placeholder {
   opacity: 1;
+}
+
+.c7:disabled {
+  color: #435465;
 }
 
 .c7:disabled ~ .c8,
@@ -1116,6 +1121,7 @@ exports[`Form should render properly with initial state 1`] = `
 .c46:focus-within::after,
 .c46:focus-within:hover::after {
   border-color: #126AFA;
+  border-radius: 0;
 }
 
 .c46:focus-within .c8,
@@ -3029,6 +3035,7 @@ exports[`Form should render properly without initial state 1`] = `
 .c8:focus-within::after,
 .c8:focus-within:hover::after {
   border-color: #126AFA;
+  border-radius: 0;
 }
 
 .c8:focus-within .c11,
@@ -3186,6 +3193,10 @@ exports[`Form should render properly without initial state 1`] = `
 
 .c10.c10.c10:focus::placeholder {
   opacity: 1;
+}
+
+.c10:disabled {
+  color: #435465;
 }
 
 .c10:disabled ~ .c11,
@@ -3415,6 +3426,7 @@ exports[`Form should render properly without initial state 1`] = `
 .c46:focus-within::after,
 .c46:focus-within:hover::after {
   border-color: #126AFA;
+  border-radius: 0;
 }
 
 .c46:focus-within .c11,

--- a/packages/theme/src/core/textField/index.ts
+++ b/packages/theme/src/core/textField/index.ts
@@ -1,6 +1,18 @@
 import colors from '../colors';
 import { TextFieldTheme } from './types';
 
+const defaultBorderWidth = '0.15rem';
+
+const defaultOutlined = {
+    borderWidth: defaultBorderWidth,
+    borderRadius: '0.4rem'
+};
+
+const defaultFusion = {
+    borderWidth: defaultBorderWidth,
+    borderRadius: '1rem'
+};
+
 const textField: TextFieldTheme = {
     height: {
         S: '4rem',
@@ -14,13 +26,16 @@ const textField: TextFieldTheme = {
         default: {
             bgColor: colors.white,
             borderColor: colors.grey[500],
+            borderRadius: defaultOutlined.borderRadius,
+            borderWidth: defaultOutlined.borderWidth,
+            helperTextColor: colors.grey[700],
             iconColor: colors.grey[600],
-            textColor: colors.black,
             labelColor: colors.grey[600],
-            helperTextColor: colors.grey[700]
+            textColor: colors.black,
         },
         hover: {
             borderColor: colors.grey[600],
+            borderWidth: defaultOutlined.borderWidth,
             shadowColor: colors.grey[600]
         },
         disabled: {
@@ -32,9 +47,11 @@ const textField: TextFieldTheme = {
         },
         active: {
             bgColor: colors.white,
-            placeholderColor: colors.grey[300],
             borderColor: colors.blue[500],
+            borderRadius: defaultOutlined.borderRadius,
+            borderWidth: defaultOutlined.borderWidth,
             labelColor: colors.blue[500],
+            placeholderColor: colors.grey[300],
             shadowColor: colors.blue[500]
         },
         error: {
@@ -85,15 +102,18 @@ const textField: TextFieldTheme = {
     },
     fusion: {
         default: {
-            borderColor: colors.grey[400],
             bgColor: colors.grey[50],
-            textColor: colors.black,
+            borderColor: colors.grey[400],
+            borderRadius: defaultFusion.borderRadius,
+            borderWidth: defaultFusion.borderWidth,
+            helperTextColor: colors.grey[700],
             labelColor: colors.grey[700],
-            helperTextColor: colors.grey[700]
+            textColor: colors.black
         },
         hover: {
             bgColor: colors.grey[50],
-            borderColor: colors.grey[600]
+            borderColor: colors.grey[600],
+            borderWidth: defaultFusion.borderWidth
         },
         disabled: {
             bgColor: colors.white,
@@ -103,10 +123,12 @@ const textField: TextFieldTheme = {
             cursor: 'not-allowed'
         },
         active: {
-            placeholderColor: colors.grey[300],
             bgColor: colors.white,
             borderColor: colors.blue[500],
-            labelColor: colors.blue[500]
+            borderRadius: defaultFusion.borderRadius,
+            borderWidth: defaultFusion.borderWidth,
+            labelColor: colors.blue[500],
+            placeholderColor: colors.grey[300]
         },
         error: {
             caretColor: colors.black,

--- a/packages/theme/src/core/textField/types.ts
+++ b/packages/theme/src/core/textField/types.ts
@@ -15,14 +15,17 @@ export interface TextFieldTheme {
         default: {
             bgColor: string;
             borderColor: string;
-            iconColor: string;
-            textColor: string;
-            labelColor: string;
+            borderRadius: string;
+            borderWidth: string;
             helperTextColor: string;
+            iconColor: string;
+            labelColor: string;
+            textColor: string;
         };
         hover: {
             borderColor: string;
             shadowColor: string;
+            borderWidth: string;
         };
         disabled: {
             bgColor: string;
@@ -33,9 +36,11 @@ export interface TextFieldTheme {
         };
         active: {
             bgColor: string;
-            placeholderColor: string;
             borderColor: string;
+            borderRadius: string;
+            borderWidth: string;
             labelColor: string;
+            placeholderColor: string;
             shadowColor: string;
         };
         error: {
@@ -70,10 +75,10 @@ export interface TextFieldTheme {
             cursor: string;
         };
         active: {
-            placeholderColor: string;
             bgColor: string;
             borderColor: string;
             labelColor: string;
+            placeholderColor: string;
         };
         error: {
             placeholderColor: string;
@@ -88,15 +93,18 @@ export interface TextFieldTheme {
     /** fusion variant theme */
     fusion: {
         default: {
-            borderColor: string;
             bgColor: string;
-            textColor: string;
-            labelColor: string;
+            borderColor: string;
+            borderRadius: string;
+            borderWidth: string;
             helperTextColor: string;
+            labelColor: string;
+            textColor: string;
         };
         hover: {
             bgColor: string;
             borderColor: string;
+            borderWidth: string;
         };
         disabled: {
             bgColor: string;
@@ -106,10 +114,12 @@ export interface TextFieldTheme {
             cursor: string;
         };
         active: {
-            placeholderColor: string;
             bgColor: string;
             borderColor: string;
+            borderRadius: string;
+            borderWidth: string;
             labelColor: string;
+            placeholderColor: string;
         };
         error: {
             placeholderColor: string;


### PR DESCRIPTION
### PR Checklist

Please check if your PR fulfills the following requirements:

-   [x] Tests for the changes have been added (for bug fixes/features)
-   [x] Docs have been added/updated (for bug fixes/features)

### PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

-   [x] Bugfix
-   [x] Feature
-   [ ] Code style update (formatting, local variables)
-   [ ] Refactoring (no functional changes, no api changes)
-   [ ] Build related changes
-   [ ] CI related changes
-   [ ] Performance improves
-   [ ] Adding missing tests
-   [x] Documentation content changes
-   [ ] Other... Please describe:

### What is the current behavior?
- Currently the `TextField` component has a set, non-customizable `border-radius` and `border-width` for all variants. 
- Additionally, the existing custom `textColor` for a `TextField` disabled state is not being use

## Fixes # (issue)
Minor fix to ensure the `disabled.textColor` is being applied to the `TextField` input

### What is the new behavior?
Added new props `borderRadius` and `borderWidth` specifically to the `outlined && fusion` variants. Those props have default values that existed in the css for both variants. Additionally, this PR includes minor styling updates to the `HelperAndErrorTextTooltip`, which can be used in the `TextField` + `Single-Select` components -- stories added for these as well.

### Does this PR introduce a breaking change?

-   [ ] Yes
-   [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path of the existing applications below. -->

### Additional context
This PR relates to PharmOS design requirements.

