### PR TITLE
feat(layout): add custom expand & collapse text in sidenav

### DIFF
--- a/packages/layout/src/components/SideNav/SideNav.stories.mdx
+++ b/packages/layout/src/components/SideNav/SideNav.stories.mdx
@@ -124,6 +124,10 @@ For grouping you just have to use `SideNav.Group` and provide title to it.
 </MedlySideNav>
 ```
 
+### Custom expand & collapse text
+
+You can pass `expandedToggleText` & `collapsedToggleText` to show custom text for expanding and collapsing the sidenav respectively
+
 ### SideNav Props
 
 <Props of={SideNav} />

--- a/packages/layout/src/components/SideNav/SideNav.tsx
+++ b/packages/layout/src/components/SideNav/SideNav.tsx
@@ -9,7 +9,8 @@ import ToggleSwitch from './ToggleSwitch';
 import { SideNavProps, SideNavStaticProps } from './types';
 
 export const Component: FC<SideNavProps> = memo(props => {
-    const { id, active, children, defaultActive, onChange, hideShadow, defaultOpen, className } = props;
+    const { id, active, children, defaultActive, onChange, hideShadow, defaultOpen, className, collapsedToggleText, expandedToggleText } =
+        props;
 
     const ref = useRef(null),
         [isHovered, setHoveredState] = useState(false),
@@ -50,7 +51,12 @@ export const Component: FC<SideNavProps> = memo(props => {
                     onMouseLeave={closeSidenav}
                 >
                     {children}
-                    <ToggleSwitch id={`${id}-toggle`} isActive={isExpanded} onClick={isExpanded ? collapseSidenav : expandSidenav} />
+                    <ToggleSwitch
+                        id={`${id}-toggle`}
+                        isActive={isExpanded}
+                        onClick={isExpanded ? collapseSidenav : expandSidenav}
+                        {...{ expandedToggleText, collapsedToggleText }}
+                    />
                 </Styled.Nav>
             </Styled.Aside>
         </SideNavContext.Provider>

--- a/packages/layout/src/components/SideNav/ToggleSwitch/ToggleSwitch.test.tsx
+++ b/packages/layout/src/components/SideNav/ToggleSwitch/ToggleSwitch.test.tsx
@@ -1,13 +1,22 @@
-import { cleanup, render } from '@test-utils';
+import { cleanup, render, screen } from '@test-utils';
 import SidenavContext from '../SideNav.context';
 import { ToggleSwitch } from './ToggleSwitch';
 
-const renderer = (isActive = true, mockOnClick = jest.fn()) =>
-    render(
-        <SidenavContext.Provider value={{ activeItem: 'dummy', isHovered: true, isExpanded: true, activeItemChangeHandler: () => null }}>
-            <ToggleSwitch id="dummy" isActive={isActive} onClick={mockOnClick} />
-        </SidenavContext.Provider>
-    );
+const defaultProps = {
+        isActive: true,
+        onClick: jest.fn(),
+        expandedToggleText: '',
+        collapsedToggleText: '',
+        isExpanded: true
+    },
+    renderer = (props = defaultProps) =>
+        render(
+            <SidenavContext.Provider
+                value={{ activeItem: 'dummy', isHovered: true, isExpanded: props.isExpanded, activeItemChangeHandler: () => null }}
+            >
+                <ToggleSwitch id="dummy" {...props} />
+            </SidenavContext.Provider>
+        );
 
 describe('NavItem', () => {
     afterEach(cleanup);
@@ -18,13 +27,23 @@ describe('NavItem', () => {
     });
 
     it('should render properly when it is showing open option', () => {
-        const { container } = renderer(false);
+        const { container } = renderer({ ...defaultProps, isActive: false });
         expect(container).toMatchSnapshot();
     });
 
     it('should call onClick when we click on it', () => {
         const mockOnClick = jest.fn();
-        const { container } = renderer(true, mockOnClick);
+        const { container } = renderer({ ...defaultProps, onClick: mockOnClick });
         expect(container).toMatchSnapshot();
+    });
+
+    it('should render with custom text passed showing hide option', () => {
+        renderer({ ...defaultProps, expandedToggleText: 'Collapse' });
+        expect(screen.getByText('Collapse')).toBeInTheDocument();
+    });
+
+    it('should render with custom text passed showing open option', () => {
+        renderer({ ...defaultProps, expandedToggleText: 'Expand', isExpanded: false });
+        expect(screen.getByText('Expand')).toBeInTheDocument();
     });
 });

--- a/packages/layout/src/components/SideNav/ToggleSwitch/ToggleSwitch.tsx
+++ b/packages/layout/src/components/SideNav/ToggleSwitch/ToggleSwitch.tsx
@@ -5,7 +5,7 @@ import NavItem from '../NavItem';
 import * as Styled from './ToggleSwitch.styled';
 import { Props } from './types';
 
-export const ToggleSwitch: FC<Props> = ({ id, isActive, onClick }) => (
+export const ToggleSwitch: FC<Props> = ({ id, isActive, expandedToggleText, collapsedToggleText, onClick }) => (
     <Styled.ToggleContainer>
         <NavItem onClick={onClick}>
             {isActive ? (
@@ -13,7 +13,7 @@ export const ToggleSwitch: FC<Props> = ({ id, isActive, onClick }) => (
             ) : (
                 <MenuExpandIcon id={`${id}-expand`} title={`${id}-expand`} />
             )}
-            <Text>{isActive ? `Hide Menu` : `Open Menu`}</Text>
+            <Text>{isActive ? expandedToggleText ?? `Hide Menu` : collapsedToggleText ?? `Open Menu`}</Text>
         </NavItem>
     </Styled.ToggleContainer>
 );

--- a/packages/layout/src/components/SideNav/ToggleSwitch/__snapshots__/ToggleSwitch.test.tsx.snap
+++ b/packages/layout/src/components/SideNav/ToggleSwitch/__snapshots__/ToggleSwitch.test.tsx.snap
@@ -186,9 +186,7 @@ exports[`NavItem should call onClick when we click on it 1`] = `
       </svg>
       <span
         class="c4 c5"
