### PR TITLE
feat(core): add flag to disable date range error

### DIFF
--- a/packages/core/src/components/DatePicker/DatePicker.test.tsx
+++ b/packages/core/src/components/DatePicker/DatePicker.test.tsx
@@ -124,33 +124,6 @@ describe('DatePicker component', () => {
             fireEvent.click(screen.getByText('Click Here'));
             expect(container.querySelector('#dob-calendar')).toBeNull();
         });
-
-        it('should show error message on outer click if the datepicker is previously active', async () => {
-            const mockOnBlur = jest.fn(),
-                { container } = render(
-                    <>
-                        <p>Click Here</p>
-                        <DatePicker id="dob" required value={null} displayFormat="MM/dd/yyyy" onChange={jest.fn()} onBlur={mockOnBlur} />
-                    </>
-                );
-            fireEvent.click(screen.getByTitle('dob-calendar-icon'));
-            expect(container.querySelector('#dob-calendar')).toBeVisible();
-            fireEvent.click(screen.getByText('Click Here'));
-            const message = await screen.findByText('Please fill in this field');
-            expect(message).toBeInTheDocument();
-            expect(mockOnBlur).toBeCalled();
-        });
-
-        it('should not show error message on outer click if the datepicker is was not previously active', async () => {
-            render(
-                <>
-                    <p>Click Here</p>
-                    <DatePicker id="dob" required value={null} displayFormat="MM/dd/yyyy" onChange={jest.fn()} />
-                </>
-            );
-            fireEvent.click(screen.getByText('Click Here'));
-            expect(screen.queryByText('Please fill in this field')).not.toBeInTheDocument();
-        });
     });
 
     describe('calendar icon', () => {
@@ -205,24 +178,6 @@ describe('DatePicker component', () => {
             expect(mockOnChange).toHaveBeenCalledWith(dateToSelect);
         });
 
-        it('should render error if typed date is out of range', async () => {
-            const mockOnChange = jest.fn();
-            render(
-                <DatePicker
-                    id="dob"
-                    value={null}
-                    displayFormat="MM/dd/yyyy"
-                    onChange={mockOnChange}
-                    minSelectableDate={new Date(2021, 0, 2)}
-                />
-            );
-            const inputEl = screen.getByRole('textbox');
-            fireEvent.change(screen.getByRole('textbox'), { target: { value: '01 / 02 / 2020' } });
-            fireEvent.blur(inputEl);
-            const message = await screen.findByText('Please select date from allowed range');
-            expect(message).toBeInTheDocument();
-        });
-
         it('should call onChange with null if typed date is invalid', async () => {
             const mockOnChange = jest.fn();
             render(<DatePicker id="dob" value={null} displayFormat="MM/dd/yyyy" onChange={mockOnChange} />);
@@ -264,6 +219,68 @@ describe('DatePicker component', () => {
             const { inputEl } = renderComponent(true, validator);
             fireEvent.invalid(inputEl);
             expect(await screen.findByText('Please enter dob')).toBeInTheDocument();
+        });
+
+        it('should render error if typed date is out of range', async () => {
+            const mockOnChange = jest.fn();
+            render(
+                <DatePicker
+                    id="dob"
+                    value={null}
+                    displayFormat="MM/dd/yyyy"
+                    onChange={mockOnChange}
+                    minSelectableDate={new Date(2021, 0, 2)}
+                />
+            );
+            const inputEl = screen.getByRole('textbox');
+            fireEvent.change(screen.getByRole('textbox'), { target: { value: '01 / 02 / 2020' } });
+            fireEvent.blur(inputEl);
+            expect(await screen.findByText('Please select date from allowed range')).toBeInTheDocument();
+        });
+
+        it('should not render error if typed date is out of range when date range error is disabled', async () => {
+            const mockOnChange = jest.fn();
+            render(
+                <DatePicker
+                    id="dob"
+                    value={null}
+                    displayFormat="MM/dd/yyyy"
+                    onChange={mockOnChange}
+                    minSelectableDate={new Date(2021, 0, 2)}
+                    disableInvalidRange
+                />
+            );
+            const inputEl = screen.getByRole('textbox');
+            fireEvent.change(screen.getByRole('textbox'), { target: { value: '01 / 02 / 2020' } });
+            fireEvent.blur(inputEl);
+            expect(screen.queryByText('Please select date from allowed range')).not.toBeInTheDocument();
+        });
+
+        it('should show error message on outer click if the date-picker is previously active', async () => {
+            const mockOnBlur = jest.fn(),
+                { container } = render(
+                    <>
+                        <p>Click Here</p>
+                        <DatePicker id="dob" required value={null} displayFormat="MM/dd/yyyy" onChange={jest.fn()} onBlur={mockOnBlur} />
+                    </>
+                );
+            fireEvent.click(screen.getByTitle('dob-calendar-icon'));
+            expect(container.querySelector('#dob-calendar')).toBeVisible();
+            fireEvent.click(screen.getByText('Click Here'));
+            const message = await screen.findByText('Please fill in this field');
+            expect(message).toBeInTheDocument();
+            expect(mockOnBlur).toBeCalled();
+        });
+
+        it('should not show error message on outer click if the date-picker is was not previously active', async () => {
+            render(
+                <>
+                    <p>Click Here</p>
+                    <DatePicker id="dob" required value={null} displayFormat="MM/dd/yyyy" onChange={jest.fn()} />
+                </>
+            );
+            fireEvent.click(screen.getByText('Click Here'));
+            expect(screen.queryByText('Please fill in this field')).not.toBeInTheDocument();
         });
     });
 

--- a/packages/core/src/components/DatePicker/DatePicker.tsx
+++ b/packages/core/src/components/DatePicker/DatePicker.tsx
@@ -31,6 +31,7 @@ const Component: FC<DatePickerProps> = memo(
                 calendarIconPosition,
                 defaultMonth,
                 defaultYear,
+                disableInvalidRange,
                 ...restProps
             } = props,
             id = props.id || props.label?.toLowerCase().replace(/\s/g, '') || 'medly-datepicker', // TODO:- Remove static ID concept to avoid dup ID
@@ -79,6 +80,7 @@ const Component: FC<DatePickerProps> = memo(
                         isValidDate = parsedDate?.toString() !== 'Invalid Date',
                         emptyDateMessage = props.required && !inputValue && 'Please fill in this field',
                         invalidDateRangeMessage =
+                            !disableInvalidRange &&
                             (parsedDate! < minSelectableDate! || parsedDate! > maxSelectableDate!) &&
                             'Please select date from allowed range',
                         invalidDateMessage = inputValue && !isValidDate && 'Please enter a valid date',
@@ -196,7 +198,8 @@ Component.defaultProps = {
     popoverPlacement: 'bottom-start',
     showCalendarIcon: true,
     showDecorators: true,
-    calendarIconPosition: 'right'
+    calendarIconPosition: 'right',
+    disableInvalidRange: false
 };
 Component.displayName = 'DatePicker';
 export const DatePicker: FC<DatePickerProps> & WithStyle = Object.assign(Component, { Style: Wrapper });

--- a/packages/core/src/components/DatePicker/types.ts
+++ b/packages/core/src/components/DatePicker/types.ts
@@ -61,6 +61,8 @@ export interface DatePickerProps extends Omit<HTMLProps<HTMLInputElement>, 'valu
     defaultMonth?: number;
     /** Default year to show on calendar */
     defaultYear?: number;
+    /** Disable invalid date range message */
+    disableInvalidRange?: boolean;
 }
 
 export interface StyleProps extends Pick<DatePickerProps, 'variant' | 'fullWidth' | 'disabled' | 'minWidth' | 'size'> {


### PR DESCRIPTION
# PR Checklist

## Description
Disable error `Please select date from allowed range` when `disableInvalidRange` flag is true

### Type of change
<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes and API changes)
- [ ] Build changes
- [ ] CI changes
- [ ] Document content changes
- [ ] Performance improvement
- [ ] Add missing tests
- [ ] Others (please describe)


## How has this been tested?
- should not render error if typed date is out of range when date range error is disabled

## What is the current behaviour?
User cannot disable the error message and can only change the date range

## What is the new behaviour?
Adding a flag will disable the date range error

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ x I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
