### PR TITLE
fix: use id in toggle

### DIFF
--- a/packages/core/src/components/Toggle/Toggle.test.tsx
+++ b/packages/core/src/components/Toggle/Toggle.test.tsx
@@ -8,7 +8,9 @@ describe('Checkbox component', () => {
     });
 
     it('should render correctly with all the props given', () => {
-        const { container } = render(<Toggle disabled fullWidth name="gender" label="Female" size="M" labelPosition="right" />);
+        const { container } = render(
+            <Toggle disabled fullWidth name="gender" label="Female" size="M" labelPosition="right" id="gender-toggle" />
+        );
         expect(container).toMatchSnapshot();
     });
 

--- a/packages/core/src/components/Toggle/Toggle.tsx
+++ b/packages/core/src/components/Toggle/Toggle.tsx
@@ -1,29 +1,31 @@
 import { WithStyle } from '@medly-components/utils';
-import { memo, forwardRef, useCallback } from 'react';
+import type { FC } from 'react';
+import { forwardRef, memo, useCallback, useMemo } from 'react';
 import FieldWithLabel from '../FieldWithLabel';
 import * as Styled from './Toggle.styled';
 import { ToggleProps } from './types';
-import type { FC } from 'react';
 
 const Component: FC<ToggleProps> = memo(
     forwardRef((props, ref) => {
-        const { size, label, required, labelPosition, labelVariant, labelWeight, labelColor, fullWidth, onChange, ...restProps } = props;
+        const { id, size, label, required, labelPosition, labelVariant, labelWeight, labelColor, fullWidth, onChange, ...restProps } =
+            props;
 
         const changeHandler = useCallback(
-            (e: any) => {
-                e.stopPropagation();
-                onChange && onChange(e);
-            },
-            [onChange]
-        );
+                (e: any) => {
+                    e.stopPropagation();
+                    onChange && onChange(e);
+                },
+                [onChange]
+            ),
+            toggleId = useMemo(() => id || label?.toLocaleLowerCase().replace(/ +/g, '-') || 'medly-toggle-checkbox', [id, label]);
 
         return (
-            <FieldWithLabel id={`${label}-checkbox`} fieldWithMaxContent {...{ fullWidth, labelPosition }}>
+            <FieldWithLabel id={toggleId} fieldWithMaxContent {...{ fullWidth, labelPosition }}>
                 {label && (
                     <FieldWithLabel.Label
                         showPointer={!restProps.disabled}
                         {...{ required, labelPosition, labelVariant, labelWeight, labelColor }}
-                        htmlFor={label}
+                        htmlFor={toggleId}
                     >
                         {label}
                     </FieldWithLabel.Label>

--- a/packages/core/src/components/Toggle/__snapshots__/Toggle.test.tsx.snap
+++ b/packages/core/src/components/Toggle/__snapshots__/Toggle.test.tsx.snap
@@ -100,7 +100,7 @@ exports[`Checkbox component should render correctly with all the default props 1
 <div>
   <div
     class="c0"
-    id="-checkbox"
+    id="medly-toggle-checkbox"
   >
     
     <div
@@ -242,11 +242,11 @@ exports[`Checkbox component should render correctly with all the props given 1`]
 <div>
   <div
     class="c0"
-    id="Female-checkbox"
+    id="gender-toggle"
   >
     <label
       class="c1 c2"
-      for="Female"
+      for="gender-toggle"
     >
       Female
     </label>


### PR DESCRIPTION
### PR Checklist

Please check if your PR fulfills the following requirements:

-   [x] Tests for the changes have been added (for bug fixes/features)
-   [x] Docs have been added/updated (for bug fixes/features)

### PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

-   [x] Bugfix
-   [ ] Feature
-   [ ] Code style update (formatting, local variables)
-   [ ] Refactoring (no functional changes, no api changes)
-   [ ] Build related changes
-   [ ] CI related changes
-   [ ] Performance improves
-   [ ] Adding missing tests
-   [ ] Documentation content changes
-   [ ] Other... Please describe:

### What is the current behavior?
`Toggle` component uses label name as id instead of the id passed

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

### What is the new behavior?
`Toggle` component will use id or label name delimited by `-` (hyphen) else the default id will be `medly-toggle-checkbox`

### Does this PR introduce a breaking change?

-   [x] Yes
-   [ ] No

<!-- If this PR contains a breaking change, please describe the impact and migration path of the existing applications below. -->

Components previously using `Toggle` component with snapshot test cases will fail and will need to update the snapshot