### PR TITLE
feat: Function to be called after the calendar popup closes

### DIFF
--- a/packages/core/src/components/DateRangePicker/DateRangePicker.stories.mdx
+++ b/packages/core/src/components/DateRangePicker/DateRangePicker.stories.mdx
@@ -62,23 +62,28 @@ return <DateRangePicker value={dates} onChange={setDates} />;
     </Story>
 </Preview>
 
-### onClose
+### onPopupClose
 
-You can pass a function using onClose prop to perform any action after the date selection.
-onChange is required to make dateRangePicker a controlled component but onClose is there to handle action like api call which you want to perform once the you are done with the date selection.
+You can pass a function using `onPopupClose` prop to perform any action when the calendar popup closes.
+`onChange` is required to make dateRangePicker a controlled component but `onPopupClose` is there to handle action like api call which you want to perform once the you are done with the date selection.
 
 ```tsx
-import { useCallApi } from '@effects';
-import { createUrlWithParams } from '@utils'
+import { useAxios } from '@medly-components/utils';
+import { createUrlWithParams } from '@utils';
+
 const DateRangePickerWithOnClose: React.FC = () => {
     const [dates, setDates] = useState<DateRangeType>({ startDate: null, endDate: null }),
-        [data, callApi] = useCallApi();
-         const handleApiCall = () =>
-            callApi({
-                url: createUrlWithParams(url, dates)
-                method: 'get',
-});
- return <DateRangePicker value={dates} onChange={setDates} onClose={handleApiCall} />;
+        { request } = useAxios();
+
+    const handleApiCall = () =>
+        dates.startDate &&
+        dates.endDate &&
+        request({
+            url: createUrlWithParams(url, dates)
+            method: 'get'
+        });
+
+    return <DateRangePicker value={dates} onChange={setDates} onPopupClose={handleApiCall} />;
 };
 ```
 

--- a/packages/core/src/components/DateRangePicker/DateRangePicker.stories.mdx
+++ b/packages/core/src/components/DateRangePicker/DateRangePicker.stories.mdx
@@ -62,6 +62,26 @@ return <DateRangePicker value={dates} onChange={setDates} />;
     </Story>
 </Preview>
 
+### onClose
+
+You can pass a function using onClose prop to perform any action after the date selection.
+onChange is required to make dateRangePicker a controlled component but onClose is there to handle action like api call which you want to perform once the you are done with the date selection.
+
+```tsx
+import { useCallApi } from '@effects';
+import { createUrlWithParams } from '@utils'
+const DateRangePickerWithOnClose: React.FC = () => {
+    const [dates, setDates] = useState<DateRangeType>({ startDate: null, endDate: null }),
+        [data, callApi] = useCallApi();
+         const handleApiCall = () =>
+            callApi({
+                url: createUrlWithParams(url, dates)
+                method: 'get',
+});
+ return <DateRangePicker value={dates} onChange={setDates} onClose={handleApiCall} />;
+};
+```
+
 ### Validations
 
 1. Validations would happen on invalid, and blur event.

--- a/packages/core/src/components/DateRangePicker/DateRangePicker.stories.mdx
+++ b/packages/core/src/components/DateRangePicker/DateRangePicker.stories.mdx
@@ -65,7 +65,7 @@ return <DateRangePicker value={dates} onChange={setDates} />;
 ### onPopupClose
 
 You can pass a function using `onPopupClose` prop to perform any action when the calendar popup closes.
