### PR TITLE
feat: add custom message support in centerAlignLoader

### DIFF
--- a/packages/core/src/components/CenterAlignedLoader/CenterAlignedLoader.stories.mdx
+++ b/packages/core/src/components/CenterAlignedLoader/CenterAlignedLoader.stories.mdx
@@ -2,25 +2,39 @@ import { CenterAlignedLoader } from './CenterAlignedLoader.tsx';
 import { Text } from '@medly-components/core';
 import { ConcentricCircleLoader } from '@medly-components/loaders';
 import { Preview, Meta, Props } from '@storybook/addon-docs/blocks';
-import { withKnobs, color, boolean, select } from '@storybook/addon-knobs';
+import { withKnobs, color, boolean, select, text } from '@storybook/addon-knobs';
 import { RelativeDiv } from './CenterAlignedLoader.stories.tsx';
 
 <Meta title="Core" component={CenterAlignedLoader} parameters={{ jest: ['CenterAlignedLoader.test.tsx'] }} />
 
 # CenterAlignedLoader
 
-`CenterAlignedLoader` displays a loading state while the main component mounts or the data loads. This component takes the width and height of the parent and then renders the loader in the center. 
+`CenterAlignedLoader` displays a loading state while the main component mounts or the data loads. This component takes the width and height of the parent and then renders the loader in the center.
 Check out all the available loaders in [Medly Components](https://medly.github.io/medly-components/?path=/story/loaders--loaders).
 
 <Preview withToolbar>
     <Story name="CenterAlignedLoader" decorators={[withKnobs]}>
-        <CenterAlignedLoader withLoadingBox={boolean('With loading box', true)} withOverlay={boolean('With overlay', true)} />
+        <CenterAlignedLoader
+            withLoadingBox={boolean('With loading box', true)}
+            loadingMessage={text('Loading message', '')}
+            withOverlay={boolean('With overlay', true)}
+        />
     </Story>
+</Preview>
+
+## Example with custom loading message
+
+To pass custom loading message, use:
+
+`<CenterAlignedLoader withLoadingBox loadingMessage="Custom message" />`
+
+<Preview withToolbar>
+    <CenterAlignedLoader withLoadingBox loadingMessage="Custom message" />
 </Preview>
 
 ## Example with different loader
 
-To pass any React component as a loader, use: 
+To pass any React component as a loader, use:
 
 `<CenterAlignedLoader withLoadingBox loader={<ConcentricCircleLoader size="XS" />} />`
 
@@ -30,7 +44,7 @@ To pass any React component as a loader, use:
 
 ## Example with absolute position
 
-To display a loader on top of another component, set the loader position to `absolute` and the parent position to `relative`. 
+To display a loader on top of another component, set the loader position to `absolute` and the parent position to `relative`.
 
 <Preview withToolbar>
     <RelativeDiv>

--- a/packages/core/src/components/CenterAlignedLoader/CenterAlignedLoader.styled.tsx
+++ b/packages/core/src/components/CenterAlignedLoader/CenterAlignedLoader.styled.tsx
@@ -33,7 +33,8 @@ export const LoadingBox = styled('div')`
     box-sizing: border-box;
     background-color: ${({ theme }) => theme.colors.white};
     height: 14.4rem;
-    width: 14.4rem;
+    min-width: 14.4rem;
+    padding: 0 1rem;
     display: flex;
     align-items: center;
     justify-content: center;

--- a/packages/core/src/components/CenterAlignedLoader/CenterAlignedLoader.test.tsx
+++ b/packages/core/src/components/CenterAlignedLoader/CenterAlignedLoader.test.tsx
@@ -1,5 +1,5 @@
 import { ConcentricCircleLoader } from '@medly-components/loaders';
-import { render } from '@test-utils';
+import { render, screen } from '@test-utils';
 import { CenterAlignedLoader } from './CenterAlignedLoader';
 
 describe('Center Aligned Loader', () => {
@@ -10,8 +10,21 @@ describe('Center Aligned Loader', () => {
 
     it('should render properly with all props given', () => {
         const { container } = render(
-            <CenterAlignedLoader withLoadingBox withOverlay position="absolute" loader={<ConcentricCircleLoader size="XS" />} />
+            <CenterAlignedLoader
+                withLoadingBox
+                withOverlay
+                position="absolute"
+                loadingMessage=""
+                loader={<ConcentricCircleLoader size="XS" />}
+            />
         );
         expect(container).toMatchSnapshot();
+        expect(screen.getByText('Loading...')).toBeInTheDocument();
+    });
+
+    it('should render properly with custom loading message', () => {
+        const { container } = render(<CenterAlignedLoader withLoadingBox loadingMessage="custom loading message" />);
+        expect(container).toMatchSnapshot();
+        expect(screen.getByText('custom loading message')).toBeInTheDocument();
     });
 });

--- a/packages/core/src/components/CenterAlignedLoader/CenterAlignedLoader.tsx
+++ b/packages/core/src/components/CenterAlignedLoader/CenterAlignedLoader.tsx
@@ -1,23 +1,23 @@
 import { WithStyle } from '@medly-components/utils';
-import { useMemo, memo } from 'react';
+import type { FC } from 'react';
+import { memo, useMemo } from 'react';
 import Text from '../Text';
 import { CenterAligned, LoadingBox } from './CenterAlignedLoader.styled';
 import Loader from './CircleLoader.svg';
 import { CenterAlignedLoaderProps } from './types';
-import type { FC } from 'react';
 
-const Component: FC<CenterAlignedLoaderProps> = memo(({ loader, withLoadingBox, ...restProps }) => {
+const Component: FC<CenterAlignedLoaderProps> = memo(({ loader, withLoadingBox, loadingMessage, ...restProps }) => {
     const children = useMemo(
         () =>
             withLoadingBox ? (
                 <LoadingBox>
                     {loader}
-                    <Text>Loading...</Text>
+                    <Text>{loadingMessage ? loadingMessage : 'Loading...'}</Text>
                 </LoadingBox>
             ) : (
                 <>{loader}</>
             ),
-        [withLoadingBox, loader]
+        [withLoadingBox, loadingMessage, loader]
     );
     return (
         <CenterAligned withLoadingBox={withLoadingBox} {...restProps}>
@@ -26,5 +26,5 @@ const Component: FC<CenterAlignedLoaderProps> = memo(({ loader, withLoadingBox, 
     );
 });
 Component.displayName = 'CenterAlignedLoader';
-Component.defaultProps = { loader: <Loader />, withLoadingBox: false, withOverlay: false, position: 'relative' };
+Component.defaultProps = { loader: <Loader />, withLoadingBox: false, loadingMessage: '', withOverlay: false, position: 'relative' };
 export const CenterAlignedLoader: FC<CenterAlignedLoaderProps> & WithStyle = Object.assign(Component, { Style: CenterAligned });

--- a/packages/core/src/components/CenterAlignedLoader/__snapshots__/CenterAlignedLoader.test.tsx.snap
+++ b/packages/core/src/components/CenterAlignedLoader/__snapshots__/CenterAlignedLoader.test.tsx.snap
@@ -52,7 +52,8 @@ exports[`Center Aligned Loader should render properly with all props given 1`] =
   box-sizing: border-box;
   background-color: #ffffff;
   height: 14.4rem;
-  width: 14.4rem;
+  min-width: 14.4rem;
+  padding: 0 1rem;
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -135,6 +136,132 @@ exports[`Center Aligned Loader should render properly with all props given 1`] =
         class="c3 c4"
       >
         Loading...
+      </span>
+    </div>
+  </div>
+</div>
+`;
+
+exports[`Center Aligned Loader should render properly with custom loading message 1`] = `
+.c3 {
+  margin: 0;
+  color: inherit;
+  font-size: 1.4rem;
+  font-weight: 400;
+  -webkit-letter-spacing: 0rem;
+  -moz-letter-spacing: 0rem;
+  -ms-letter-spacing: 0rem;
+  letter-spacing: 0rem;
+  line-height: 2.2rem;
+  text-align: initial;
+  display: inline-block;
+}
+
+.c0 {
+  height: 100%;
+  width: 100%;
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-box-pack: center;
+  -webkit-justify-content: center;
+  -ms-flex-pack: center;
+  justify-content: center;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  z-index: 1001;
+  position: relative;
+}
+
+.c0 > * {
+  -webkit-animation: hHgZmL 300ms ease-in-out;
+  animation: hHgZmL 300ms ease-in-out;
+}
+
+.c1 {
+  box-sizing: border-box;
+  background-color: #ffffff;
+  height: 14.4rem;
+  min-width: 14.4rem;
+  padding: 0 1rem;
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  -webkit-box-pack: center;
+  -webkit-justify-content: center;
+  -ms-flex-pack: center;
+  justify-content: center;
+  -webkit-flex-direction: column;
+  -ms-flex-direction: column;
+  flex-direction: column;
+  box-shadow: 0 0.4rem 1.6rem rgba(96,120,144,0.2);
+  border-radius: 1rem;
+}
+
+.c1 .c2 {
+  margin-top: 1.4rem;
+  color: #546A7F;
+}
+
+<div>
+  <div
+    class="c0"
+  >
+    <div
+      class="c1"
+    >
+      <svg
+        class="sc-qPLKk NhgoW"
+        fill="none"
+        height="51"
+        viewBox="0 0 51 51"
+        width="51"
+        xmlns="http://www.w3.org/2000/svg"
+      >
+        <circle
+          cx="25.5"
+          cy="25.5"
+          r="24"
+          stroke="url(#lg)"
+          stroke-width="3"
+        >
+          <animatetransform
+            attributeName="transform"
+            attributeType="XML"
+            dur="900ms"
+            from="0 25.5 25.5"
+            repeatCount="indefinite"
+            to="360 25.5 25.5"
+            type="rotate"
+          />
+        </circle>
+        <defs>
+          <lineargradient
+            id="lg"
+          >
+            <stop
+              offset="70%"
+              stop-color="#EFF2F4"
+            />
+            <stop
+              offset="95%"
+              stop-color="#546A7F"
+            />
+          </lineargradient>
+        </defs>
+      </svg>
+      <span
+        class="c2 c3"
+      >
+        custom loading message
       </span>
     </div>
   </div>

--- a/packages/core/src/components/CenterAlignedLoader/types.ts
+++ b/packages/core/src/components/CenterAlignedLoader/types.ts
@@ -4,6 +4,8 @@ import type { ReactNode } from 'react';
 export interface CenterAlignedProps extends HTMLProps<HTMLDivElement> {
     /** Set it true to show the box with text and loader */
     withLoadingBox?: boolean;
+    /** Set it to a message to show custom loading text and loader */
+    loadingMessage?: string;
     /** Set it true to show overlay */
     withOverlay?: boolean;
     /** Use it to set the position of a wrapper component */


### PR DESCRIPTION
# PR Checklist

## Description
Added feature to use the custom message in center align loader component

### Type of change
<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes and API changes)
- [ ] Build changes
- [ ] CI changes
- [ ] Document content changes
- [ ] Performance improvement
- [ ] Add missing tests
- [ ] Others (please describe)


## How has this been tested?

[ ]  I have written a unit test to check if the custom message is present if you pass the custom message to the component

## Fixes #<issue_number>


## What is the current behaviour?
There is no functionality for passing a custom message to center align loader component 

## What is the new behaviour?
Now you can pass custom message prop to center align loader component.


## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No


## Additional context


## Checklist
<!-- Please check the one that applies to this PR using "x". -->

- [x] My code follows the style guidelines of this project

- [x] I have performed a self-review of my own code

- [ ] I have commented my code, particularly in hard-to-understand areas

- [x] I have made corresponding changes to the documentation

- [x] My changes generate no new warnings

- [x] I have added tests that prove my fix is effective or that my feature works

- [x] New and existing unit tests pass locally with my changes

- [ ] Any dependent changes have been merged and published in downstream modules
