### PR TITLE
fix(core): fix single select issue for async options

### DIFF
--- a/packages/core/src/components/SingleSelect/SingleSelect.tsx
+++ b/packages/core/src/components/SingleSelect/SingleSelect.tsx
@@ -87,17 +87,11 @@ const Component: FC<SingleSelectProps> = memo(
                 },
                 [areOptionsVisible, defaultOptions, selectedOption, updateToDefaultOptions]
             ),
-            selectOption = useCallback(
-                (option: Option) => {
-                    setSelectedOption(option);
-                    setOptions(getUpdatedOptions(options, option));
-                },
-                [options]
-            ),
             handleOptionClick = useCallback(
                 (option: Option) => {
                     if (!option.disabled && !Array.isArray(option.value)) {
-                        selectOption(option);
+                        setSelectedOption(option);
+                        setOptions(getUpdatedOptions(options, option));
                         setInputValue(option.label);
                         hideOptions();
                         onChange && onChange(option.value);
@@ -106,7 +100,7 @@ const Component: FC<SingleSelectProps> = memo(
                         inputRef.current?.focus();
                     }
                 },
-                [inputRef.current, onChange]
+                [inputRef.current, options, onChange]
             ),
             handleOuterClick = useCallback(() => {
                 if (areOptionsVisible) {


### PR DESCRIPTION
affects: @medly-components/core

# PR Checklist

## Description
Options dropdown gets blank on the selection of the same option twice, when options are loaded asynchronously.

<img width="225" alt="Screenshot 2022-05-06 at 3 59 29 PM" src="https://user-images.githubusercontent.com/4823921/167115181-ba0183bc-b7d7-48af-b653-6465a063c64b.png">

### Type of change
<!-- Please check the one that applies to this PR using "x". -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes and API changes)
- [ ] Build changes
- [ ] CI changes
- [ ] Document content changes
- [ ] Performance improvement
- [ ] Add missing tests
- [ ] Others (please describe)