-`onChange` is required to make dateRangePicker a controlled component but `onPopupClose` is there to handle action like api call which you want to perform once the you are done with the date selection.
+`onChange` is required to make dateRangePicker a controlled component but `onPopupClose` is there to handle action like api call which you want to perform once you are done with the date selection.
 
 ```tsx
 import { useAxios } from '@medly-components/utils';

--- a/packages/core/src/components/DateRangePicker/DateRangePicker.test.tsx
+++ b/packages/core/src/components/DateRangePicker/DateRangePicker.test.tsx
@@ -358,6 +358,26 @@ describe('DateRangePicker', () => {
         });
     });
 
+    it('should not call onPopupClose when calendar is hidden', () => {
+        const mockOnPopupClose = jest.fn(),
+            { container, getByText } = render(
+                <>
+                    <p>Click Here</p>
+                    <DateRangePicker
+                        id="contract"
+                        value={{ startDate: new Date(2010, 0, 1), endDate: new Date(2010, 0, 2) }}
+                        displayFormat="MM/dd/yyyy"
+                        onChange={jest.fn()}
+                        onPopupClose={mockOnPopupClose}
+                    />
+                </>
+            );
+
+        expect(container.querySelector('#contract-calendar')).toBeNull();
+        fireEvent.click(getByText('Click Here'));
+        expect(mockOnPopupClose).not.toHaveBeenCalled();
+    });
+
     describe('date selection', () => {
         it('should swap the date if start date is greater than end date', () => {
             const mockOnChange = jest.fn(),

--- a/packages/core/src/components/DateRangePicker/DateRangePicker.test.tsx
+++ b/packages/core/src/components/DateRangePicker/DateRangePicker.test.tsx
@@ -352,8 +352,6 @@ describe('DateRangePicker', () => {
             fireEvent.click(screen.getByTitle('contract-calendar-icon'));
             expect(container.querySelector('#contract-calendar')).toBeInTheDocument();
             fireEvent.click(getByText('Click Here'));
-            expect(container.querySelector('#contract-calendar')).toBeNull();
-            fireEvent.click(getByText('Click Here'));
             expect(mockOnPopupClose).toHaveBeenCalledTimes(1);
         });
     });

--- a/packages/core/src/components/DateRangePicker/DateRangePicker.test.tsx
+++ b/packages/core/src/components/DateRangePicker/DateRangePicker.test.tsx
@@ -334,8 +334,8 @@ describe('DateRangePicker', () => {
             expect(mockOnInvalid).toHaveBeenCalled();
         });
 
-        it('should call onClose after date selection', () => {
-            const mockOnClose = jest.fn(),
+        it('should call onPopupClose when calendar popup closes', () => {
+            const mockOnPopupClose = jest.fn(),
                 { container, getByText } = render(
                     <>
                         <p>Click Here</p>
@@ -344,19 +344,17 @@ describe('DateRangePicker', () => {
                             value={{ startDate: new Date(2010, 0, 1), endDate: new Date(2010, 0, 2) }}
                             displayFormat="MM/dd/yyyy"
                             onChange={jest.fn()}
-                            onClose={mockOnClose}
+                            onPopupClose={mockOnPopupClose}
                         />
                     </>
                 );
-            const startDateInput = screen.getByRole('textbox', { name: 'From' }),
-                endDateInput = screen.getByRole('textbox', { name: 'To' });
+
             fireEvent.click(screen.getByTitle('contract-calendar-icon'));
-            fireEvent.change(startDateInput, { target: { value: '06 / 05 / 2020' } });
-            fireEvent.change(endDateInput, { target: { value: '07 / 06 / 2020' } });
+            expect(container.querySelector('#contract-calendar')).toBeInTheDocument();
             fireEvent.click(getByText('Click Here'));
             expect(container.querySelector('#contract-calendar')).toBeNull();
             fireEvent.click(getByText('Click Here'));
-            expect(mockOnClose).toHaveBeenCalledTimes(1);
+            expect(mockOnPopupClose).toHaveBeenCalledTimes(1);
         });
     });
 

--- a/packages/core/src/components/DateRangePicker/DateRangePicker.test.tsx
+++ b/packages/core/src/components/DateRangePicker/DateRangePicker.test.tsx
@@ -333,6 +333,31 @@ describe('DateRangePicker', () => {
             fireEvent.invalid(startDateInput);
             expect(mockOnInvalid).toHaveBeenCalled();
         });
+
+        it('should call onClose after date selection', () => {
+            const mockOnClose = jest.fn(),
+                { container, getByText } = render(
+                    <>
+                        <p>Click Here</p>
+                        <DateRangePicker
+                            id="contract"
+                            value={{ startDate: new Date(2010, 0, 1), endDate: new Date(2010, 0, 2) }}
+                            displayFormat="MM/dd/yyyy"
+                            onChange={jest.fn()}
+                            onClose={mockOnClose}
+                        />
+                    </>
+                );
+            const startDateInput = screen.getByRole('textbox', { name: 'From' }),
+                endDateInput = screen.getByRole('textbox', { name: 'To' });
+            fireEvent.click(screen.getByTitle('contract-calendar-icon'));
+            fireEvent.change(startDateInput, { target: { value: '06 / 05 / 2020' } });
+            fireEvent.change(endDateInput, { target: { value: '07 / 06 / 2020' } });
+            fireEvent.click(getByText('Click Here'));
+            expect(container.querySelector('#contract-calendar')).toBeNull();
+            fireEvent.click(getByText('Click Here'));
+            expect(mockOnClose).toHaveBeenCalledTimes(1);
+        });
     });
 
     describe('date selection', () => {

--- a/packages/core/src/components/DateRangePicker/DateRangePicker.tsx
+++ b/packages/core/src/components/DateRangePicker/DateRangePicker.tsx
@@ -32,7 +32,7 @@ export const DateRangePicker: FC<DateRangeProps> = React.memo(props => {
         withSingleMonth,
         showTooltipForHelperAndErrorText,
         customDateRangeOptions,
-        onClose,
+        onPopupClose,
         ...restProps
     } = props;
     const startDateRef = useRef<HTMLInputElement>(null),
@@ -85,7 +85,7 @@ export const DateRangePicker: FC<DateRangeProps> = React.memo(props => {
 
     useOuterClickNotifier(() => {
         setActive(false);
-        isActive && onClose && onClose();
+        isActive && onPopupClose && onPopupClose();
         isActive && outerClickValidator.current && outerClickValidator.current();
     }, wrapperRef);
     useUpdateEffect(() => focusElement(focusedElement), [focusedElement]);

--- a/packages/core/src/components/DateRangePicker/DateRangePicker.tsx
+++ b/packages/core/src/components/DateRangePicker/DateRangePicker.tsx
@@ -32,6 +32,7 @@ export const DateRangePicker: FC<DateRangeProps> = React.memo(props => {
         withSingleMonth,
         showTooltipForHelperAndErrorText,
         customDateRangeOptions,
+        onClose,
         ...restProps
     } = props;
     const startDateRef = useRef<HTMLInputElement>(null),
@@ -84,6 +85,7 @@ export const DateRangePicker: FC<DateRangeProps> = React.memo(props => {
 
     useOuterClickNotifier(() => {
         setActive(false);
+        isActive && onClose && onClose();
         isActive && outerClickValidator.current && outerClickValidator.current();
     }, wrapperRef);
     useUpdateEffect(() => focusElement(focusedElement), [focusedElement]);

--- a/packages/core/src/components/DateRangePicker/types.ts
+++ b/packages/core/src/components/DateRangePicker/types.ts
@@ -22,6 +22,8 @@ export type DateRangeProps = Omit<HTMLProps<HTMLInputElement>, 'prefix' | 'size'
     value: DateRangeType;
     /** Function to be called on change of the dates */
     onChange: (value: DateRangeType) => void;
+    /** Function to be called after date selection */
+    onClose?: () => void;
     /** Variants */
     variant?: 'outlined' | 'filled';
     /** Function will called with the input value on blur and invalid event */

--- a/packages/core/src/components/DateRangePicker/types.ts
+++ b/packages/core/src/components/DateRangePicker/types.ts
@@ -22,8 +22,8 @@ export type DateRangeProps = Omit<HTMLProps<HTMLInputElement>, 'prefix' | 'size'
     value: DateRangeType;
     /** Function to be called on change of the dates */
     onChange: (value: DateRangeType) => void;
-    /** Function to be called after date selection */
-    onClose?: () => void;
+    /** Function to be called when calendar popup closes */
+    onPopupClose?: () => void;
     /** Variants */
     variant?: 'outlined' | 'filled';
     /** Function will called with the input value on blur and invalid event */


### PR DESCRIPTION
### PR Checklist

Please check if your PR fulfills the following requirements:

-   [x] Tests for the changes have been added (for bug fixes/features)
-   [x] Docs have been added/updated (for bug fixes/features)

### PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

-   [ ] Bugfix
-   [x] Feature
-   [ ] Code style update (formatting, local variables)
-   [ ] Refactoring (no functional changes, no api changes)
-   [ ] Build related changes
-   [ ] CI related changes
-   [ ] Performance improves
-   [ ] Adding missing tests
-   [ ] Documentation content changes
-   [ ] Other... Please describe:

### What is the current behavior?
Currently, there is no way to trigger an action, when the user closes the calendar popup after selecting the dates.
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

## Fixes # (issue)
#228
### What is the new behavior?
a function will be called when the calendar popup closes.
### Does this PR introduce a breaking change?

-   [ ] Yes
-   [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path of the existing applications below. -->

### Additional context

Provide any additional context or screenshots about the feature PR.
