### PR TITLE
fix: fix active tab value for TabList

### DIFF
--- a/packages/core/src/components/Tabs/TabList/TabList.tsx
+++ b/packages/core/src/components/Tabs/TabList/TabList.tsx
@@ -20,8 +20,9 @@ const Component: FC<TabListProps> = memo(props => {
                     .map((child: any) => child.props.id),
             [props.children]
         ),
+        enabledTabIds = useMemo(() => Children.toArray(props.children).map((child: any) => child.props.id), [props.children]),
         { 0: first, [tabIds.length - 1]: last } = tabIds,
-        activeTabIdx = tabIds.indexOf(active),
+        activeTabIdx = enabledTabIds.indexOf(active),
         totalTabs = Children.toArray(props.children).length,
         { tabSize, variant } = useContext(TabsContext);
 

--- a/packages/core/src/components/Tabs/TabList/TabList.tsx
+++ b/packages/core/src/components/Tabs/TabList/TabList.tsx
@@ -13,24 +13,24 @@ const Component: FC<TabListProps> = memo(props => {
         homePress = useKeyPress('Home'),
         endPress = useKeyPress('End'),
         [isFocused, setFocusState] = useState(false),
-        tabIds = useMemo(
+        enabledTabIds = useMemo(
             () =>
                 Children.toArray(props.children)
                     .filter((child: any) => !child.props.disabled)
                     .map((child: any) => child.props.id),
             [props.children]
         ),
-        enabledTabIds = useMemo(() => Children.toArray(props.children).map((child: any) => child.props.id), [props.children]),
+        tabIds = useMemo(() => Children.toArray(props.children).map((child: any) => child.props.id), [props.children]),
         { 0: first, [tabIds.length - 1]: last } = tabIds,
-        activeTabIdx = enabledTabIds.indexOf(active),
+        activeTabIdx = tabIds.indexOf(active),
         totalTabs = Children.toArray(props.children).length,
         { tabSize, variant } = useContext(TabsContext);
 
     useEffect(() => {
-        rightPress && isFocused && (active === last ? onChange(first) : onChange(tabIds[tabIds.indexOf(active) + 1]));
+        rightPress && isFocused && (active === last ? onChange(first) : onChange(enabledTabIds[enabledTabIds.indexOf(active) + 1]));
     }, [rightPress]);
     useEffect(() => {
-        leftPress && isFocused && (active === first ? onChange(last) : onChange(tabIds[tabIds.indexOf(active) - 1]));
+        leftPress && isFocused && (active === first ? onChange(last) : onChange(enabledTabIds[enabledTabIds.indexOf(active) - 1]));
     }, [leftPress]);
     useEffect(() => {
         homePress && isFocused && onChange(first);


### PR DESCRIPTION
affects: @medly-components/core

### PR Checklist

Please check if your PR fulfills the following requirements:

-   [ ] Tests for the changes have been added (for bug fixes/features)
-   [ ] Docs have been added/updated (for bug fixes/features)

### PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

-   [x] Bugfix
-   [ ] Feature
-   [ ] Code style update (formatting, local variables)
-   [ ] Refactoring (no functional changes, no api changes)
-   [ ] Build related changes
-   [ ] CI related changes
-   [ ] Performance improves
-   [ ] Adding missing tests
-   [ ] Documentation content changes
-   [ ] Other... Please describe:

### What is the current behavior?

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Currently, the logic to position the slider in the `solid` tabs variant does not properly handle disabled tabs (i.e. if the second tab in the tab list is active and the first tab is disabled, the slider will be positioned incorrectly on the disabled tab list item).

Original:  
![Screen Shot 2021-12-20 at 11 03 10 AM](https://user-images.githubusercontent.com/42226043/146797273-2ac05cc6-43cd-41c5-bbd6-0d63ab321e24.png)

## Fixes # (issue)

### What is the new behavior?

I've updated the logic to correctly position the `solid` variant slider so that it does not become positioned on disabled tabs in the tab list.

Updated: 
![Screen Shot 2021-12-20 at 11 02 44 AM](https://user-images.githubusercontent.com/42226043/146797299-31c1378f-7320-4300-b628-e84e849b926c.png)

### Does this PR introduce a breaking change?

-   [ ] Yes
-   [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path of the existing applications below. -->

### Additional context

Provide any additional context or screenshots about the feature PR.
