### PR TITLE
fix: fix text component line height issue

### DIFF
--- a/packages/core/src/components/Avatar/__snapshots__/Avatar.test.tsx.snap
+++ b/packages/core/src/components/Avatar/__snapshots__/Avatar.test.tsx.snap
@@ -13,6 +13,7 @@ exports[`Avatar component should render avatar without hover and pressed states 
   line-height: 2.2rem;
   text-align: initial;
   text-transform: uppercase;
+  display: inline-block;
 }
 
 .c0 {
@@ -140,6 +141,7 @@ exports[`Avatar component should render with all the props given 1`] = `
   line-height: 2.2rem;
   text-align: initial;
   text-transform: uppercase;
+  display: inline-block;
 }
 
 .c0 {
@@ -220,6 +222,7 @@ exports[`Avatar component should render with default hover and pressed states 1`
   line-height: 2.2rem;
   text-align: initial;
   text-transform: uppercase;
+  display: inline-block;
 }
 
 .c0 {
@@ -300,6 +303,7 @@ exports[`Avatar component should render with default theme 1`] = `
   line-height: 2.2rem;
   text-align: initial;
   text-transform: uppercase;
+  display: inline-block;
 }
 
 .c0 {
@@ -363,6 +367,7 @@ exports[`Avatar component should render with not-allowed cursor when it is disab
   line-height: 2.2rem;
   text-align: initial;
   text-transform: uppercase;
+  display: inline-block;
 }
 
 .c0 {

--- a/packages/core/src/components/Box/__snapshots__/Box.test.tsx.snap
+++ b/packages/core/src/components/Box/__snapshots__/Box.test.tsx.snap
@@ -12,6 +12,7 @@ exports[`Box Component should not render with border if borderColor is not provi
   letter-spacing: 0rem;
   line-height: 2.2rem;
   text-align: initial;
+  display: inline-block;
 }
 
 .c0 {
@@ -67,6 +68,7 @@ exports[`Box Component should not render with border if borderWidth is not provi
   letter-spacing: 0rem;
   line-height: 2.2rem;
   text-align: initial;
+  display: inline-block;
 }
 
 .c0 {
@@ -122,6 +124,7 @@ exports[`Box Component should not render with given shadowColor if shadow size i
   letter-spacing: 0rem;
   line-height: 2.2rem;
   text-align: initial;
+  display: inline-block;
 }
 
 .c0 {
@@ -177,6 +180,7 @@ exports[`Box Component should render properly 1`] = `
   letter-spacing: 0rem;
   line-height: 2.2rem;
   text-align: initial;
+  display: inline-block;
 }
 
 .c0 {
@@ -240,6 +244,7 @@ exports[`Box Component should render properly when loading 1`] = `
   letter-spacing: 0rem;
   line-height: 2.2rem;
   text-align: initial;
+  display: inline-block;
 }
 
 .c3 {
@@ -376,6 +381,7 @@ exports[`Box Component should render properly with "L" shadow size 1`] = `
   letter-spacing: 0rem;
   line-height: 2.2rem;
   text-align: initial;
+  display: inline-block;
 }
 
 .c0 {
@@ -431,6 +437,7 @@ exports[`Box Component should render properly with "M" shadow size 1`] = `
   letter-spacing: 0rem;
   line-height: 2.2rem;
   text-align: initial;
+  display: inline-block;
 }
 
 .c0 {
@@ -486,6 +493,7 @@ exports[`Box Component should render properly with "S" shadow size 1`] = `
   letter-spacing: 0rem;
   line-height: 2.2rem;
   text-align: initial;
+  display: inline-block;
 }
 
 .c0 {
@@ -541,6 +549,7 @@ exports[`Box Component should render properly with "XL" shadow size 1`] = `
   letter-spacing: 0rem;
   line-height: 2.2rem;
   text-align: initial;
+  display: inline-block;
 }
 
 .c0 {
@@ -604,6 +613,7 @@ exports[`Box Component should render properly with L size and loading state 1`] 
   letter-spacing: 0rem;
   line-height: 2.2rem;
   text-align: initial;
+  display: inline-block;
 }
 
 .c3 {
@@ -748,6 +758,7 @@ exports[`Box Component should render properly with M size and loading state 1`] 
   letter-spacing: 0rem;
   line-height: 2.2rem;
   text-align: initial;
+  display: inline-block;
 }
 
 .c3 {
@@ -892,6 +903,7 @@ exports[`Box Component should render properly with S size and loading state 1`] 
   letter-spacing: 0rem;
   line-height: 2.2rem;
   text-align: initial;
+  display: inline-block;
 }
 
 .c3 {
@@ -1036,6 +1048,7 @@ exports[`Box Component should render properly with XL size and loading state 1`]
   letter-spacing: 0rem;
   line-height: 2.2rem;
   text-align: initial;
+  display: inline-block;
 }
 
 .c3 {
@@ -1172,6 +1185,7 @@ exports[`Box Component should render properly with border 1`] = `
   letter-spacing: 0rem;
   line-height: 2.2rem;
   text-align: initial;
+  display: inline-block;
 }
 
 .c0 {
@@ -1228,6 +1242,7 @@ exports[`Box Component should render properly with given bg and color 1`] = `
   letter-spacing: 0rem;
   line-height: 2.2rem;
   text-align: initial;
+  display: inline-block;
 }
 
 .c0 {
@@ -1283,6 +1298,7 @@ exports[`Box Component should render properly with given height and width 1`] = 
   letter-spacing: 0rem;
   line-height: 2.2rem;
   text-align: initial;
+  display: inline-block;
 }
 
 .c0 {
@@ -1342,6 +1358,7 @@ exports[`Box Component should render with given margin 1`] = `
   letter-spacing: 0rem;
   line-height: 2.2rem;
   text-align: initial;
+  display: inline-block;
 }
 
 .c0 {
@@ -1397,6 +1414,7 @@ exports[`Box Component should render with given padding 1`] = `
   letter-spacing: 0rem;
   line-height: 2.2rem;
   text-align: initial;
+  display: inline-block;
 }
 
 .c0 {
@@ -1452,6 +1470,7 @@ exports[`Box Component should render with given shadowColor 1`] = `
   letter-spacing: 0rem;
   line-height: 2.2rem;
   text-align: initial;
+  display: inline-block;
 }
 
 .c0 {
@@ -1507,6 +1526,7 @@ exports[`Box Component should wrap children into Text component when rendering s
   letter-spacing: 0rem;
   line-height: 2.2rem;
   text-align: initial;
+  display: inline-block;
 }
 
 .c0 {

--- a/packages/core/src/components/Breadcrumb/__snapshots__/Breadcrumb.test.tsx.snap
+++ b/packages/core/src/components/Breadcrumb/__snapshots__/Breadcrumb.test.tsx.snap
@@ -27,6 +27,7 @@ exports[`Breadcrumb component should render properly with "/" separator 1`] = `
   letter-spacing: 0rem;
   line-height: 2.2rem;
   text-align: initial;
+  display: inline-block;
 }
 
 .c6 {
@@ -244,6 +245,7 @@ exports[`Breadcrumb component should render properly with {"$typeof": Symbol(rea
   letter-spacing: 0rem;
   line-height: 2.2rem;
   text-align: initial;
+  display: inline-block;
 }
 
 .c6 {

--- a/packages/core/src/components/Button/__snapshots__/Button.test.tsx.snap
+++ b/packages/core/src/components/Button/__snapshots__/Button.test.tsx.snap
@@ -12,6 +12,7 @@ exports[`Button component should render flat variant properly when hideUnderline
   letter-spacing: 0rem;
   line-height: 2.6rem;
   text-align: initial;
+  display: inline-block;
 }
 
 .c0 {
@@ -169,6 +170,7 @@ exports[`Button component should render flat variant properly when hideUnderline
   letter-spacing: 0rem;
   line-height: 2.6rem;
   text-align: initial;
+  display: inline-block;
 }
 
 .c0 {
@@ -326,6 +328,7 @@ exports[`Button component should render properly as outlined when theme has hove
   letter-spacing: 0rem;
   line-height: 2.6rem;
   text-align: initial;
+  display: inline-block;
 }
 
 .c0 {
@@ -484,6 +487,7 @@ exports[`Button component should render properly as solid when theme has hover s
   letter-spacing: 0rem;
   line-height: 2.6rem;
   text-align: initial;
+  display: inline-block;
 }
 
 .c0 {
@@ -604,6 +608,7 @@ exports[`Button component should render properly with "circle" edges 1`] = `
   letter-spacing: 0rem;
   line-height: 2.6rem;
   text-align: initial;
+  display: inline-block;
 }
 
 .c0 {
@@ -725,6 +730,7 @@ exports[`Button component should render properly with "rounded" edges 1`] = `
   letter-spacing: 0rem;
   line-height: 2.6rem;
   text-align: initial;
+  display: inline-block;
 }
 
 .c0 {
@@ -846,6 +852,7 @@ exports[`Button component should render properly with "square" edges 1`] = `
   letter-spacing: 0rem;
   line-height: 2.6rem;
   text-align: initial;
+  display: inline-block;
 }
 
 .c0 {
@@ -967,6 +974,7 @@ exports[`Button component should render properly with L size and loading state 1
   letter-spacing: 0rem;
   line-height: 2.6rem;
   text-align: initial;
+  display: inline-block;
 }
 
 .c0 {
@@ -1154,6 +1162,7 @@ exports[`Button component should render properly with S size and loading state 1
   letter-spacing: 0rem;
   line-height: 2.2rem;
   text-align: initial;
+  display: inline-block;
 }
 
 .c0 {
@@ -1356,6 +1365,7 @@ exports[`Button component should render properly with any icon at the beginning 
   letter-spacing: 0rem;
   line-height: 2.6rem;
   text-align: initial;
+  display: inline-block;
 }
 
 .c0 {
@@ -1506,6 +1516,7 @@ exports[`Button component should render properly with any icon at the end of the
   letter-spacing: 0rem;
   line-height: 2.6rem;
   text-align: initial;
+  display: inline-block;
 }
 
 .c0 {
@@ -1641,6 +1652,7 @@ exports[`Button component should render properly with outlined and theme doesn't
   letter-spacing: 0rem;
   line-height: 2.6rem;
   text-align: initial;
+  display: inline-block;
 }
 
 .c0 {
@@ -1800,6 +1812,7 @@ exports[`Button component should wrap children into Text component when renderin
   letter-spacing: 0rem;
   line-height: 2.6rem;
   text-align: initial;
+  display: inline-block;
 }
 
 .c0 {
@@ -1927,6 +1940,7 @@ exports[`Button component with "flat" variant should render properly 1`] = `
   letter-spacing: 0rem;
   line-height: 2.6rem;
   text-align: initial;
+  display: inline-block;
 }
 
 .c0 {
@@ -2084,6 +2098,7 @@ exports[`Button component with "flat" variant should render properly when it is 
   letter-spacing: 0rem;
   line-height: 2.6rem;
   text-align: initial;
+  display: inline-block;
 }
 
 .c0 {
@@ -2242,6 +2257,7 @@ exports[`Button component with "flat" variant should render properly when it is 
   letter-spacing: 0rem;
   line-height: 2.6rem;
   text-align: initial;
+  display: inline-block;
 }
 
 .c0 {
@@ -2465,6 +2481,7 @@ exports[`Button component with "flat" variant should render properly with "L" si
   letter-spacing: 0rem;
   line-height: 2.6rem;
   text-align: initial;
+  display: inline-block;
 }
 
 .c0 {
@@ -2622,6 +2639,7 @@ exports[`Button component with "flat" variant should render properly with "M" si
   letter-spacing: 0rem;
   line-height: 2.6rem;
   text-align: initial;
+  display: inline-block;
 }
 
 .c0 {
@@ -2779,6 +2797,7 @@ exports[`Button component with "flat" variant should render properly with "S" si
   letter-spacing: 0rem;
   line-height: 2.2rem;
   text-align: initial;
+  display: inline-block;
 }
 
 .c0 {
@@ -2936,6 +2955,7 @@ exports[`Button component with "flat" variant should render properly with "XS" s
   letter-spacing: 0rem;
   line-height: 2.2rem;
   text-align: initial;
+  display: inline-block;
 }
 
 .c0 {
@@ -3093,6 +3113,7 @@ exports[`Button component with "outlined" variant should render properly 1`] = `
   letter-spacing: 0rem;
   line-height: 2.6rem;
   text-align: initial;
+  display: inline-block;
 }
 
 .c0 {
@@ -3252,6 +3273,7 @@ exports[`Button component with "outlined" variant should render properly when it
   letter-spacing: 0rem;
   line-height: 2.6rem;
   text-align: initial;
+  display: inline-block;
 }
 
 .c0 {
@@ -3412,6 +3434,7 @@ exports[`Button component with "outlined" variant should render properly when it
   letter-spacing: 0rem;
   line-height: 2.6rem;
   text-align: initial;
+  display: inline-block;
 }
 
 .c0 {
@@ -3637,6 +3660,7 @@ exports[`Button component with "outlined" variant should render properly with "L
   letter-spacing: 0rem;
   line-height: 2.6rem;
   text-align: initial;
+  display: inline-block;
 }
 
 .c0 {
@@ -3796,6 +3820,7 @@ exports[`Button component with "outlined" variant should render properly with "M
   letter-spacing: 0rem;
   line-height: 2.6rem;
   text-align: initial;
+  display: inline-block;
 }
 
 .c0 {
@@ -3955,6 +3980,7 @@ exports[`Button component with "outlined" variant should render properly with "S
   letter-spacing: 0rem;
   line-height: 2.2rem;
   text-align: initial;
+  display: inline-block;
 }
 
 .c0 {
@@ -4114,6 +4140,7 @@ exports[`Button component with "outlined" variant should render properly with "X
   letter-spacing: 0rem;
   line-height: 2.2rem;
   text-align: initial;
+  display: inline-block;
 }
 
 .c0 {
@@ -4273,6 +4300,7 @@ exports[`Button component with "solid" variant should render properly 1`] = `
   letter-spacing: 0rem;
   line-height: 2.6rem;
   text-align: initial;
+  display: inline-block;
 }
 
 .c0 {
@@ -4394,6 +4422,7 @@ exports[`Button component with "solid" variant should render properly when it is
   letter-spacing: 0rem;
   line-height: 2.6rem;
   text-align: initial;
+  display: inline-block;
 }
 
 .c0 {
@@ -4516,6 +4545,7 @@ exports[`Button component with "solid" variant should render properly when it is
   letter-spacing: 0rem;
   line-height: 2.6rem;
   text-align: initial;
+  display: inline-block;
 }
 
 .c0 {
@@ -4703,6 +4733,7 @@ exports[`Button component with "solid" variant should render properly with "L" s
   letter-spacing: 0rem;
   line-height: 2.6rem;
   text-align: initial;
+  display: inline-block;
 }
 
 .c0 {
@@ -4824,6 +4855,7 @@ exports[`Button component with "solid" variant should render properly with "M" s
   letter-spacing: 0rem;
   line-height: 2.6rem;
   text-align: initial;
+  display: inline-block;
 }
 
 .c0 {
@@ -4945,6 +4977,7 @@ exports[`Button component with "solid" variant should render properly with "S" s
   letter-spacing: 0rem;
   line-height: 2.2rem;
   text-align: initial;
+  display: inline-block;
 }
 
 .c0 {
@@ -5066,6 +5099,7 @@ exports[`Button component with "solid" variant should render properly with "XS" 
   letter-spacing: 0rem;
   line-height: 2.2rem;
   text-align: initial;
+  display: inline-block;
 }
 
 .c0 {

--- a/packages/core/src/components/Calendar/__snapshots__/Calendar.test.tsx.snap
+++ b/packages/core/src/components/Calendar/__snapshots__/Calendar.test.tsx.snap
@@ -42,6 +42,7 @@ exports[`Calendar Component should render given date 1`] = `
   letter-spacing: 0rem;
   line-height: 1.6rem;
   text-align: initial;
+  display: inline-block;
 }
 
 .c12 {
@@ -55,6 +56,7 @@ exports[`Calendar Component should render given date 1`] = `
   letter-spacing: 0rem;
   line-height: 2.2rem;
   text-align: initial;
+  display: inline-block;
 }
 
 .c15 {
@@ -68,6 +70,7 @@ exports[`Calendar Component should render given date 1`] = `
   letter-spacing: 0rem;
   line-height: 2.2rem;
   text-align: initial;
+  display: inline-block;
 }
 
 .c0 {
@@ -1071,6 +1074,7 @@ exports[`Calendar Component should render properly with with error state 1`] = `
   letter-spacing: 0rem;
   line-height: 1.6rem;
   text-align: initial;
+  display: inline-block;
 }
 
 .c12 {
@@ -1084,6 +1088,7 @@ exports[`Calendar Component should render properly with with error state 1`] = `
   letter-spacing: 0rem;
   line-height: 2.2rem;
   text-align: initial;
+  display: inline-block;
 }
 
 .c15 {
@@ -1097,6 +1102,7 @@ exports[`Calendar Component should render properly with with error state 1`] = `
   letter-spacing: 0rem;
   line-height: 2.2rem;
   text-align: initial;
+  display: inline-block;
 }
 
 .c0 {

--- a/packages/core/src/components/Card/__snapshots__/Card.test.tsx.snap
+++ b/packages/core/src/components/Card/__snapshots__/Card.test.tsx.snap
@@ -12,6 +12,7 @@ exports[`Card component should render correctly with all the default props 1`] =
   letter-spacing: 0rem;
   line-height: 2.2rem;
   text-align: initial;
+  display: inline-block;
 }
 
 .c0 {
@@ -89,6 +90,7 @@ exports[`Card component should render properly when flow direction is horizontal
   letter-spacing: 0rem;
   line-height: 2.2rem;
   text-align: initial;
+  display: inline-block;
 }
 
 .c0 {
@@ -427,6 +429,7 @@ exports[`Card component should render properly when fullWidth and fullHeight is 
   letter-spacing: 0rem;
   line-height: 2.2rem;
   text-align: initial;
+  display: inline-block;
 }
 
 .c0 {
@@ -506,6 +509,7 @@ exports[`Card component should render properly when it is clickable 1`] = `
   letter-spacing: 0rem;
   line-height: 2.2rem;
   text-align: initial;
+  display: inline-block;
 }
 
 .c0 {
@@ -592,6 +596,7 @@ exports[`Card component should render properly when separator is set true flow d
   letter-spacing: 0rem;
   line-height: 2.2rem;
   text-align: initial;
+  display: inline-block;
 }
 
 .c0 {
@@ -888,6 +893,7 @@ exports[`Card component should render properly with "flat" variant 1`] = `
   letter-spacing: 0rem;
   line-height: 2.2rem;
   text-align: initial;
+  display: inline-block;
 }
 
 .c0 {
@@ -967,6 +973,7 @@ exports[`Card component should render properly with "solid" variant 1`] = `
   letter-spacing: 0rem;
   line-height: 2.2rem;
   text-align: initial;
+  display: inline-block;
 }
 
 .c0 {
@@ -1044,6 +1051,7 @@ exports[`Card component should render properly with display "block" 1`] = `
   letter-spacing: 0rem;
   line-height: 2.2rem;
   text-align: initial;
+  display: inline-block;
 }
 
 .c0 {
@@ -1121,6 +1129,7 @@ exports[`Card component should render properly with display "flex" 1`] = `
   letter-spacing: 0rem;
   line-height: 2.2rem;
   text-align: initial;
+  display: inline-block;
 }
 
 .c0 {

--- a/packages/core/src/components/CardTable/Body/Cell/__snapshots__/Cell.test.tsx.snap
+++ b/packages/core/src/components/CardTable/Body/Cell/__snapshots__/Cell.test.tsx.snap
@@ -12,6 +12,7 @@ exports[`CardTable Cell should be able to "center" align 1`] = `
   letter-spacing: 0rem;
   line-height: 2.2rem;
   text-align: initial;
+  display: inline-block;
 }
 
 .c0 {
@@ -73,6 +74,7 @@ exports[`CardTable Cell should be able to "left" align 1`] = `
   letter-spacing: 0rem;
   line-height: 2.2rem;
   text-align: initial;
+  display: inline-block;
 }
 
 .c0 {
@@ -134,6 +136,7 @@ exports[`CardTable Cell should be able to "right" align 1`] = `
   letter-spacing: 0rem;
   line-height: 2.2rem;
   text-align: initial;
+  display: inline-block;
 }
 
 .c0 {
@@ -195,6 +198,7 @@ exports[`CardTable Cell should render cell with text component with wrap text as
   letter-spacing: 0rem;
   line-height: 2.2rem;
   text-align: initial;
+  display: inline-block;
 }
 
 .c0 {
@@ -248,6 +252,7 @@ exports[`CardTable Cell should render cell with text component with wrap text as
   letter-spacing: 0rem;
   line-height: 2.2rem;
   text-align: initial;
+  display: inline-block;
 }
 
 .c0 {
@@ -307,6 +312,7 @@ exports[`CardTable Cell should render cell with text properly 1`] = `
   letter-spacing: 0rem;
   line-height: 2.2rem;
   text-align: initial;
+  display: inline-block;
 }
 
 .c0 {

--- a/packages/core/src/components/CardTable/Body/__snapshots__/Body.test.tsx.snap
+++ b/packages/core/src/components/CardTable/Body/__snapshots__/Body.test.tsx.snap
@@ -12,6 +12,7 @@ exports[`CardTable Body should render card table body properly 1`] = `
   letter-spacing: 0rem;
   line-height: 2.2rem;
   text-align: initial;
+  display: inline-block;
 }
 
 .c1 {
@@ -111,6 +112,7 @@ exports[`CardTable Body should render no result row when there is no data 1`] = 
   letter-spacing: 0rem;
   line-height: 2.2rem;
   text-align: initial;
+  display: inline-block;
 }
 
 .c0 {

--- a/packages/core/src/components/CardTable/__snapshots__/CardTable.test.tsx.snap
+++ b/packages/core/src/components/CardTable/__snapshots__/CardTable.test.tsx.snap
@@ -26,6 +26,7 @@ exports[`CardTable should render properly with grey background 1`] = `
   letter-spacing: 0rem;
   line-height: 2.2rem;
   text-align: initial;
+  display: inline-block;
 }
 
 .c10 {
@@ -304,6 +305,7 @@ exports[`CardTable should render properly with white background 1`] = `
   letter-spacing: 0rem;
   line-height: 2.2rem;
   text-align: initial;
+  display: inline-block;
 }
 
 .c10 {

--- a/packages/core/src/components/CenterAlignedLoader/__snapshots__/CenterAlignedLoader.test.tsx.snap
+++ b/packages/core/src/components/CenterAlignedLoader/__snapshots__/CenterAlignedLoader.test.tsx.snap
@@ -20,6 +20,7 @@ exports[`Center Aligned Loader should render properly with all props given 1`] =
   letter-spacing: 0rem;
   line-height: 2.2rem;
   text-align: initial;
+  display: inline-block;
 }
 
 .c0 {

--- a/packages/core/src/components/Checkbox/__snapshots__/checkbox.test.tsx.snap
+++ b/packages/core/src/components/Checkbox/__snapshots__/checkbox.test.tsx.snap
@@ -27,6 +27,7 @@ exports[`Checkbox component should render correctly with bottom labelPosition 1`
   letter-spacing: 0rem;
   line-height: 2.2rem;
   text-align: initial;
+  display: inline-block;
 }
 
 .c2 {
@@ -227,6 +228,7 @@ exports[`Checkbox component should render correctly with checked false and activ
   letter-spacing: 0rem;
   line-height: 2.2rem;
   text-align: initial;
+  display: inline-block;
 }
 
 .c6 {
@@ -427,6 +429,7 @@ exports[`Checkbox component should render correctly with checked false and disab
   letter-spacing: 0rem;
   line-height: 2.2rem;
   text-align: initial;
+  display: inline-block;
 }
 
 .c6 {
@@ -620,6 +623,7 @@ exports[`Checkbox component should render correctly with checked false and hasEr
   letter-spacing: 0rem;
   line-height: 2.2rem;
   text-align: initial;
+  display: inline-block;
 }
 
 .c6 {
@@ -820,6 +824,7 @@ exports[`Checkbox component should render correctly with checked false and indet
   letter-spacing: 0rem;
   line-height: 2.2rem;
   text-align: initial;
+  display: inline-block;
 }
 
 .c6 {
@@ -1029,6 +1034,7 @@ exports[`Checkbox component should render correctly with checked true and active
   letter-spacing: 0rem;
   line-height: 2.2rem;
   text-align: initial;
+  display: inline-block;
 }
 
 .c6 {
@@ -1232,6 +1238,7 @@ exports[`Checkbox component should render correctly with checked true and disabl
   letter-spacing: 0rem;
   line-height: 2.2rem;
   text-align: initial;
+  display: inline-block;
 }
 
 .c6 {
@@ -1426,6 +1433,7 @@ exports[`Checkbox component should render correctly with checked true and hasErr
   letter-spacing: 0rem;
   line-height: 2.2rem;
   text-align: initial;
+  display: inline-block;
 }
 
 .c6 {
@@ -1629,6 +1637,7 @@ exports[`Checkbox component should render correctly with checked true and indete
   letter-spacing: 0rem;
   line-height: 2.2rem;
   text-align: initial;
+  display: inline-block;
 }
 
 .c6 {
@@ -1839,6 +1848,7 @@ exports[`Checkbox component should render correctly with left labelPosition 1`] 
   letter-spacing: 0rem;
   line-height: 2.2rem;
   text-align: initial;
+  display: inline-block;
 }
 
 .c2 {
@@ -2043,6 +2053,7 @@ exports[`Checkbox component should render correctly with right labelPosition 1`]
   letter-spacing: 0rem;
   line-height: 2.2rem;
   text-align: initial;
+  display: inline-block;
 }
 
 .c2 {
@@ -2247,6 +2258,7 @@ exports[`Checkbox component should render correctly with top labelPosition 1`] =
   letter-spacing: 0rem;
   line-height: 2.2rem;
   text-align: initial;
+  display: inline-block;
 }
 
 .c2 {

--- a/packages/core/src/components/CheckboxGroup/__snapshots__/CheckboxGroup.test.tsx.snap
+++ b/packages/core/src/components/CheckboxGroup/__snapshots__/CheckboxGroup.test.tsx.snap
@@ -27,6 +27,7 @@ exports[`CheckboxGroup component should render properly 1`] = `
   letter-spacing: 0rem;
   line-height: 2.6rem;
   text-align: initial;
+  display: inline-block;
 }
 
 .c6 {
@@ -40,6 +41,7 @@ exports[`CheckboxGroup component should render properly 1`] = `
   letter-spacing: 0rem;
   line-height: 2.2rem;
   text-align: initial;
+  display: inline-block;
 }
 
 .c0 {
@@ -552,6 +554,7 @@ exports[`CheckboxGroup component should render properly with disabled state 1`] 
   letter-spacing: 0rem;
   line-height: 2.6rem;
   text-align: initial;
+  display: inline-block;
 }
 
 .c6 {
@@ -565,6 +568,7 @@ exports[`CheckboxGroup component should render properly with disabled state 1`] 
   letter-spacing: 0rem;
   line-height: 2.2rem;
   text-align: initial;
+  display: inline-block;
 }
 
 .c0 {
@@ -1048,6 +1052,7 @@ exports[`CheckboxGroup component should render properly with fullWidth 1`] = `
   letter-spacing: 0rem;
   line-height: 2.6rem;
   text-align: initial;
+  display: inline-block;
 }
 
 .c6 {
@@ -1061,6 +1066,7 @@ exports[`CheckboxGroup component should render properly with fullWidth 1`] = `
   letter-spacing: 0rem;
   line-height: 2.2rem;
   text-align: initial;
+  display: inline-block;
 }
 
 .c0 {

--- a/packages/core/src/components/Chip/__snapshots__/Chip.test.tsx.snap
+++ b/packages/core/src/components/Chip/__snapshots__/Chip.test.tsx.snap
@@ -12,6 +12,7 @@ exports[`Chip component should render properly when it is disabled 1`] = `
   letter-spacing: 0rem;
   line-height: 2.2rem;
   text-align: initial;
+  display: inline-block;
 }
 
 .c0 {
@@ -87,6 +88,7 @@ exports[`Chip component should render properly with flat variant 1`] = `
   letter-spacing: 0rem;
   line-height: 2.2rem;
   text-align: initial;
+  display: inline-block;
 }
 
 .c0 {
@@ -160,6 +162,7 @@ exports[`Chip component should render properly with outlined variant 1`] = `
   letter-spacing: 0rem;
   line-height: 2.2rem;
   text-align: initial;
+  display: inline-block;
 }
 
 .c0 {
@@ -234,6 +237,7 @@ exports[`Chip component should render properly with solid variant 1`] = `
   letter-spacing: 0rem;
   line-height: 2.2rem;
   text-align: initial;
+  display: inline-block;
 }
 
 .c0 {

--- a/packages/core/src/components/DatePicker/__snapshots__/DatePicker.test.tsx.snap
+++ b/packages/core/src/components/DatePicker/__snapshots__/DatePicker.test.tsx.snap
@@ -884,6 +884,7 @@ exports[`DatePicker component popover placement should render properly with "bot
   letter-spacing: 0rem;
   line-height: 1.6rem;
   text-align: initial;
+  display: inline-block;
 }
 
 .c13 {
@@ -897,6 +898,7 @@ exports[`DatePicker component popover placement should render properly with "bot
   letter-spacing: 0rem;
   line-height: 2.2rem;
   text-align: initial;
+  display: inline-block;
 }
 
 .c16 {
@@ -910,6 +912,7 @@ exports[`DatePicker component popover placement should render properly with "bot
   letter-spacing: 0rem;
   line-height: 2.2rem;
   text-align: initial;
+  display: inline-block;
 }
 
 .c1 {
@@ -1922,6 +1925,7 @@ exports[`DatePicker component popover placement should render properly with "bot
   letter-spacing: 0rem;
   line-height: 1.6rem;
   text-align: initial;
+  display: inline-block;
 }
 
 .c13 {
@@ -1935,6 +1939,7 @@ exports[`DatePicker component popover placement should render properly with "bot
   letter-spacing: 0rem;
   line-height: 2.2rem;
   text-align: initial;
+  display: inline-block;
 }
 
 .c16 {
@@ -1948,6 +1953,7 @@ exports[`DatePicker component popover placement should render properly with "bot
   letter-spacing: 0rem;
   line-height: 2.2rem;
   text-align: initial;
+  display: inline-block;
 }
 
 .c1 {
@@ -2957,6 +2963,7 @@ exports[`DatePicker component popover placement should render properly with "bot
   letter-spacing: 0rem;
   line-height: 1.6rem;
   text-align: initial;
+  display: inline-block;
 }
 
 .c13 {
@@ -2970,6 +2977,7 @@ exports[`DatePicker component popover placement should render properly with "bot
   letter-spacing: 0rem;
   line-height: 2.2rem;
   text-align: initial;
+  display: inline-block;
 }
 
 .c16 {
@@ -2983,6 +2991,7 @@ exports[`DatePicker component popover placement should render properly with "bot
   letter-spacing: 0rem;
   line-height: 2.2rem;
   text-align: initial;
+  display: inline-block;
 }
 
 .c1 {
@@ -3992,6 +4001,7 @@ exports[`DatePicker component popover placement should render properly with "lef
   letter-spacing: 0rem;
   line-height: 1.6rem;
   text-align: initial;
+  display: inline-block;
 }
 
 .c13 {
@@ -4005,6 +4015,7 @@ exports[`DatePicker component popover placement should render properly with "lef
   letter-spacing: 0rem;
   line-height: 2.2rem;
   text-align: initial;
+  display: inline-block;
 }
 
 .c16 {
@@ -4018,6 +4029,7 @@ exports[`DatePicker component popover placement should render properly with "lef
   letter-spacing: 0rem;
   line-height: 2.2rem;
   text-align: initial;
+  display: inline-block;
 }
 
 .c1 {
@@ -5029,6 +5041,7 @@ exports[`DatePicker component popover placement should render properly with "lef
   letter-spacing: 0rem;
   line-height: 1.6rem;
   text-align: initial;
+  display: inline-block;
 }
 
 .c13 {
@@ -5042,6 +5055,7 @@ exports[`DatePicker component popover placement should render properly with "lef
   letter-spacing: 0rem;
   line-height: 2.2rem;
   text-align: initial;
+  display: inline-block;
 }
 
 .c16 {
@@ -5055,6 +5069,7 @@ exports[`DatePicker component popover placement should render properly with "lef
   letter-spacing: 0rem;
   line-height: 2.2rem;
   text-align: initial;
+  display: inline-block;
 }
 
 .c1 {
@@ -6063,6 +6078,7 @@ exports[`DatePicker component popover placement should render properly with "lef
   letter-spacing: 0rem;
   line-height: 1.6rem;
   text-align: initial;
+  display: inline-block;
 }
 
 .c13 {
@@ -6076,6 +6092,7 @@ exports[`DatePicker component popover placement should render properly with "lef
   letter-spacing: 0rem;
   line-height: 2.2rem;
   text-align: initial;
+  display: inline-block;
 }
 
 .c16 {
@@ -6089,6 +6106,7 @@ exports[`DatePicker component popover placement should render properly with "lef
   letter-spacing: 0rem;
   line-height: 2.2rem;
   text-align: initial;
+  display: inline-block;
 }
 
 .c1 {
@@ -7097,6 +7115,7 @@ exports[`DatePicker component popover placement should render properly with "rig
   letter-spacing: 0rem;
   line-height: 1.6rem;
   text-align: initial;
+  display: inline-block;
 }
 
 .c13 {
@@ -7110,6 +7129,7 @@ exports[`DatePicker component popover placement should render properly with "rig
   letter-spacing: 0rem;
   line-height: 2.2rem;
   text-align: initial;
+  display: inline-block;
 }
 
 .c16 {
@@ -7123,6 +7143,7 @@ exports[`DatePicker component popover placement should render properly with "rig
   letter-spacing: 0rem;
   line-height: 2.2rem;
   text-align: initial;
+  display: inline-block;
 }
 
 .c1 {
@@ -8134,6 +8155,7 @@ exports[`DatePicker component popover placement should render properly with "rig
   letter-spacing: 0rem;
   line-height: 1.6rem;
   text-align: initial;
+  display: inline-block;
 }
 
 .c13 {
@@ -8147,6 +8169,7 @@ exports[`DatePicker component popover placement should render properly with "rig
   letter-spacing: 0rem;
   line-height: 2.2rem;
   text-align: initial;
+  display: inline-block;
 }
 
 .c16 {
@@ -8160,6 +8183,7 @@ exports[`DatePicker component popover placement should render properly with "rig
   letter-spacing: 0rem;
   line-height: 2.2rem;
   text-align: initial;
+  display: inline-block;
 }
 
 .c1 {
@@ -9168,6 +9192,7 @@ exports[`DatePicker component popover placement should render properly with "rig
   letter-spacing: 0rem;
   line-height: 1.6rem;
   text-align: initial;
+  display: inline-block;
 }
 
 .c13 {
@@ -9181,6 +9206,7 @@ exports[`DatePicker component popover placement should render properly with "rig
   letter-spacing: 0rem;
   line-height: 2.2rem;
   text-align: initial;
+  display: inline-block;
 }
 
 .c16 {
@@ -9194,6 +9220,7 @@ exports[`DatePicker component popover placement should render properly with "rig
   letter-spacing: 0rem;
   line-height: 2.2rem;
   text-align: initial;
+  display: inline-block;
 }
 
 .c1 {
@@ -10202,6 +10229,7 @@ exports[`DatePicker component popover placement should render properly with "top
   letter-spacing: 0rem;
   line-height: 1.6rem;
   text-align: initial;
+  display: inline-block;
 }
 
 .c13 {
@@ -10215,6 +10243,7 @@ exports[`DatePicker component popover placement should render properly with "top
   letter-spacing: 0rem;
   line-height: 2.2rem;
   text-align: initial;
+  display: inline-block;
 }
 
 .c16 {
@@ -10228,6 +10257,7 @@ exports[`DatePicker component popover placement should render properly with "top
   letter-spacing: 0rem;
   line-height: 2.2rem;
   text-align: initial;
+  display: inline-block;
 }
 
 .c1 {
@@ -11239,6 +11269,7 @@ exports[`DatePicker component popover placement should render properly with "top
   letter-spacing: 0rem;
   line-height: 1.6rem;
   text-align: initial;
+  display: inline-block;
 }
 
 .c13 {
@@ -11252,6 +11283,7 @@ exports[`DatePicker component popover placement should render properly with "top
   letter-spacing: 0rem;
   line-height: 2.2rem;
   text-align: initial;
+  display: inline-block;
 }
 
 .c16 {
@@ -11265,6 +11297,7 @@ exports[`DatePicker component popover placement should render properly with "top
   letter-spacing: 0rem;
   line-height: 2.2rem;
   text-align: initial;
+  display: inline-block;
 }
 
 .c1 {
@@ -12273,6 +12306,7 @@ exports[`DatePicker component popover placement should render properly with "top
   letter-spacing: 0rem;
   line-height: 1.6rem;
   text-align: initial;
+  display: inline-block;
 }
 
 .c13 {
@@ -12286,6 +12320,7 @@ exports[`DatePicker component popover placement should render properly with "top
   letter-spacing: 0rem;
   line-height: 2.2rem;
   text-align: initial;
+  display: inline-block;
 }
 
 .c16 {
@@ -12299,6 +12334,7 @@ exports[`DatePicker component popover placement should render properly with "top
   letter-spacing: 0rem;
   line-height: 2.2rem;
   text-align: initial;
+  display: inline-block;
 }
 
 .c1 {

--- a/packages/core/src/components/DateRangePicker/__snapshots__/DateRangePicker.test.tsx.snap
+++ b/packages/core/src/components/DateRangePicker/__snapshots__/DateRangePicker.test.tsx.snap
@@ -12,6 +12,7 @@ exports[`DateRangePicker Custom date range options popover placement should rend
   letter-spacing: 0rem;
   line-height: 2.6rem;
   text-align: initial;
+  display: inline-block;
 }
 
 .c2 {
@@ -165,6 +166,7 @@ exports[`DateRangePicker Custom date range options popover placement should rend
   letter-spacing: 0rem;
   line-height: 2.6rem;
   text-align: initial;
+  display: inline-block;
 }
 
 .c2 {
@@ -315,6 +317,7 @@ exports[`DateRangePicker Custom date range options popover placement should rend
   letter-spacing: 0rem;
   line-height: 2.6rem;
   text-align: initial;
+  display: inline-block;
 }
 
 .c2 {
@@ -465,6 +468,7 @@ exports[`DateRangePicker Custom date range options popover placement should rend
   letter-spacing: 0rem;
   line-height: 2.6rem;
   text-align: initial;
+  display: inline-block;
 }
 
 .c2 {
@@ -618,6 +622,7 @@ exports[`DateRangePicker Custom date range options popover placement should rend
   letter-spacing: 0rem;
   line-height: 2.6rem;
   text-align: initial;
+  display: inline-block;
 }
 
 .c2 {
@@ -768,6 +773,7 @@ exports[`DateRangePicker Custom date range options popover placement should rend
   letter-spacing: 0rem;
   line-height: 2.6rem;
   text-align: initial;
+  display: inline-block;
 }
 
 .c2 {
@@ -918,6 +924,7 @@ exports[`DateRangePicker Custom date range options popover placement should rend
   letter-spacing: 0rem;
   line-height: 2.6rem;
   text-align: initial;
+  display: inline-block;
 }
 
 .c2 {
@@ -1071,6 +1078,7 @@ exports[`DateRangePicker Custom date range options popover placement should rend
   letter-spacing: 0rem;
   line-height: 2.6rem;
   text-align: initial;
+  display: inline-block;
 }
 
 .c2 {
@@ -1221,6 +1229,7 @@ exports[`DateRangePicker Custom date range options popover placement should rend
   letter-spacing: 0rem;
   line-height: 2.6rem;
   text-align: initial;
+  display: inline-block;
 }
 
 .c2 {
@@ -1371,6 +1380,7 @@ exports[`DateRangePicker Custom date range options popover placement should rend
   letter-spacing: 0rem;
   line-height: 2.6rem;
   text-align: initial;
+  display: inline-block;
 }
 
 .c2 {
@@ -1524,6 +1534,7 @@ exports[`DateRangePicker Custom date range options popover placement should rend
   letter-spacing: 0rem;
   line-height: 2.6rem;
   text-align: initial;
+  display: inline-block;
 }
 
 .c2 {
@@ -1674,6 +1685,7 @@ exports[`DateRangePicker Custom date range options popover placement should rend
   letter-spacing: 0rem;
   line-height: 2.6rem;
   text-align: initial;
+  display: inline-block;
 }
 
 .c2 {
@@ -2031,6 +2043,7 @@ exports[`DateRangePicker Custom date range options should render properly with c
   letter-spacing: 0rem;
   line-height: 2.6rem;
   text-align: initial;
+  display: inline-block;
 }
 
 .c17 {
@@ -2497,6 +2510,7 @@ exports[`DateRangePicker popover placement should render properly with "bottom" 
   letter-spacing: 0rem;
   line-height: 2.6rem;
   text-align: center;
+  display: inline-block;
 }
 
 .c13 {
@@ -2510,6 +2524,7 @@ exports[`DateRangePicker popover placement should render properly with "bottom" 
   letter-spacing: 0rem;
   line-height: 2.2rem;
   text-align: initial;
+  display: inline-block;
 }
 
 .c22 {
@@ -2523,6 +2538,7 @@ exports[`DateRangePicker popover placement should render properly with "bottom" 
   letter-spacing: 0rem;
   line-height: 2.2rem;
   text-align: initial;
+  display: inline-block;
 }
 
 .c3 {
@@ -4300,6 +4316,7 @@ exports[`DateRangePicker popover placement should render properly with "bottom-e
   letter-spacing: 0rem;
   line-height: 2.6rem;
   text-align: center;
+  display: inline-block;
 }
 
 .c13 {
@@ -4313,6 +4330,7 @@ exports[`DateRangePicker popover placement should render properly with "bottom-e
   letter-spacing: 0rem;
   line-height: 2.2rem;
   text-align: initial;
+  display: inline-block;
 }
 
 .c22 {
@@ -4326,6 +4344,7 @@ exports[`DateRangePicker popover placement should render properly with "bottom-e
   letter-spacing: 0rem;
   line-height: 2.2rem;
   text-align: initial;
+  display: inline-block;
 }
 
 .c3 {
@@ -6100,6 +6119,7 @@ exports[`DateRangePicker popover placement should render properly with "bottom-s
   letter-spacing: 0rem;
   line-height: 2.6rem;
   text-align: center;
+  display: inline-block;
 }
 
 .c13 {
@@ -6113,6 +6133,7 @@ exports[`DateRangePicker popover placement should render properly with "bottom-s
   letter-spacing: 0rem;
   line-height: 2.2rem;
   text-align: initial;
+  display: inline-block;
 }
 
 .c22 {
@@ -6126,6 +6147,7 @@ exports[`DateRangePicker popover placement should render properly with "bottom-s
   letter-spacing: 0rem;
   line-height: 2.2rem;
   text-align: initial;
+  display: inline-block;
 }
 
 .c3 {
@@ -7900,6 +7922,7 @@ exports[`DateRangePicker popover placement should render properly with "left" po
   letter-spacing: 0rem;
   line-height: 2.6rem;
   text-align: center;
+  display: inline-block;
 }
 
 .c13 {
@@ -7913,6 +7936,7 @@ exports[`DateRangePicker popover placement should render properly with "left" po
   letter-spacing: 0rem;
   line-height: 2.2rem;
   text-align: initial;
+  display: inline-block;
 }
 
 .c22 {
@@ -7926,6 +7950,7 @@ exports[`DateRangePicker popover placement should render properly with "left" po
   letter-spacing: 0rem;
   line-height: 2.2rem;
   text-align: initial;
+  display: inline-block;
 }
 
 .c3 {
@@ -9702,6 +9727,7 @@ exports[`DateRangePicker popover placement should render properly with "left-end
   letter-spacing: 0rem;
   line-height: 2.6rem;
   text-align: center;
+  display: inline-block;
 }
 
 .c13 {
@@ -9715,6 +9741,7 @@ exports[`DateRangePicker popover placement should render properly with "left-end
   letter-spacing: 0rem;
   line-height: 2.2rem;
   text-align: initial;
+  display: inline-block;
 }
 
 .c22 {
@@ -9728,6 +9755,7 @@ exports[`DateRangePicker popover placement should render properly with "left-end
   letter-spacing: 0rem;
   line-height: 2.2rem;
   text-align: initial;
+  display: inline-block;
 }
 
 .c3 {
@@ -11501,6 +11529,7 @@ exports[`DateRangePicker popover placement should render properly with "left-sta
   letter-spacing: 0rem;
   line-height: 2.6rem;
   text-align: center;
+  display: inline-block;
 }
 
 .c13 {
@@ -11514,6 +11543,7 @@ exports[`DateRangePicker popover placement should render properly with "left-sta
   letter-spacing: 0rem;
   line-height: 2.2rem;
   text-align: initial;
+  display: inline-block;
 }
 
 .c22 {
@@ -11527,6 +11557,7 @@ exports[`DateRangePicker popover placement should render properly with "left-sta
   letter-spacing: 0rem;
   line-height: 2.2rem;
   text-align: initial;
+  display: inline-block;
 }
 
 .c3 {
@@ -13300,6 +13331,7 @@ exports[`DateRangePicker popover placement should render properly with "right" p
   letter-spacing: 0rem;
   line-height: 2.6rem;
   text-align: center;
+  display: inline-block;
 }
 
 .c13 {
@@ -13313,6 +13345,7 @@ exports[`DateRangePicker popover placement should render properly with "right" p
   letter-spacing: 0rem;
   line-height: 2.2rem;
   text-align: initial;
+  display: inline-block;
 }
 
 .c22 {
@@ -13326,6 +13359,7 @@ exports[`DateRangePicker popover placement should render properly with "right" p
   letter-spacing: 0rem;
   line-height: 2.2rem;
   text-align: initial;
+  display: inline-block;
 }
 
 .c3 {
@@ -15102,6 +15136,7 @@ exports[`DateRangePicker popover placement should render properly with "right-en
   letter-spacing: 0rem;
   line-height: 2.6rem;
   text-align: center;
+  display: inline-block;
 }
 
 .c13 {
@@ -15115,6 +15150,7 @@ exports[`DateRangePicker popover placement should render properly with "right-en
   letter-spacing: 0rem;
   line-height: 2.2rem;
   text-align: initial;
+  display: inline-block;
 }
 
 .c22 {
@@ -15128,6 +15164,7 @@ exports[`DateRangePicker popover placement should render properly with "right-en
   letter-spacing: 0rem;
   line-height: 2.2rem;
   text-align: initial;
+  display: inline-block;
 }
 
 .c3 {
@@ -16901,6 +16938,7 @@ exports[`DateRangePicker popover placement should render properly with "right-st
   letter-spacing: 0rem;
   line-height: 2.6rem;
   text-align: center;
+  display: inline-block;
 }
 
 .c13 {
@@ -16914,6 +16952,7 @@ exports[`DateRangePicker popover placement should render properly with "right-st
   letter-spacing: 0rem;
   line-height: 2.2rem;
   text-align: initial;
+  display: inline-block;
 }
 
 .c22 {
@@ -16927,6 +16966,7 @@ exports[`DateRangePicker popover placement should render properly with "right-st
   letter-spacing: 0rem;
   line-height: 2.2rem;
   text-align: initial;
+  display: inline-block;
 }
 
 .c3 {
@@ -18700,6 +18740,7 @@ exports[`DateRangePicker popover placement should render properly with "top" pos
   letter-spacing: 0rem;
   line-height: 2.6rem;
   text-align: center;
+  display: inline-block;
 }
 
 .c13 {
@@ -18713,6 +18754,7 @@ exports[`DateRangePicker popover placement should render properly with "top" pos
   letter-spacing: 0rem;
   line-height: 2.2rem;
   text-align: initial;
+  display: inline-block;
 }
 
 .c22 {
@@ -18726,6 +18768,7 @@ exports[`DateRangePicker popover placement should render properly with "top" pos
   letter-spacing: 0rem;
   line-height: 2.2rem;
   text-align: initial;
+  display: inline-block;
 }
 
 .c3 {
@@ -20502,6 +20545,7 @@ exports[`DateRangePicker popover placement should render properly with "top-end"
   letter-spacing: 0rem;
   line-height: 2.6rem;
   text-align: center;
+  display: inline-block;
 }
 
 .c13 {
@@ -20515,6 +20559,7 @@ exports[`DateRangePicker popover placement should render properly with "top-end"
   letter-spacing: 0rem;
   line-height: 2.2rem;
   text-align: initial;
+  display: inline-block;
 }
 
 .c22 {
@@ -20528,6 +20573,7 @@ exports[`DateRangePicker popover placement should render properly with "top-end"
   letter-spacing: 0rem;
   line-height: 2.2rem;
   text-align: initial;
+  display: inline-block;
 }
 
 .c3 {
@@ -22301,6 +22347,7 @@ exports[`DateRangePicker popover placement should render properly with "top-star
   letter-spacing: 0rem;
   line-height: 2.6rem;
   text-align: center;
+  display: inline-block;
 }
 
 .c13 {
@@ -22314,6 +22361,7 @@ exports[`DateRangePicker popover placement should render properly with "top-star
   letter-spacing: 0rem;
   line-height: 2.2rem;
   text-align: initial;
+  display: inline-block;
 }
 
 .c22 {
@@ -22327,6 +22375,7 @@ exports[`DateRangePicker popover placement should render properly with "top-star
   letter-spacing: 0rem;
   line-height: 2.2rem;
   text-align: initial;
+  display: inline-block;
 }
 
 .c3 {
@@ -24307,6 +24356,7 @@ exports[`DateRangePicker should render properly 1`] = `
   letter-spacing: 0rem;
   line-height: 2.6rem;
   text-align: center;
+  display: inline-block;
 }
 
 .c27 {
@@ -24320,6 +24370,7 @@ exports[`DateRangePicker should render properly 1`] = `
   letter-spacing: 0rem;
   line-height: 2.2rem;
   text-align: initial;
+  display: inline-block;
 }
 
 .c36 {
@@ -24333,6 +24384,7 @@ exports[`DateRangePicker should render properly 1`] = `
   letter-spacing: 0rem;
   line-height: 2.2rem;
   text-align: initial;
+  display: inline-block;
 }
 
 .c18 {
@@ -26592,6 +26644,7 @@ exports[`DateRangePicker should render properly with single month 1`] = `
   letter-spacing: 0rem;
   line-height: 1.6rem;
   text-align: initial;
+  display: inline-block;
 }
 
 .c32 {
@@ -26605,6 +26658,7 @@ exports[`DateRangePicker should render properly with single month 1`] = `
   letter-spacing: 0rem;
   line-height: 2.2rem;
   text-align: initial;
+  display: inline-block;
 }
 
 .c41 {
@@ -26618,6 +26672,7 @@ exports[`DateRangePicker should render properly with single month 1`] = `
   letter-spacing: 0rem;
   line-height: 2.2rem;
   text-align: initial;
+  display: inline-block;
 }
 
 .c26 {

--- a/packages/core/src/components/FieldWithLabel/__snapshots__/FieldWithLabel.test.tsx.snap
+++ b/packages/core/src/components/FieldWithLabel/__snapshots__/FieldWithLabel.test.tsx.snap
@@ -12,6 +12,7 @@ exports[`FieldWithLabel component should render properly when lable is not prese
   letter-spacing: 0rem;
   line-height: 2.2rem;
   text-align: initial;
+  display: inline-block;
 }
 
 .c2 {
@@ -98,6 +99,7 @@ exports[`FieldWithLabel component should render properly with props labelPositio
   letter-spacing: 0rem;
   line-height: 2.2rem;
   text-align: initial;
+  display: inline-block;
 }
 
 .c4 {
@@ -198,6 +200,7 @@ exports[`FieldWithLabel component should render properly with props labelPositio
   letter-spacing: 0rem;
   line-height: 2.2rem;
   text-align: initial;
+  display: inline-block;
 }
 
 .c4 {
@@ -299,6 +302,7 @@ exports[`FieldWithLabel component should render properly with props labelPositio
   letter-spacing: 0rem;
   line-height: 2.2rem;
   text-align: initial;
+  display: inline-block;
 }
 
 .c4 {
@@ -400,6 +404,7 @@ exports[`FieldWithLabel component should render properly with props labelPositio
   letter-spacing: 0rem;
   line-height: 2.2rem;
   text-align: initial;
+  display: inline-block;
 }
 
 .c4 {

--- a/packages/core/src/components/FileInput/__snapshots__/FileInput.test.tsx.snap
+++ b/packages/core/src/components/FileInput/__snapshots__/FileInput.test.tsx.snap
@@ -30,6 +30,7 @@ exports[`FileInput component should render properly with all props 1`] = `
   letter-spacing: 0rem;
   line-height: 2.2rem;
   text-align: initial;
+  display: inline-block;
 }
 
 .c2 {

--- a/packages/core/src/components/Input/__snapshots__/Input.test.tsx.snap
+++ b/packages/core/src/components/Input/__snapshots__/Input.test.tsx.snap
@@ -25,6 +25,7 @@ exports[`Input component should render correctly when fullWidth & required props
   letter-spacing: 0rem;
   line-height: 2.2rem;
   text-align: initial;
+  display: inline-block;
 }
 
 .c2 {
@@ -469,6 +470,7 @@ exports[`Input component should render correctly with all the props given 1`] = 
   letter-spacing: 0rem;
   line-height: 2.2rem;
   text-align: initial;
+  display: inline-block;
 }
 
 .c2 {

--- a/packages/core/src/components/Link/__snapshots__/Link.test.tsx.snap
+++ b/packages/core/src/components/Link/__snapshots__/Link.test.tsx.snap
@@ -12,6 +12,7 @@ exports[`Link Component should render with component as child 1`] = `
   letter-spacing: 0rem;
   line-height: 2.2rem;
   text-align: initial;
+  display: inline-block;
 }
 
 .c0 {
@@ -59,6 +60,7 @@ exports[`Link Component should render with default props 1`] = `
   letter-spacing: 0rem;
   line-height: 2.2rem;
   text-align: initial;
+  display: inline-block;
 }
 
 .c0 {

--- a/packages/core/src/components/MultiSelect/__snapshots__/MultiSelect.test.tsx.snap
+++ b/packages/core/src/components/MultiSelect/__snapshots__/MultiSelect.test.tsx.snap
@@ -308,6 +308,7 @@ exports[`MultiSelect component should render correctly with all the props given 
   letter-spacing: 0rem;
   line-height: 2.6rem;
   text-align: initial;
+  display: inline-block;
 }
 
 .c14 {
@@ -1240,6 +1241,7 @@ exports[`MultiSelect component should render properly with M size 1`] = `
   letter-spacing: 0rem;
   line-height: 2.6rem;
   text-align: initial;
+  display: inline-block;
 }
 
 .c10 {
@@ -1875,6 +1877,7 @@ exports[`MultiSelect component should render properly with S size 1`] = `
   letter-spacing: 0rem;
   line-height: 2.2rem;
   text-align: initial;
+  display: inline-block;
 }
 
 .c10 {

--- a/packages/core/src/components/Pagination/__snapshots__/Pagination.test.tsx.snap
+++ b/packages/core/src/components/Pagination/__snapshots__/Pagination.test.tsx.snap
@@ -199,6 +199,7 @@ exports[`Pagination component should render correctly with all the default props
   letter-spacing: 0rem;
   line-height: 2.2rem;
   text-align: center;
+  display: inline-block;
 }
 
 .c10 {
@@ -555,6 +556,7 @@ exports[`Pagination component should render correctly with all the props given 1
   letter-spacing: 0rem;
   line-height: 2.2rem;
   text-align: center;
+  display: inline-block;
 }
 
 .c7 {

--- a/packages/core/src/components/Radio/__snapshots__/radio.test.tsx.snap
+++ b/packages/core/src/components/Radio/__snapshots__/radio.test.tsx.snap
@@ -12,6 +12,7 @@ exports[`Radio component should render correctly with bottom labelPosition 1`] =
   letter-spacing: 0rem;
   line-height: 2.2rem;
   text-align: initial;
+  display: inline-block;
 }
 
 .c2 {
@@ -942,6 +943,7 @@ exports[`Radio component should render correctly with left labelPosition 1`] = `
   letter-spacing: 0rem;
   line-height: 2.2rem;
   text-align: initial;
+  display: inline-block;
 }
 
 .c2 {
@@ -1105,6 +1107,7 @@ exports[`Radio component should render correctly with right labelPosition 1`] = 
   letter-spacing: 0rem;
   line-height: 2.2rem;
   text-align: initial;
+  display: inline-block;
 }
 
 .c2 {
@@ -1268,6 +1271,7 @@ exports[`Radio component should render correctly with top labelPosition 1`] = `
   letter-spacing: 0rem;
   line-height: 2.2rem;
   text-align: initial;
+  display: inline-block;
 }
 
 .c2 {

--- a/packages/core/src/components/RadioGroup/__snapshots__/RadioGroup.test.tsx.snap
+++ b/packages/core/src/components/RadioGroup/__snapshots__/RadioGroup.test.tsx.snap
@@ -12,6 +12,7 @@ exports[`Radio Group should render disabled state properly 1`] = `
   letter-spacing: 0rem;
   line-height: 2.6rem;
   text-align: initial;
+  display: inline-block;
 }
 
 .c6 {
@@ -25,6 +26,7 @@ exports[`Radio Group should render disabled state properly 1`] = `
   letter-spacing: 0rem;
   line-height: 2.2rem;
   text-align: initial;
+  display: inline-block;
 }
 
 .c0 {
@@ -279,6 +281,7 @@ exports[`Radio Group should render properly 1`] = `
   letter-spacing: 0rem;
   line-height: 2.6rem;
   text-align: initial;
+  display: inline-block;
 }
 
 .c6 {
@@ -292,6 +295,7 @@ exports[`Radio Group should render properly 1`] = `
   letter-spacing: 0rem;
   line-height: 2.2rem;
   text-align: initial;
+  display: inline-block;
 }
 
 .c0 {

--- a/packages/core/src/components/SearchBox/__snapshots__/SearchBox.test.tsx.snap
+++ b/packages/core/src/components/SearchBox/__snapshots__/SearchBox.test.tsx.snap
@@ -27,6 +27,7 @@ exports[`SearchBox options should render options when user search option specifi
   letter-spacing: 0rem;
   line-height: 2.2rem;
   text-align: initial;
+  display: inline-block;
 }
 
 .c10 {

--- a/packages/core/src/components/SingleSelect/__snapshots__/SingleSelect.test.tsx.snap
+++ b/packages/core/src/components/SingleSelect/__snapshots__/SingleSelect.test.tsx.snap
@@ -790,6 +790,7 @@ exports[`SingleSelect component should render properly with M size 1`] = `
   letter-spacing: 0rem;
   line-height: 2.6rem;
   text-align: initial;
+  display: inline-block;
 }
 
 .c0 {
@@ -885,6 +886,7 @@ exports[`SingleSelect component should render properly with S size 1`] = `
   letter-spacing: 0rem;
   line-height: 2.2rem;
   text-align: initial;
+  display: inline-block;
 }
 
 .c0 {
@@ -980,6 +982,7 @@ exports[`SingleSelect component should take passed max width 1`] = `
   letter-spacing: 0rem;
   line-height: 2.6rem;
   text-align: initial;
+  display: inline-block;
 }
 
 .c9 {
@@ -1920,6 +1923,7 @@ exports[`SingleSelect component with filled variant should render options correc
   letter-spacing: 0rem;
   line-height: 2.6rem;
   text-align: initial;
+  display: inline-block;
 }
 
 .c5 {
@@ -2469,6 +2473,7 @@ exports[`SingleSelect component with filled variant should render properly when 
   letter-spacing: 0rem;
   line-height: 2.6rem;
   text-align: initial;
+  display: inline-block;
 }
 
 .c19 {
@@ -2482,6 +2487,7 @@ exports[`SingleSelect component with filled variant should render properly when 
   letter-spacing: 0rem;
   line-height: 2.6rem;
   text-align: initial;
+  display: inline-block;
 }
 
 .c21 {
@@ -2495,6 +2501,7 @@ exports[`SingleSelect component with filled variant should render properly when 
   letter-spacing: 0rem;
   line-height: 2.2rem;
   text-align: initial;
+  display: inline-block;
 }
 
 .c9 {
@@ -3569,6 +3576,7 @@ exports[`SingleSelect component with flat variant should render disabled state p
   letter-spacing: 0rem;
   line-height: 1.6rem;
   text-align: initial;
+  display: inline-block;
 }
 
 .c4 {
@@ -3811,6 +3819,7 @@ exports[`SingleSelect component with flat variant should render options correctl
   letter-spacing: 0rem;
   line-height: 1.6rem;
   text-align: initial;
+  display: inline-block;
 }
 
 .c5 {
@@ -3971,6 +3980,7 @@ exports[`SingleSelect component with flat variant should render properly 1`] = `
   letter-spacing: 0rem;
   line-height: 1.6rem;
   text-align: initial;
+  display: inline-block;
 }
 
 .c4 {
@@ -4199,6 +4209,7 @@ exports[`SingleSelect component with flat variant should render properly when op
   letter-spacing: 0rem;
   line-height: 1.6rem;
   text-align: initial;
+  display: inline-block;
 }
 
 .c13 {
@@ -4212,6 +4223,7 @@ exports[`SingleSelect component with flat variant should render properly when op
   letter-spacing: 0rem;
   line-height: 1.6rem;
   text-align: initial;
+  display: inline-block;
 }
 
 .c16 {
@@ -4225,6 +4237,7 @@ exports[`SingleSelect component with flat variant should render properly when op
   letter-spacing: 0rem;
   line-height: 2.2rem;
   text-align: initial;
+  display: inline-block;
 }
 
 .c8 {
@@ -4710,6 +4723,7 @@ exports[`SingleSelect component with flat variant should render with label prope
   letter-spacing: 0rem;
   line-height: 1.6rem;
   text-align: initial;
+  display: inline-block;
 }
 
 .c6 {
@@ -5385,6 +5399,7 @@ exports[`SingleSelect component with fusion variant should render options correc
   letter-spacing: 0rem;
   line-height: 2.6rem;
   text-align: initial;
+  display: inline-block;
 }
 
 .c5 {
@@ -5971,6 +5986,7 @@ exports[`SingleSelect component with fusion variant should render properly when 
   letter-spacing: 0rem;
   line-height: 2.6rem;
   text-align: initial;
+  display: inline-block;
 }
 
 .c19 {
@@ -5984,6 +6000,7 @@ exports[`SingleSelect component with fusion variant should render properly when 
   letter-spacing: 0rem;
   line-height: 2.6rem;
   text-align: initial;
+  display: inline-block;
 }
 
 .c21 {
@@ -5997,6 +6014,7 @@ exports[`SingleSelect component with fusion variant should render properly when 
   letter-spacing: 0rem;
   line-height: 2.2rem;
   text-align: initial;
+  display: inline-block;
 }
 
 .c9 {
@@ -7537,6 +7555,7 @@ exports[`SingleSelect component with outlined variant should render options corr
   letter-spacing: 0rem;
   line-height: 2.6rem;
   text-align: initial;
+  display: inline-block;
 }
 
 .c5 {
@@ -8107,6 +8126,7 @@ exports[`SingleSelect component with outlined variant should render properly whe
   letter-spacing: 0rem;
   line-height: 2.6rem;
   text-align: initial;
+  display: inline-block;
 }
 
 .c19 {
@@ -8120,6 +8140,7 @@ exports[`SingleSelect component with outlined variant should render properly whe
   letter-spacing: 0rem;
   line-height: 2.6rem;
   text-align: initial;
+  display: inline-block;
 }
 
 .c21 {
@@ -8133,6 +8154,7 @@ exports[`SingleSelect component with outlined variant should render properly whe
   letter-spacing: 0rem;
   line-height: 2.2rem;
   text-align: initial;
+  display: inline-block;
 }
 
 .c9 {

--- a/packages/core/src/components/Stepper/__snapshots__/Stepper.test.tsx.snap
+++ b/packages/core/src/components/Stepper/__snapshots__/Stepper.test.tsx.snap
@@ -13,6 +13,7 @@ exports[`Stepper component should change active step when click on any step 1`] 
   line-height: 2.2rem;
   text-align: initial;
   text-transform: uppercase;
+  display: inline-block;
 }
 
 .c6 {
@@ -26,6 +27,7 @@ exports[`Stepper component should change active step when click on any step 1`] 
   letter-spacing: 0rem;
   line-height: 2.2rem;
   text-align: initial;
+  display: inline-block;
 }
 
 .c3 {
@@ -192,6 +194,7 @@ exports[`Stepper component should render correctly with all the default props 1`
   line-height: 2.2rem;
   text-align: initial;
   text-transform: uppercase;
+  display: inline-block;
 }
 
 .c6 {
@@ -205,6 +208,7 @@ exports[`Stepper component should render correctly with all the default props 1`
   letter-spacing: 0rem;
   line-height: 2.2rem;
   text-align: initial;
+  display: inline-block;
 }
 
 .c3 {
@@ -367,6 +371,7 @@ exports[`Stepper component should render correctly with all the props given 1`] 
   line-height: 2.2rem;
   text-align: initial;
   text-transform: uppercase;
+  display: inline-block;
 }
 
 .c6 {
@@ -380,6 +385,7 @@ exports[`Stepper component should render correctly with all the props given 1`] 
   letter-spacing: 0rem;
   line-height: 2.2rem;
   text-align: initial;
+  display: inline-block;
 }
 
 .c3 {

--- a/packages/core/src/components/Table/ActionBar/__snapshots__/ActionBar.test.tsx.snap
+++ b/packages/core/src/components/Table/ActionBar/__snapshots__/ActionBar.test.tsx.snap
@@ -27,6 +27,7 @@ exports[`ActionBar component should not render Action bar with passed parameters
   letter-spacing: 0rem;
   line-height: 2.2rem;
   text-align: initial;
+  display: inline-block;
 }
 
 .c9 {
@@ -40,6 +41,7 @@ exports[`ActionBar component should not render Action bar with passed parameters
   letter-spacing: 0rem;
   line-height: 1.6rem;
   text-align: initial;
+  display: inline-block;
 }
 
 .c4 {
@@ -341,6 +343,7 @@ exports[`ActionBar component should render correctly with all the default props 
   letter-spacing: 0rem;
   line-height: 2.2rem;
   text-align: initial;
+  display: inline-block;
 }
 
 .c9 {
@@ -354,6 +357,7 @@ exports[`ActionBar component should render correctly with all the default props 
   letter-spacing: 0rem;
   line-height: 1.6rem;
   text-align: initial;
+  display: inline-block;
 }
 
 .c4 {

--- a/packages/core/src/components/Table/Body/Cell/__snapshots__/Cell.test.tsx.snap
+++ b/packages/core/src/components/Table/Body/Cell/__snapshots__/Cell.test.tsx.snap
@@ -12,6 +12,7 @@ exports[`Cell should not render text if hidden property is given 1`] = `
   letter-spacing: 0rem;
   line-height: 2.2rem;
   text-align: initial;
+  display: inline-block;
 }
 
 .c0 {
@@ -81,6 +82,7 @@ exports[`Cell should render checkbox properly 1`] = `
   letter-spacing: 0rem;
   line-height: 2.2rem;
   text-align: initial;
+  display: inline-block;
 }
 
 .c4 {
@@ -300,6 +302,7 @@ exports[`Cell should render frozen text properly 1`] = `
   letter-spacing: 0rem;
   line-height: 2.2rem;
   text-align: initial;
+  display: inline-block;
 }
 
 .c0 {
@@ -361,6 +364,7 @@ exports[`Cell should render text properly 1`] = `
   letter-spacing: 0rem;
   line-height: 2.2rem;
   text-align: initial;
+  display: inline-block;
 }
 
 .c0 {
@@ -414,6 +418,7 @@ exports[`Cell should render tooltip properly 1`] = `
   letter-spacing: 0rem;
   line-height: 2.2rem;
   text-align: initial;
+  display: inline-block;
 }
 
 .c0 {

--- a/packages/core/src/components/Table/Foot/__snapshots__/Foot.test.tsx.snap
+++ b/packages/core/src/components/Table/Foot/__snapshots__/Foot.test.tsx.snap
@@ -12,6 +12,7 @@ exports[`Table Foot should render correctly with L size 1`] = `
   letter-spacing: 0rem;
   line-height: 2.2rem;
   text-align: initial;
+  display: inline-block;
 }
 
 .c9 {
@@ -25,6 +26,7 @@ exports[`Table Foot should render correctly with L size 1`] = `
   letter-spacing: 0rem;
   line-height: 2.2rem;
   text-align: initial;
+  display: inline-block;
 }
 
 .c6 {
@@ -292,6 +294,7 @@ exports[`Table Foot should render correctly with M size 1`] = `
   letter-spacing: 0rem;
   line-height: 2.2rem;
   text-align: initial;
+  display: inline-block;
 }
 
 .c9 {
@@ -305,6 +308,7 @@ exports[`Table Foot should render correctly with M size 1`] = `
   letter-spacing: 0rem;
   line-height: 2.2rem;
   text-align: initial;
+  display: inline-block;
 }
 
 .c6 {
@@ -572,6 +576,7 @@ exports[`Table Foot should render correctly with S size 1`] = `
   letter-spacing: 0rem;
   line-height: 2.2rem;
   text-align: initial;
+  display: inline-block;
 }
 
 .c9 {
@@ -585,6 +590,7 @@ exports[`Table Foot should render correctly with S size 1`] = `
   letter-spacing: 0rem;
   line-height: 2.2rem;
   text-align: initial;
+  display: inline-block;
 }
 
 .c6 {
@@ -852,6 +858,7 @@ exports[`Table Foot should render correctly with XS size 1`] = `
   letter-spacing: 0rem;
   line-height: 2.2rem;
   text-align: initial;
+  display: inline-block;
 }
 
 .c11 {
@@ -865,6 +872,7 @@ exports[`Table Foot should render correctly with XS size 1`] = `
   letter-spacing: 0rem;
   line-height: 2.2rem;
   text-align: initial;
+  display: inline-block;
 }
 
 .c8 {

--- a/packages/core/src/components/Table/GroupCell/__snapshots__/GroupCell.test.tsx.snap
+++ b/packages/core/src/components/Table/GroupCell/__snapshots__/GroupCell.test.tsx.snap
@@ -12,6 +12,7 @@ exports[`GroupCell should not render hidden prop is given 1`] = `
   letter-spacing: 0rem;
   line-height: 2.2rem;
   text-align: initial;
+  display: inline-block;
 }
 
 .c0 {
@@ -49,6 +50,7 @@ exports[`GroupCell should render GroupCell with right border if it is a title ce
   letter-spacing: 0rem;
   line-height: 2.2rem;
   text-align: initial;
+  display: inline-block;
 }
 
 .c0 {
@@ -99,6 +101,7 @@ exports[`GroupCell should render GroupCellTitle properly 1`] = `
   letter-spacing: 0rem;
   line-height: 2.2rem;
   text-align: initial;
+  display: inline-block;
 }
 
 .c0 {
@@ -159,6 +162,7 @@ exports[`GroupCell should render properly 1`] = `
   letter-spacing: 0rem;
   line-height: 2.2rem;
   text-align: initial;
+  display: inline-block;
 }
 
 .c0 {

--- a/packages/core/src/components/Table/__snapshots__/Table.test.tsx.snap
+++ b/packages/core/src/components/Table/__snapshots__/Table.test.tsx.snap
@@ -13,6 +13,7 @@ exports[`Table component pagination should call onPageChange prop on click on an
   line-height: 2.2rem;
   text-align: initial;
   text-transform: uppercase;
+  display: inline-block;
 }
 
 .c17 {
@@ -26,6 +27,7 @@ exports[`Table component pagination should call onPageChange prop on click on an
   letter-spacing: 0rem;
   line-height: 2.2rem;
   text-align: initial;
+  display: inline-block;
 }
 
 .c27 {
@@ -39,6 +41,7 @@ exports[`Table component pagination should call onPageChange prop on click on an
   letter-spacing: 0rem;
   line-height: 2.2rem;
   text-align: center;
+  display: inline-block;
 }
 
 .c30 {
@@ -65,6 +68,7 @@ exports[`Table component pagination should call onPageChange prop on click on an
   letter-spacing: 0rem;
   line-height: 2.2rem;
   text-align: initial;
+  display: inline-block;
 }
 
 .c9 {
@@ -1667,6 +1671,7 @@ exports[`Table component should render properly 1`] = `
   line-height: 2.2rem;
   text-align: initial;
   text-transform: uppercase;
+  display: inline-block;
 }
 
 .c17 {
@@ -1680,6 +1685,7 @@ exports[`Table component should render properly 1`] = `
   letter-spacing: 0rem;
   line-height: 2.2rem;
   text-align: initial;
+  display: inline-block;
 }
 
 .c9 {

--- a/packages/core/src/components/Tabs/Tab/__snapshots__/Tab.test.tsx.snap
+++ b/packages/core/src/components/Tabs/Tab/__snapshots__/Tab.test.tsx.snap
@@ -27,6 +27,7 @@ exports[`Tab should render active state properly 1`] = `
   letter-spacing: 0rem;
   line-height: 2.2rem;
   text-align: initial;
+  display: inline-block;
 }
 
 .c9 {
@@ -284,6 +285,7 @@ exports[`Tab should render disabled state properly 1`] = `
   letter-spacing: 0rem;
   line-height: 2.2rem;
   text-align: initial;
+  display: inline-block;
 }
 
 .c9 {
@@ -564,6 +566,7 @@ exports[`Tab should render properly with GREY tab background 1`] = `
   letter-spacing: 0rem;
   line-height: 2.2rem;
   text-align: initial;
+  display: inline-block;
 }
 
 .c9 {
@@ -850,6 +853,7 @@ exports[`Tab should render properly with L tab size 1`] = `
   letter-spacing: 0rem;
   line-height: 2.2rem;
   text-align: initial;
+  display: inline-block;
 }
 
 .c9 {
@@ -1143,6 +1147,7 @@ exports[`Tab should render properly with L tab size 2`] = `
   letter-spacing: 0rem;
   line-height: 2.2rem;
   text-align: initial;
+  display: inline-block;
 }
 
 .c9 {
@@ -1436,6 +1441,7 @@ exports[`Tab should render properly with M tab size 1`] = `
   letter-spacing: 0rem;
   line-height: 2.2rem;
   text-align: initial;
+  display: inline-block;
 }
 
 .c9 {
@@ -1718,6 +1724,7 @@ exports[`Tab should render properly with M tab size 2`] = `
   letter-spacing: 0rem;
   line-height: 2.2rem;
   text-align: initial;
+  display: inline-block;
 }
 
 .c9 {
@@ -1997,6 +2004,7 @@ exports[`Tab should render properly with S tab size 1`] = `
   letter-spacing: 0rem;
   line-height: 2.2rem;
   text-align: initial;
+  display: inline-block;
 }
 
 .c9 {
@@ -2276,6 +2284,7 @@ exports[`Tab should render properly with S tab size 2`] = `
   letter-spacing: 0rem;
   line-height: 2.2rem;
   text-align: initial;
+  display: inline-block;
 }
 
 .c9 {
@@ -2555,6 +2564,7 @@ exports[`Tab should render properly with WHITE tab background 1`] = `
   letter-spacing: 0rem;
   line-height: 2.2rem;
   text-align: initial;
+  display: inline-block;
 }
 
 .c9 {
@@ -2834,6 +2844,7 @@ exports[`Tab should render properly with flat tab variant 1`] = `
   letter-spacing: 0rem;
   line-height: 2.2rem;
   text-align: initial;
+  display: inline-block;
 }
 
 .c9 {
@@ -3113,6 +3124,7 @@ exports[`Tab should render properly with outlined tab variant 1`] = `
   letter-spacing: 0rem;
   line-height: 2.2rem;
   text-align: initial;
+  display: inline-block;
 }
 
 .c9 {
@@ -3387,6 +3399,7 @@ exports[`Tab should render properly with solid tab variant 1`] = `
   letter-spacing: 0rem;
   line-height: 2.2rem;
   text-align: initial;
+  display: inline-block;
 }
 
 .c9 {

--- a/packages/core/src/components/Tabs/TabList/__snapshots__/TabList.test.tsx.snap
+++ b/packages/core/src/components/Tabs/TabList/__snapshots__/TabList.test.tsx.snap
@@ -12,6 +12,7 @@ exports[`TabList should render properly 1`] = `
   letter-spacing: 0rem;
   line-height: 2.2rem;
   text-align: initial;
+  display: inline-block;
 }
 
 .c6 {

--- a/packages/core/src/components/Tabs/__snapshots__/Tabs.test.tsx.snap
+++ b/packages/core/src/components/Tabs/__snapshots__/Tabs.test.tsx.snap
@@ -12,6 +12,7 @@ exports[`Tabs should render properly with flat tab variant 1`] = `
   letter-spacing: 0rem;
   line-height: 2.2rem;
   text-align: initial;
+  display: inline-block;
 }
 
 .c8 {
@@ -500,6 +501,7 @@ exports[`Tabs should render properly with outlined tab variant 1`] = `
   letter-spacing: 0rem;
   line-height: 2.2rem;
   text-align: initial;
+  display: inline-block;
 }
 
 .c8 {
@@ -978,6 +980,7 @@ exports[`Tabs should render properly with solid tab variant 1`] = `
   letter-spacing: 0rem;
   line-height: 2.2rem;
   text-align: initial;
+  display: inline-block;
 }
 
 .c9 {

--- a/packages/core/src/components/Text/Text.styled.tsx
+++ b/packages/core/src/components/Text/Text.styled.tsx
@@ -38,6 +38,7 @@ export const TextStyled = styled('span')<TextProps>`
 
     ${props => props.uppercase && uppercase()};
     ${props => props.lineThrough && lineThrough()};
+    display: ${({ as }) => (as === 'strong' || as === 'span' || as === 'a') && 'inline-block'};
 `;
 
 TextStyled.defaultProps = {

--- a/packages/core/src/components/Text/__snapshots__/Text.test.tsx.snap
+++ b/packages/core/src/components/Text/__snapshots__/Text.test.tsx.snap
@@ -12,6 +12,7 @@ exports[`Text Component should render span element by default 1`] = `
   letter-spacing: 0rem;
   line-height: 2.2rem;
   text-align: initial;
+  display: inline-block;
 }
 
 <div>
@@ -33,6 +34,7 @@ exports[`Text Component should render strong html tag for textWeight ExtraStrong
   letter-spacing: 0rem;
   line-height: 2.2rem;
   text-align: initial;
+  display: inline-block;
 }
 
 <div>
@@ -54,6 +56,7 @@ exports[`Text Component should render strong html tag for textWeight Strong 1`] 
   letter-spacing: 0rem;
   line-height: 2.2rem;
   text-align: initial;
+  display: inline-block;
 }
 
 <div>
@@ -80,6 +83,7 @@ exports[`Text Component should render with all the props 1`] = `
   text-transform: uppercase;
   -webkit-text-decoration: line-through;
   text-decoration: line-through;
+  display: inline-block;
 }
 
 <div>

--- a/packages/core/src/components/Toast/__snapshots__/Toast.test.tsx.snap
+++ b/packages/core/src/components/Toast/__snapshots__/Toast.test.tsx.snap
@@ -45,6 +45,7 @@ exports[`Toast should render action button 1`] = `
   letter-spacing: 0rem;
   line-height: 2.2rem;
   text-align: initial;
+  display: inline-block;
 }
 
 .c7 {
@@ -549,6 +550,7 @@ exports[`Toast should render header and message text 1`] = `
   letter-spacing: 0rem;
   line-height: 2.2rem;
   text-align: initial;
+  display: inline-block;
 }
 
 .c6 {
@@ -562,6 +564,7 @@ exports[`Toast should render header and message text 1`] = `
   letter-spacing: 0rem;
   line-height: 2.2rem;
   text-align: initial;
+  display: inline-block;
 }
 
 .c0 {
@@ -939,6 +942,7 @@ exports[`Toast should render properly with fullWidth prop 1`] = `
   letter-spacing: 0rem;
   line-height: 2.2rem;
   text-align: initial;
+  display: inline-block;
 }
 
 .c0 {

--- a/packages/core/src/components/ToastContainer/__snapshots__/ToastContainer.test.tsx.snap
+++ b/packages/core/src/components/ToastContainer/__snapshots__/ToastContainer.test.tsx.snap
@@ -45,6 +45,7 @@ exports[`ToastContainer should render properly with position bottom 1`] = `
   letter-spacing: 0rem;
   line-height: 2.2rem;
   text-align: initial;
+  display: inline-block;
 }
 
 .c7 {
@@ -58,6 +59,7 @@ exports[`ToastContainer should render properly with position bottom 1`] = `
   letter-spacing: 0rem;
   line-height: 2.2rem;
   text-align: initial;
+  display: inline-block;
 }
 
 .c1 {
@@ -283,6 +285,7 @@ exports[`ToastContainer should render properly with position bottom-end 1`] = `
   letter-spacing: 0rem;
   line-height: 2.2rem;
   text-align: initial;
+  display: inline-block;
 }
 
 .c7 {
@@ -296,6 +299,7 @@ exports[`ToastContainer should render properly with position bottom-end 1`] = `
   letter-spacing: 0rem;
   line-height: 2.2rem;
   text-align: initial;
+  display: inline-block;
 }
 
 .c1 {
@@ -518,6 +522,7 @@ exports[`ToastContainer should render properly with position bottom-start 1`] = 
   letter-spacing: 0rem;
   line-height: 2.2rem;
   text-align: initial;
+  display: inline-block;
 }
 
 .c7 {
@@ -531,6 +536,7 @@ exports[`ToastContainer should render properly with position bottom-start 1`] = 
   letter-spacing: 0rem;
   line-height: 2.2rem;
   text-align: initial;
+  display: inline-block;
 }
 
 .c1 {
@@ -753,6 +759,7 @@ exports[`ToastContainer should render properly with position left 1`] = `
   letter-spacing: 0rem;
   line-height: 2.2rem;
   text-align: initial;
+  display: inline-block;
 }
 
 .c7 {
@@ -766,6 +773,7 @@ exports[`ToastContainer should render properly with position left 1`] = `
   letter-spacing: 0rem;
   line-height: 2.2rem;
   text-align: initial;
+  display: inline-block;
 }
 
 .c1 {
@@ -991,6 +999,7 @@ exports[`ToastContainer should render properly with position left-end 1`] = `
   letter-spacing: 0rem;
   line-height: 2.2rem;
   text-align: initial;
+  display: inline-block;
 }
 
 .c7 {
@@ -1004,6 +1013,7 @@ exports[`ToastContainer should render properly with position left-end 1`] = `
   letter-spacing: 0rem;
   line-height: 2.2rem;
   text-align: initial;
+  display: inline-block;
 }
 
 .c1 {
@@ -1224,6 +1234,7 @@ exports[`ToastContainer should render properly with position left-start 1`] = `
   letter-spacing: 0rem;
   line-height: 2.2rem;
   text-align: initial;
+  display: inline-block;
 }
 
 .c7 {
@@ -1237,6 +1248,7 @@ exports[`ToastContainer should render properly with position left-start 1`] = `
   letter-spacing: 0rem;
   line-height: 2.2rem;
   text-align: initial;
+  display: inline-block;
 }
 
 .c1 {
@@ -1457,6 +1469,7 @@ exports[`ToastContainer should render properly with position right 1`] = `
   letter-spacing: 0rem;
   line-height: 2.2rem;
   text-align: initial;
+  display: inline-block;
 }
 
 .c7 {
@@ -1470,6 +1483,7 @@ exports[`ToastContainer should render properly with position right 1`] = `
   letter-spacing: 0rem;
   line-height: 2.2rem;
   text-align: initial;
+  display: inline-block;
 }
 
 .c1 {
@@ -1695,6 +1709,7 @@ exports[`ToastContainer should render properly with position right-end 1`] = `
   letter-spacing: 0rem;
   line-height: 2.2rem;
   text-align: initial;
+  display: inline-block;
 }
 
 .c7 {
@@ -1708,6 +1723,7 @@ exports[`ToastContainer should render properly with position right-end 1`] = `
   letter-spacing: 0rem;
   line-height: 2.2rem;
   text-align: initial;
+  display: inline-block;
 }
 
 .c1 {
@@ -1928,6 +1944,7 @@ exports[`ToastContainer should render properly with position right-start 1`] = `
   letter-spacing: 0rem;
   line-height: 2.2rem;
   text-align: initial;
+  display: inline-block;
 }
 
 .c7 {
@@ -1941,6 +1958,7 @@ exports[`ToastContainer should render properly with position right-start 1`] = `
   letter-spacing: 0rem;
   line-height: 2.2rem;
   text-align: initial;
+  display: inline-block;
 }
 
 .c1 {
@@ -2161,6 +2179,7 @@ exports[`ToastContainer should render properly with position top 1`] = `
   letter-spacing: 0rem;
   line-height: 2.2rem;
   text-align: initial;
+  display: inline-block;
 }
 
 .c7 {
@@ -2174,6 +2193,7 @@ exports[`ToastContainer should render properly with position top 1`] = `
   letter-spacing: 0rem;
   line-height: 2.2rem;
   text-align: initial;
+  display: inline-block;
 }
 
 .c1 {
@@ -2399,6 +2419,7 @@ exports[`ToastContainer should render properly with position top-end 1`] = `
   letter-spacing: 0rem;
   line-height: 2.2rem;
   text-align: initial;
+  display: inline-block;
 }
 
 .c7 {
@@ -2412,6 +2433,7 @@ exports[`ToastContainer should render properly with position top-end 1`] = `
   letter-spacing: 0rem;
   line-height: 2.2rem;
   text-align: initial;
+  display: inline-block;
 }
 
 .c1 {
@@ -2634,6 +2656,7 @@ exports[`ToastContainer should render properly with position top-start 1`] = `
   letter-spacing: 0rem;
   line-height: 2.2rem;
   text-align: initial;
+  display: inline-block;
 }
 
 .c7 {
@@ -2647,6 +2670,7 @@ exports[`ToastContainer should render properly with position top-start 1`] = `
   letter-spacing: 0rem;
   line-height: 2.2rem;
   text-align: initial;
+  display: inline-block;
 }
 
 .c1 {

--- a/packages/forms/src/components/Actions/__snapshots__/Actions.test.tsx.snap
+++ b/packages/forms/src/components/Actions/__snapshots__/Actions.test.tsx.snap
@@ -12,6 +12,7 @@ exports[`Form Actions should render center aligned actions defined in action sch
   letter-spacing: 0rem;
   line-height: 2.6rem;
   text-align: initial;
+  display: inline-block;
 }
 
 .c1 {
@@ -159,6 +160,7 @@ exports[`Form Actions should render default action button 1`] = `
   letter-spacing: 0rem;
   line-height: 2.6rem;
   text-align: initial;
+  display: inline-block;
 }
 
 .c1 {
@@ -306,6 +308,7 @@ exports[`Form Actions should render left aligned actions defined in action schem
   letter-spacing: 0rem;
   line-height: 2.6rem;
   text-align: initial;
+  display: inline-block;
 }
 
 .c1 {

--- a/packages/forms/src/components/Form/__snapshots__/Form.test.tsx.snap
+++ b/packages/forms/src/components/Form/__snapshots__/Form.test.tsx.snap
@@ -12,6 +12,7 @@ exports[`Form should not render any field if component type is not matched 1`] =
   letter-spacing: 0rem;
   line-height: 2.6rem;
   text-align: initial;
+  display: inline-block;
 }
 
 .c3 {
@@ -223,6 +224,7 @@ exports[`Form should render properly with initial state 1`] = `
   letter-spacing: 0rem;
   line-height: 2.2rem;
   text-align: initial;
+  display: inline-block;
 }
 
 .c21 {
@@ -236,6 +238,7 @@ exports[`Form should render properly with initial state 1`] = `
   letter-spacing: 0rem;
   line-height: 2.6rem;
   text-align: initial;
+  display: inline-block;
 }
 
 .c58 {
@@ -2559,6 +2562,7 @@ exports[`Form should render properly without initial state 1`] = `
   letter-spacing: 0rem;
   line-height: 2.6rem;
   text-align: initial;
+  display: inline-block;
 }
 
 .c20 {
@@ -2572,6 +2576,7 @@ exports[`Form should render properly without initial state 1`] = `
   letter-spacing: 0rem;
   line-height: 2.2rem;
   text-align: initial;
+  display: inline-block;
 }
 
 .c23 {
@@ -2585,6 +2590,7 @@ exports[`Form should render properly without initial state 1`] = `
   letter-spacing: 0rem;
   line-height: 2.6rem;
   text-align: initial;
+  display: inline-block;
 }
 
 .c57 {

--- a/packages/layout/src/components/SideNav/NavItem/__snapshots__/NavItem.test.tsx.snap
+++ b/packages/layout/src/components/SideNav/NavItem/__snapshots__/NavItem.test.tsx.snap
@@ -12,6 +12,7 @@ exports[`NavItem should render properly when it is in active state 1`] = `
   letter-spacing: 0rem;
   line-height: 2.2rem;
   text-align: initial;
+  display: inline-block;
 }
 
 .c4 .c0 {
@@ -89,6 +90,7 @@ exports[`NavItem should render properly when it is in default state 1`] = `
   letter-spacing: 0rem;
   line-height: 2.2rem;
   text-align: initial;
+  display: inline-block;
 }
 
 .c5 .c0 {
@@ -222,6 +224,7 @@ exports[`NavItem should render properly when it is in hovered state 1`] = `
   letter-spacing: 0rem;
   line-height: 2.2rem;
   text-align: initial;
+  display: inline-block;
 }
 
 .c5 .c0 {

--- a/packages/layout/src/components/SideNav/ToggleSwitch/__snapshots__/ToggleSwitch.test.tsx.snap
+++ b/packages/layout/src/components/SideNav/ToggleSwitch/__snapshots__/ToggleSwitch.test.tsx.snap
@@ -27,6 +27,7 @@ exports[`NavItem should call onClick when we click on it 1`] = `
   letter-spacing: 0rem;
   line-height: 2.2rem;
   text-align: initial;
+  display: inline-block;
 }
 
 .c1 {
@@ -220,6 +221,7 @@ exports[`NavItem should render properly when it is showing hide option 1`] = `
   letter-spacing: 0rem;
   line-height: 2.2rem;
   text-align: initial;
+  display: inline-block;
 }
 
 .c1 {
@@ -413,6 +415,7 @@ exports[`NavItem should render properly when it is showing open option 1`] = `
   letter-spacing: 0rem;
   line-height: 2.2rem;
   text-align: initial;
+  display: inline-block;
 }
 
 .c1 {

--- a/packages/layout/src/components/SideNav/__snapshots__/SideNav.test.tsx.snap
+++ b/packages/layout/src/components/SideNav/__snapshots__/SideNav.test.tsx.snap
@@ -42,6 +42,7 @@ exports[`SideNav should render properly with shadow 1`] = `
   letter-spacing: 0rem;
   line-height: 2.2rem;
   text-align: initial;
+  display: inline-block;
 }
 
 .c12 {
@@ -551,6 +552,7 @@ exports[`SideNav should render properly without shadow 1`] = `
   letter-spacing: 0rem;
   line-height: 2.2rem;
   text-align: initial;
+  display: inline-block;
 }
 
 .c12 {


### PR DESCRIPTION
affects: @medly-components/core, @medly-components/forms, @medly-components/layout

### PR Checklist

Please check if your PR fulfills the following requirements:

-   [x] Tests for the changes have been added (for bug fixes/features)
-   [ ] Docs have been added/updated (for bug fixes/features)

### PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

-   [x] Bugfix
-   [ ] Feature
-   [ ] Code style update (formatting, local variables)
-   [ ] Refactoring (no functional changes, no api changes)
-   [ ] Build related changes
-   [ ] CI related changes
-   [ ] Performance improves
-   [ ] Adding missing tests
-   [ ] Documentation content changes
-   [ ] Other... Please describe:

### What is the current behavior?

Due to the `inline` property of Text component the height of Text component is not respecting the line height.

### What is the new behavior?

Adding the `display: inline-block` to Text component, it respects the line height.

### Does this PR introduce a breaking change?

-   [ ] Yes
-   [x] No