### PR TITLE
docs: move deprecated components to different folder in storybook

### DIFF
--- a/packages/core/src/components/CardTable/docs/CardTable.stories.mdx
+++ b/packages/core/src/components/CardTable/docs/CardTable.stories.mdx
@@ -5,7 +5,7 @@ import { Preview, Story, Meta, Props } from '@storybook/addon-docs/blocks';
 import { ColumnConfigInterface, WithGreyBackground, WithWhiteBackground, Theme } from './CardTable.stories';
 
 <Meta
-    title="Core/CardTable"
+    title="Deprecated/Core/CardTable"
     component={CardTable}
     parameters={{
         jest: [

--- a/packages/core/src/components/Input/Input.stories.mdx
+++ b/packages/core/src/components/Input/Input.stories.mdx
@@ -2,13 +2,13 @@ import { Input } from './Input';
 import { Preview, Story, Meta, Props } from '@storybook/addon-docs/blocks';
 import * as stories from './Input.stories';
 
-<Meta title="Core" component={Input} />
+<Meta title="Deprecated/Core" component={Input} />
 
 # Input
 
-The `Input` component allows you to get user input in a text field. 
+The `Input` component allows you to get user input in a text field.
 
-> **Note:**  Input is deprecated in favor of the TextField component.
+> **Note:** Input is deprecated in favor of the TextField component.
 
 <Preview withToolbar>
     <Story


### PR DESCRIPTION
# PR Checklist

## Description
There was a callout to separate out deprecated components in storybook. This PR moves two components (Input and CardTable) to Deprecated folder in storybook.

### Type of change
<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes and API changes)
- [ ] Build changes
- [ ] CI changes
- [x] Document content changes
- [ ] Performance improvement
- [ ] Add missing tests
- [ ] Others (please describe)


## How has this been tested?
Reviewed updates in storybook. See last folder "Deprecated"
<img width="217" alt="Screen Shot 2022-04-25 at 4 27 15 PM" src="https://user-images.githubusercontent.com/26680539/165172020-e4c4fe7d-ac15-4269-a594-3b9ea91f7104.png">

[ ] Test A

[ ] Test B


## Fixes #<issue_number>
[DS-48](https://medlypharmacy.atlassian.net/jira/software/projects/DS/boards/14/backlog?selectedIssue=DS-48)

## What is the current behaviour?
Two deprecated components are inside core/ folder in storybook
<img width="206" alt="Screen Shot 2022-04-25 at 4 47 54 PM" src="https://user-images.githubusercontent.com/26680539/165172300-72f65e9b-a7a7-413f-8c6a-5c9ed8639b95.png">


## What is the new behaviour?
Two deprecated components are inside deprecated/ folder in storybook
<img width="217" alt="Screen Shot 2022-04-25 at 4 27 15 PM" src="https://user-images.githubusercontent.com/26680539/165172020-e4c4fe7d-ac15-4269-a594-3b9ea91f7104.png">

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

**Note:** No breaking changes


## Additional context
(Replace This Text: Please describe any other related information or add screenshots of the PR.)


## Checklist
<!-- Please check the one that applies to this PR using "x". -->

- [x] My code follows the style guidelines of this project

- [x] I have performed a self-review of my own code

- [x] I have commented my code, particularly in hard-to-understand areas

- [x] I have made corresponding changes to the documentation

- [x] My changes generate no new warnings

- [ ] I have added tests that prove my fix is effective or that my feature works

- [ ] New and existing unit tests pass locally with my changes

- [ ] Any dependent changes have been merged and published in downstream modules
