### PR TITLE
feat(core): add prop to expand row by default

### DIFF
--- a/packages/core/src/components/Table/Body/Row/Row.tsx
+++ b/packages/core/src/components/Table/Body/Row/Row.tsx
@@ -12,8 +12,7 @@ import * as Styled from './Row.styled';
 import { RowProps } from './types';
 
 export const Row: FC<RowProps> = memo(props => {
-    const [isExpanded, setExpansionState] = useState(false),
-        [isRowHovered, setIsRowHovered] = useState(false),
+    const [isRowHovered, setIsRowHovered] = useState(false),
         {
             id,
             data,
@@ -34,6 +33,7 @@ export const Row: FC<RowProps> = memo(props => {
             addColumnMaxSize,
             rowClickDisableKey,
             rowSelectionDisableKey,
+            defaultRowExpandKey,
             isRowSelectable,
             isRowExpandable,
             isGroupedTable,
@@ -44,7 +44,8 @@ export const Row: FC<RowProps> = memo(props => {
             rowHoverActions: RowHoverActions
         } = useContext(TableComponentsCommonPropsContext);
 
-    const isRowSelected = useMemo(() => !isLoading && selectedRowIds.includes(id), [id, isLoading, selectedRowIds]),
+    const [isExpanded, setExpansionState] = useState<boolean>(defaultRowExpandKey && data[defaultRowExpandKey]),
+        isRowSelected = useMemo(() => !isLoading && selectedRowIds.includes(id), [id, isLoading, selectedRowIds]),
         isRowClickDisabled = useMemo(() => rowClickDisableKey && data[rowClickDisableKey], [data, rowClickDisableKey]),
         isRowSelectionDisabled = useMemo(() => rowSelectionDisableKey && data[rowSelectionDisableKey], [data, rowSelectionDisableKey]),
         handleRowSelection = useCallback(() => onRowSelection(id), [id, onRowSelection]),

--- a/packages/core/src/components/Table/Table.test.tsx
+++ b/packages/core/src/components/Table/Table.test.tsx
@@ -5,7 +5,12 @@ import testData from './docs/data';
 import { Table } from './Table';
 import { TableProps } from './types';
 
-const renderTable = (props?: Partial<TableProps>) => render(<Table data={testData} columns={testColumns} {...props} />);
+const renderTable = (props?: Partial<TableProps>) => render(<Table data={testData} columns={testColumns} {...props} />),
+    ExpandedRowComponent: TableProps['expandedRowComponent'] = () => <Text>Hello from Accordion</Text>,
+    downArrowKeyPress = (container: HTMLElement) => {
+        fireEvent.keyDown(container, { key: 'ArrowDown', code: 40 });
+        fireEvent.keyUp(container, { key: 'ArrowDown', code: 40 });
+    };
 
 describe('Table component', () => {
     it('should render properly', () => {
@@ -75,13 +80,6 @@ describe('Table component', () => {
     });
 
     describe('keyboard navigation', () => {
-        const downArrowKeyPress = (container: HTMLElement) => {
-            fireEvent.keyDown(container, { key: 'ArrowDown', code: 40 });
-            fireEvent.keyUp(container, { key: 'ArrowDown', code: 40 });
-        };
-
-        const ExpandedRowComponent: TableProps['expandedRowComponent'] = () => <Text>Hello from Accordion</Text>;
-
         const mockOnRowClick = jest.fn(),
             commonProps = {
                 isRowSelectable: true,
@@ -160,6 +158,32 @@ describe('Table component', () => {
             fireEvent.click(document.activeElement as HTMLInputElement);
 
             expect(onRowSelectionFn).toBeCalledTimes(1);
+        });
+    });
+
+    describe('accordion', () => {
+        it('should render table with accordion', () => {
+            renderTable({
+                isRowExpandable: true,
+                expandedRowComponent: ExpandedRowComponent
+            });
+
+            const table = screen.getByRole('table');
+
+            downArrowKeyPress(table);
+            fireEvent.keyDown(table, { key: 'ArrowRight', code: 39 });
+
+            expect(screen.getByText('Hello from Accordion')).toBeInTheDocument();
+        });
+
+        it('should render table with default expanded row', () => {
+            renderTable({
+                isRowExpandable: true,
+                defaultRowExpandKey: 'expanded',
+                expandedRowComponent: ExpandedRowComponent,
+                data: [{ ...testData[0], expanded: true }, ...testData.slice(1)]
+            });
+            expect(screen.getByText('Hello from Accordion')).toBeInTheDocument();
         });
     });
 });

--- a/packages/core/src/components/Table/docs/Table.stories.mdx
+++ b/packages/core/src/components/Table/docs/Table.stories.mdx
@@ -115,8 +115,10 @@ export const Dummy: React.FC = () => {
 
 ## Row Accordion
 
-To show Row Accordion, you must pass two props: `isRowExpandable` as `true` and pass react component as `expandedRowComponent` to show details in the expanded area. 
+To show Row Accordion, you must pass two props: `isRowExpandable` as `true` and pass react component as `expandedRowComponent` to show details in the expanded area.
 Type: `expandedRowComponent?: React.FC<{ rowData: any; rowId?: any; disabled?: boolean }>`; we are passing row data, id, and disabled state to the component.
+
+If you want a row to be expanded by default, you can pass `rowDefaultExpandKey` with a key which will be picked from the `data` object and the value should be `boolean` only.
 
 You can write your component like below:
 
@@ -137,7 +139,7 @@ export const ExpandedRowComponent: TableProps['expandedRowComponent'] = ({ rowDa
                 <DummyWrapper>
                     <DarkBackground showRowWithCardStyle={boolean('Show Row With Card Style', false)} />
                     <Table
-                        data={tableData}
+                        data={[{ ...tableData[0], expanded: true }, ...tableData.slice(1)]}
                         columns={columns}
                         onRowClick={action('Row Clicked')}
                         isLoading={boolean('Loading', false)}
@@ -152,6 +154,7 @@ export const ExpandedRowComponent: TableProps['expandedRowComponent'] = ({ rowDa
                         onPageChange={action('Page Changed')}
                         onScrolledToBottom={action('Scrolled to bottom')}
                         withRowSeparators={boolean('Enable row separators', true)}
+                        defaultRowExpandKey="expanded"
                     />
                 </DummyWrapper>
             );
@@ -201,7 +204,7 @@ type Data = [{ [your_groupBy_keyname]: string | number; count: number; secondary
 
 For example, if your data is `[{name: "A", role: "doctor"}, {name: "B", role: "engineer"}]` and if you want to group by role then you have to set `groupBy` prop to `role` and your `data` must be `[{role: 'doctor', count: 1}, {role: 'engineer', 1}]`
 
-And once you expand any row `getGroupedData` function it will be called with the group title. 
+And once you expand any row `getGroupedData` function it will be called with the group title.
 For example, in the above scenario if you expand row with `doctor` title then `getGroupedData("doctor")` will be called and you have to return a promise with grouped data according to column config.
 
 -   To expand any row by default you can pass `defaultExpandedRowIdentifier` and `rowIdentifier` prop values.
@@ -366,8 +369,8 @@ To show Custom component, you need to pass props in the below format.
 
 ## Keyboard navigation
 
-To navigate the rows in a table, use the `Up Arrow` and `Down Arrow` keys. To select a row, use the `Space` key. To expand a row use the `Right Arrow` key, and to collapse a row use the `Left Arrow` key. 
-These are the default browser key values that you can override (except the select `Space` key) by passing the keyBindings object to the `keyBindings` prop. Also, you must match the key values to the HTML spec. 
+To navigate the rows in a table, use the `Up Arrow` and `Down Arrow` keys. To select a row, use the `Space` key. To expand a row use the `Right Arrow` key, and to collapse a row use the `Left Arrow` key.
+These are the default browser key values that you can override (except the select `Space` key) by passing the keyBindings object to the `keyBindings` prop. Also, you must match the key values to the HTML spec.
 You can view the key values [here](https://keycode.info/).
 
 ```tsx
@@ -463,7 +466,7 @@ To show Pagination you must pass `withPagination` as `true` and pass `totalItems
 
 ### Custom Column Cell Component
 
-You can pass a Custom component to the `columns` prop of the table. This will render that Custom component inside the table inplace of the respective column on the UI. 
+You can pass a Custom component to the `columns` prop of the table. This will render that Custom component inside the table inplace of the respective column on the UI.
 
 For your Custom component to be rendered as a column cell, you need to pass props in the below format:
 
@@ -485,6 +488,7 @@ const CustomComponent: TableColumnConfig['component'] = React.memo(({ data, rowD
 ## Props
 
 There are only two required props `data` & `columns`. If possible, provide the `rowIdentifier`. A `rowIdentifier` is used as key name in data to identify rows.
+
 <Props of={Table} />
 
 ### Table Prop Types

--- a/packages/core/src/components/Table/types.ts
+++ b/packages/core/src/components/Table/types.ts
@@ -83,6 +83,8 @@ export interface TableProps extends Omit<HTMLProps<HTMLTableElement>, 'data' | '
     rowSelectionDisableKey?: string;
     /** Key name to disable row click */
     rowClickDisableKey?: string;
+    /** Key name to identify the row expansion */
+    defaultRowExpandKey?: string;
     /** Set it true to show checkboxes to select rows */
     isRowSelectable?: boolean;
     /** Set it true to expand rows to show extra info */


### PR DESCRIPTION
# PR Checklist

## Description
(Replace This Text: Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change.)

### Type of change
<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes and API changes)
- [ ] Build changes
- [ ] CI changes
- [ ] Document content changes
- [ ] Performance improvement
- [ ] Add missing tests
- [ ] Others (please describe)


## How has this been tested?
table > accordion (inside describe)

[x] should render table with accordion
[x] should render table with default expanded row

## Fixes #658 

## What is the current behaviour?
By default row cannot be expanded


## What is the new behaviour?
Row expansion can be done by adding `defaultRowExpandKey` and setting the value of key `true`


## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No


## Checklist
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules