### PR TITLE
feat(core): add noResutRowText prop in table

### DIFF
--- a/packages/core/src/components/Table/Body/Body.tsx
+++ b/packages/core/src/components/Table/Body/Body.tsx
@@ -10,8 +10,19 @@ import { NoResultCell, NoResultRow } from './Row/Row.styled';
 import { TableBodyProps } from './types';
 
 const Body: FC<TableBodyProps> = memo(props => {
-    const { data, groupBy, rowIdentifier, showRowWithCardStyle, noResultRow, tableRef, withMinimap, columns, size, keyBindings } =
-            useContext(TableComponentsCommonPropsContext),
+    const {
+            data,
+            groupBy,
+            rowIdentifier,
+            showRowWithCardStyle,
+            noResultRow,
+            noResultRowText,
+            tableRef,
+            withMinimap,
+            columns,
+            size,
+            keyBindings
+        } = useContext(TableComponentsCommonPropsContext),
         { selectedRowIds, onRowSelection, onGroupedRowSelection, setUniqueIds, ...restProps } = props,
         [cursor, setCursor] = useState(-1),
         /* since minimap is positioned sticky with respect to the tbody, tbody should have full table width otherwise minimap positioning fails */
@@ -42,7 +53,7 @@ const Body: FC<TableBodyProps> = memo(props => {
                         withMinimap={withMinimap}
                     >
                         <NoResultCell width={tableVisibleWidth} tableSize={size}>
-                            No result
+                            {noResultRowText || 'No result'}
                         </NoResultCell>
                     </NoResultRow>
                 ))}

--- a/packages/core/src/components/Table/Table.test.tsx
+++ b/packages/core/src/components/Table/Table.test.tsx
@@ -25,6 +25,14 @@ describe('Table component', () => {
         expect(screen.getByText('NO RESULT CUSTOM COMPONENT')).toBeInTheDocument();
     });
 
+    it('should render no result row text', () => {
+        renderTable({
+            data: [],
+            noResultRowText: 'No Result Row Text'
+        });
+        expect(screen.getByText('No Result Row Text')).toBeInTheDocument();
+    });
+
     describe('pagination', () => {
         const mockOnPageChange = jest.fn(),
             commonProps = {

--- a/packages/core/src/components/Table/types.ts
+++ b/packages/core/src/components/Table/types.ts
@@ -117,8 +117,10 @@ export interface TableProps extends Omit<HTMLProps<HTMLTableElement>, 'data' | '
     itemsPerPage?: number;
     /** Default active page */
     defaultActivePage?: number;
-    /** No Result Row*/
+    /** Component to be displayed when there is no data */
     noResultRow?: React.ReactElement<any>;
+    /** Text to be displayed when there is no data */
+    noResultRowText?: string;
     /** Value of the default expanded Row's identifier */
     defaultExpandedRowIdentifier?: unknown;
     /** Row hover actions component */


### PR DESCRIPTION
### PR Checklist

Please check if your PR fulfills the following requirements:

-   [x] Tests for the changes have been added (for bug fixes/features)
-   [x] Docs have been added/updated (for bug fixes/features)

### PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

-   [ ] Bugfix
-   [x] Feature
-   [ ] Code style update (formatting, local variables)
-   [ ] Refactoring (no functional changes, no api changes)
-   [ ] Build related changes
-   [ ] CI related changes
-   [ ] Performance improves
-   [ ] Adding missing tests
-   [ ] Documentation content changes
-   [ ] Other... Please describe:

### What is the current behavior?
To change the text for `noResultRow` you have to create a custom component. The styling for the component needs to be manually adjusted which seems too much work for just changing the text.

### What is the new behavior?
Adds `noResultRowText` prop to table component to directly show text if there is no result or data in table

### Does this PR introduce a breaking change?

-   [ ] Yes
-   [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path of the existing applications below. -->