### PR TITLE
fix(core): make nested table field resizeable

### DIFF
--- a/packages/core/src/components/Table/helpers.ts
+++ b/packages/core/src/components/Table/helpers.ts
@@ -82,7 +82,10 @@ export const getGridTemplateColumns = (configs: TableColumnConfig[]) => {
 export const changeSize = (width: number, dottedField: string, columnConfigs: TableColumnConfig[]) => {
     const newColumnConfigs = [...columnConfigs],
         [currField, nextField] = dottedField.split(/\.(.+)/),
-        index = columnConfigs.findIndex(config => config.field === currField),
+        index =
+            columnConfigs.findIndex(config => config.field === currField) >= 0
+                ? columnConfigs.findIndex(config => config.field === currField)
+                : columnConfigs.findIndex(config => config.field === dottedField),
         widthRegex = new RegExp(/(minmax\()(.*)(,.*\))/); //NOSONAR
 
     if (index >= 0) {
@@ -96,7 +99,6 @@ export const changeSize = (width: number, dottedField: string, columnConfigs: Ta
         } else {
             config.size = config.size?.replace(widthRegex, `$1${width}px$3`);
         }
-
         newColumnConfigs[index] = config;
     }
 


### PR DESCRIPTION
# PR Checklist

## Description
make nested table field resizeable

### Type of change
<!-- Please check the one that applies to this PR using "x". -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes and API changes)
- [ ] Build changes
- [ ] CI changes
- [ ] Document content changes
- [ ] Performance improvement
- [ ] Add missing tests
- [ ] Others (please describe)

## What is the current behaviour?
If field property of column config is using nested/dotted value (user.name) then the column is not resizeable.


## What is the new behaviour?
Column will be resizeable regardless of using nested value


## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

## Checklist
<!-- Please check the one that applies to this PR using "x". -->

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