-      >
-        Hide Menu
-      </span>
+      />
     </li>
   </ul>
 </div>
@@ -380,9 +378,7 @@ exports[`NavItem should render properly when it is showing hide option 1`] = `
       </svg>
       <span
         class="c4 c5"
-      >
-        Hide Menu
-      </span>
+      />
     </li>
   </ul>
 </div>
@@ -574,9 +570,7 @@ exports[`NavItem should render properly when it is showing open option 1`] = `
       </svg>
       <span
         class="c4 c5"
-      >
-        Open Menu
-      </span>
+      />
     </li>
   </ul>
 </div>

--- a/packages/layout/src/components/SideNav/ToggleSwitch/types.ts
+++ b/packages/layout/src/components/SideNav/ToggleSwitch/types.ts
@@ -2,4 +2,6 @@ export interface Props {
     id: string;
     isActive: boolean;
     onClick: () => void;
+    expandedToggleText?: string;
+    collapsedToggleText?: string;
 }

--- a/packages/layout/src/components/SideNav/types.ts
+++ b/packages/layout/src/components/SideNav/types.ts
@@ -28,6 +28,10 @@ export interface SideNavProps {
     defaultOpen?: boolean;
     /** ClassName to be be passed to aside html tag */
     className?: string;
+    /** Text to be displayed when side nav is collapsed */
+    collapsedToggleText?: string;
+    /** Text to be displayed when side nav is expanded */
+    expandedToggleText?: string;
 }
 
 export interface SideNavStaticProps {


### PR DESCRIPTION
# PR Checklist

## Description
Adds custom text for sidenav button while expanding or collapsing the sidenav. As per current implementation the text is static and cannot be modified.

### Type of change
<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes and API changes)
- [ ] Build changes
- [ ] CI changes
- [ ] Document content changes
- [ ] Performance improvement
- [ ] Add missing tests
- [ ] Others (please describe)


## How has this been tested?
Added two test case to handle the state change for `toggleSwitch` component.

[x] should render with custom text passed showing hide option

[x] should render with custom text passed showing open option


## Fixes #<issue_number>


## What is the current behaviour?
As per current implementation the text for expanding or collapsing sidenav is static and cannot be modified.


## What is the new behaviour?
Adds two props to customize the text as per users requirement


## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No