### PR TITLE
fix: accordion content height issue

### DIFF
--- a/packages/core/src/components/Accordion/Accordion.test.tsx
+++ b/packages/core/src/components/Accordion/Accordion.test.tsx
@@ -34,14 +34,14 @@ describe('Accordion component', () => {
     it('should render content when header is clicked', async () => {
         renderAccordion({});
         fireEvent.click(screen.getByText(/List Of Components/));
-        expect(screen.getByRole('region')).toHaveStyle(`opacity: 1; max-height: 100vh`);
+        expect(screen.getByRole('region')).toHaveStyle(`opacity: 1`);
         fireEvent.click(screen.getByText(/List Of Components/));
         expect(screen.getByRole('region')).toHaveStyle(`opacity: 0; max-height: 0`);
     });
 
     it('should show content when defaultActive is true', () => {
         renderAccordion({ defaultActive: true });
-        expect(screen.getByRole('region')).toHaveStyle(`opacity: 1; max-height: 100vh`);
+        expect(screen.getByRole('region')).toHaveStyle(`opacity: 1`);
     });
 
     it('should change external state when header is clicked', () => {
@@ -49,6 +49,6 @@ describe('Accordion component', () => {
         expect(screen.getByRole('region')).toHaveStyle(`opacity: 0; max-height: 0`);
         fireEvent.click(screen.getByText(/List Of Components/));
         expect(container.querySelector('#active')).toBeInTheDocument();
-        expect(screen.getByRole('region')).toHaveStyle(`opacity: 1; max-height: 100vh`);
+        expect(screen.getByRole('region')).toHaveStyle(`opacity: 1`);
     });
 });

--- a/packages/core/src/components/Accordion/Accordion.tsx
+++ b/packages/core/src/components/Accordion/Accordion.tsx
@@ -1,3 +1,4 @@
+import { WithStyle } from '@medly-components/utils';
 import type { FC } from 'react';
 import { memo, useState } from 'react';
 import { Section } from './Accordion.styled';
@@ -21,8 +22,9 @@ Component.defaultProps = {
 };
 Component.displayName = 'Accordion';
 
-export const Accordion: FC<AccordionProps> & StaticProps = Object.assign(Component, {
+export const Accordion: FC<AccordionProps> & StaticProps & WithStyle = Object.assign(Component, {
     Header,
     Content,
-    Context: AccordionContext
+    Context: AccordionContext,
+    Style: Section
 });

--- a/packages/core/src/components/Accordion/Content/Content.styled.tsx
+++ b/packages/core/src/components/Accordion/Content/Content.styled.tsx
@@ -3,7 +3,7 @@ import styled from 'styled-components';
 export const Wrapper = styled('div')<{ isActive: boolean }>`
     overflow: hidden;
     transition: all 200ms ${({ isActive }) => (isActive ? 'ease-in' : 'ease-out')};
-    max-height: ${({ isActive }) => (isActive ? '100vh' : 0)};
+    max-height: ${({ isActive }) => !isActive && 0};
     opacity: ${({ isActive }) => (isActive ? 1 : 0)};
     border-bottom-left-radius: 0.8rem;
     border-bottom-right-radius: 0.8rem;

--- a/packages/core/src/components/Accordion/types.ts
+++ b/packages/core/src/components/Accordion/types.ts
@@ -1,8 +1,9 @@
+import { WithStyle } from '@medly-components/utils';
 import type { Context, Dispatch, FC, SetStateAction } from 'react';
 
 export type StaticProps = {
-    Header: FC;
-    Content: FC;
+    Header: FC & WithStyle;
+    Content: FC & WithStyle;
     Context: Context<AccordionContextType>;
 };
 


### PR DESCRIPTION
affects: @medly-components/core

# PR Checklist

## Description
Remove `max-height: 100vh` from `Accordion.Content` when it is open.

### Type of change
<!-- Please check the one that applies to this PR using "x". -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes and API changes)
- [ ] Build changes
- [ ] CI changes
- [ ] Document content changes
- [ ] Performance improvement
- [ ] Add missing tests
- [ ] Others (please describe)


## How has this been tested?
I have updated the unit tests accordingly.


## Fixes #<issue_number>


## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

**Note:** (Replace This Text: If this PR contains a breaking change please describe the impact and migration path for existing application.)


## Additional context
(Replace This Text: Please describe any other related information or add screenshots of the PR.)


## Checklist
<!-- Please check the one that applies to this PR using "x". -->

- [x] My code follows the style guidelines of this project

- [x] I have performed a self-review of my own code

- [ ] I have commented my code, particularly in hard-to-understand areas

- [ ] I have made corresponding changes to the documentation

- [x] My changes generate no new warnings

- [x] I have added tests that prove my fix is effective or that my feature works

- [x] New and existing unit tests pass locally with my changes

- [ ] Any dependent changes have been merged and published in downstream modules
