### PR TITLE
feat(theme): allow @font-face ascent and descent overrides

### DIFF
--- a/packages/core/src/components/CssBaseline/fonts.tsx
+++ b/packages/core/src/components/CssBaseline/fonts.tsx
@@ -9,6 +9,8 @@ const formatFontFace = (fontFace: FontFaceItem, fontFamily: string) => `
         font-weight: ${fontFace.fontWeight};
         font-style: ${fontFace.fontStyle};
         font-display: ${fontFace.fontDisplay};
+        ${fontFace.ascentOverride && `ascent-override: ${fontFace.ascentOverride};`}
+        ${fontFace.descentOverride && `descent-override: ${fontFace.descentOverride};`}
     }`;
 
 const formatFontFamily = (fontFamilyDetails: FontFaceTheme) => {

--- a/packages/theme/src/core/font/types.ts
+++ b/packages/theme/src/core/font/types.ts
@@ -26,6 +26,8 @@ export interface FontFaceItem {
     fontWeight: number;
     fontStyle: string;
     fontDisplay?: string;
+    ascentOverride?: string;
+    descentOverride?: string;
 }
 
 export interface FontTheme {


### PR DESCRIPTION
affects: @medly-components/core, @medly-components/theme

# PR Checklist

## Description
Certain Medly apps use a custom font which has vertical alignment issues on Windows and Android browsers. This change allows users of the library to fine tune the font's vertical spacing.

### Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes and API changes)
- [ ] Build changes
- [ ] CI changes
- [ ] Document content changes
- [ ] Performance improvement
- [ ] Add missing tests
- [ ] Others (please describe)


## How has this been tested?

[x] Manual testing using MacOS and Android devices


## What is the current behaviour?
Currently we are not exposing the `ascent-override` and `descent-override` properties for a font face.


## What is the new behaviour?
Added type definitions for `ascent-override` and `descent-override`. These values are now used when generating the global CSS, if they are defined.


## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

## Checklist

- [x] My code follows the style guidelines of this project

- [x] I have performed a self-review of my own code

- [ ] I have commented my code, particularly in hard-to-understand areas

- [ ] I have made corresponding changes to the documentation

- [x] My changes generate no new warnings

- [ ] I have added tests that prove my fix is effective or that my feature works

- [x] New and existing unit tests pass locally with my changes

- [ ] Any dependent changes have been merged and published in downstream modules
