### PR TITLE
fix(forms): clear number input

### DIFF
--- a/packages/forms/src/components/Form/Form.test.tsx
+++ b/packages/forms/src/components/Form/Form.test.tsx
@@ -320,5 +320,35 @@ describe('Form', () => {
                 }
             });
         });
+
+        it('should allow user to clear number input', () => {
+            render(
+                <Form
+                    name="Test form"
+                    fieldSchema={testSchema}
+                    header="Dummy Form"
+                    helperText="Dummy Description"
+                    onSubmit={jest.fn()}
+                    minWidth="300px"
+                    fullWidth
+                    gridGap="1.2rem"
+                    actionLabel="Upload"
+                />
+            );
+            const mathsInput = screen.getByLabelText('Maths');
+            expect(mathsInput).toBeInTheDocument();
+            fireEvent.change(mathsInput, {
+                target: {
+                    value: 23451
+                }
+            });
+            expect(mathsInput).toHaveValue(23451);
+            fireEvent.change(mathsInput, {
+                target: {
+                    value: ''
+                }
+            });
+            expect(mathsInput).toHaveValue(null);
+        });
     });
 });

--- a/packages/forms/src/hooks/useForm/useForm.ts
+++ b/packages/forms/src/hooks/useForm/useForm.ts
@@ -68,7 +68,7 @@ export const useForm = (initialState: Record<string, unknown>): UseFormResult =>
     const handleNumberChange: Handlers['handleNumberChange'] = useCallback(
         memoize(name => event => {
             const { value } = event.target as HTMLInputElement;
-            setValues(val => ({ ...val, [name]: !value ? undefined : Number(value) }));
+            setValues(val => ({ ...val, [name]: Number(value) || undefined }));
         }),
         []
     );

--- a/packages/forms/src/hooks/useForm/useForm.ts
+++ b/packages/forms/src/hooks/useForm/useForm.ts
@@ -68,7 +68,7 @@ export const useForm = (initialState: Record<string, unknown>): UseFormResult =>
     const handleNumberChange: Handlers['handleNumberChange'] = useCallback(
         memoize(name => event => {
             const { value } = event.target as HTMLInputElement;
-            setValues(val => ({ ...val, [name]: Number(value) }));
+            setValues(val => ({ ...val, [name]: !value ? undefined : Number(value) }));
         }),
         []
     );


### PR DESCRIPTION
# PR Checklist

## Description
Allow user to clear number input after entering a number

### Type of change
<!-- Please check the one that applies to this PR using "x". -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes and API changes)
- [ ] Build changes
- [ ] CI changes
- [ ] Document content changes
- [ ] Performance improvement
- [ ] Add missing tests
- [ ] Others (please describe)

## Fixes #603

## What is the current behaviour?
Once you enter a number in number input, user is now allowed to clear it and there is always a value `0` set

## What is the new behaviour?
User can clear the number input

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

## Checklist
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
