### PR TITLE
fix(core): persists X in SearchBox after pressing enter

### DIFF
--- a/packages/core/src/components/SearchBox/SearchBox.test.tsx
+++ b/packages/core/src/components/SearchBox/SearchBox.test.tsx
@@ -95,6 +95,27 @@ describe('SearchBox', () => {
             fireEvent.change(inputEl, { target: { value: '' } });
             expect(screen.queryByTitle('close icon')).not.toBeInTheDocument();
         });
+
+        describe('when submitting a search with text', () => {
+            it('should show the close icon after pressing enter', () => {
+                const { container, inputEl } = renderComponent(props);
+                fireEvent.change(inputEl, { target: { value: 'Brooklyn' } });
+                const closeIcon = screen.getByTitle('close icon');
+                expect(closeIcon).toBeInTheDocument();
+                fireEvent.keyDown(container, { key: 'Enter', code: 13 });
+                expect(inputEl.value).toHaveLength(8);
+                expect(screen.queryByTitle('close icon')).toBeInTheDocument();
+            });
+            it('should show the close icon after clicking the search icon', () => {
+                const { inputEl } = renderComponent(props);
+                fireEvent.change(inputEl, { target: { value: 'Brooklyn' } });
+                const closeIcon = screen.getByTitle('close icon');
+                expect(closeIcon).toBeInTheDocument();
+                fireEvent.click(screen.getByTitle('search icon'));
+                expect(inputEl.value).toHaveLength(8);
+                expect(screen.queryByTitle('close icon')).toBeInTheDocument();
+            });
+        });
     });
 
     describe('expand icon', () => {

--- a/packages/core/src/components/SearchBox/SearchBox.tsx
+++ b/packages/core/src/components/SearchBox/SearchBox.tsx
@@ -121,7 +121,7 @@ const Component: FC<SearchBoxProps> = memo(
                 }
                 onSearch && onSearch(inputRef.current?.value || '');
                 setOptionsVisibilityState(false);
-                setShowCloseIcon(false);
+                setShowCloseIcon(inputRef.current?.value.length !== 0);
                 updateIsTyping(false);
             }
         }, [isEnterKeyPress]);


### PR DESCRIPTION
affects: @medly-components/core

Persists X in SearchBox after pressing enter.
Matches functionality for pressing enter as when
clicking Search Icon.
Adds 2 tests to confirm both enter and clicking search icon match
functionality.

# PR Checklist

## Description
Fixes [this issue](https://medlypharmacy.atlassian.net/browse/CNCT-1107?atlOrigin=eyJpIjoiZmQ3NzJlZjY0YzIwNGE1MGI5ZjNmOGU2ODljYjkwNDYiLCJwIjoiaiJ9) on behalf of Medly360 team where the SearchBox X disappears after pressing Enter when submitting a non-empty search. Functionality is not broken when submitting a search via the Search Icon.

### Type of change
<!-- Please check the one that applies to this PR using "x". -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes and API changes)
- [ ] Build changes
- [ ] CI changes
- [ ] Document content changes
- [ ] Performance improvement
- [ ] Add missing tests
- [ ] Others (please describe)


## How has this been tested?
Created two tests in the Searchbox.test.tsx folder to confirm X does not disappear upon submitting a search with text for both pressing Enter and clicking the Search Icon.

[x] Test A

[x] Test B


## Fixes #<issue_number>


## What is the current behaviour?
You can see a video at the Jira link above which demonstrates how the X box disappears after pressing enter.


## What is the new behaviour?
Expected new behavior is that the X persists after pressing enter as long as there is text in the search input.


## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

**Note:** (Replace This Text: If this PR contains a breaking change please describe the impact and migration path for existing application.)


## Additional context
(Replace This Text: Please describe any other related information or add screenshots of the PR.)


## Checklist
<!-- Please check the one that applies to this PR using "x". -->

- [x] My code follows the style guidelines of this project

- [x] I have performed a self-review of my own code

- [ ] I have commented my code, particularly in hard-to-understand areas

- [ ] I have made corresponding changes to the documentation

- [x] My changes generate no new warnings

- [x] I have added tests that prove my fix is effective or that my feature works

- [x] New and existing unit tests pass locally with my changes

- [ ] Any dependent changes have been merged and published in downstream modules
