### PR TITLE
feat: add controlled cursor and onRowNavigated for Table

### DIFF
--- a/packages/core/src/components/Table/Body/Body.tsx
+++ b/packages/core/src/components/Table/Body/Body.tsx
@@ -23,8 +23,16 @@ const Body: FC<TableBodyProps> = memo(props => {
             size,
             keyBindings
         } = useContext(TableComponentsCommonPropsContext),
-        { selectedRowIds, onRowSelection, onGroupedRowSelection, setUniqueIds, ...restProps } = props,
-        [cursor, setCursor] = useState(-1),
+        {
+            selectedRowIds,
+            onRowSelection,
+            onGroupedRowSelection,
+            setUniqueIds,
+            rowCursor: customCursor,
+            onRowNavigated,
+            ...restProps
+        } = props,
+        [cursorState, setCursor] = useState(-1),
         /* since minimap is positioned sticky with respect to the tbody, tbody should have full table width otherwise minimap positioning fails */
         tableVisibleWidth = tableRef.current?.clientWidth ?? 0,
         minimapDimensionDeps = useMemo(() => [columns], [columns]),
@@ -34,12 +42,17 @@ const Body: FC<TableBodyProps> = memo(props => {
         isCollapseKeyPressed = useKeyPress(keyBindings.collapseRow!, false, tableRef);
 
     useEffect(() => {
-        data.length && isUpKeyPressed && setCursor(prevState => (prevState > 0 ? prevState - 1 : prevState));
+        !customCursor && data.length && isUpKeyPressed && setCursor(prevState => (prevState > 0 ? prevState - 1 : prevState));
     }, [isUpKeyPressed, data]);
 
     useEffect(() => {
-        data.length && isDownKeyPressed && setCursor(prevState => (prevState < data.length - 1 ? prevState + 1 : prevState));
+        !customCursor &&
+            data.length &&
+            isDownKeyPressed &&
+            setCursor(prevState => (prevState < data.length - 1 ? prevState + 1 : prevState));
     }, [isDownKeyPressed, data]);
+
+    const cursor = customCursor ?? cursorState;
 
     return (
         <TBody>
@@ -75,6 +88,7 @@ const Body: FC<TableBodyProps> = memo(props => {
                         id={uniqueId}
                         key={identifier}
                         data={row}
+                        onRowNavigated={onRowNavigated}
                         selectedRowIds={selectedRowIds}
                         onRowSelection={onRowSelection}
                         isNavigated={index === cursor}

--- a/packages/core/src/components/Table/Body/Body.tsx
+++ b/packages/core/src/components/Table/Body/Body.tsx
@@ -43,14 +43,14 @@ const Body: FC<TableBodyProps> = memo(props => {
 
     useEffect(() => {
         !customCursor && data.length && isUpKeyPressed && setCursor(prevState => (prevState > 0 ? prevState - 1 : prevState));
-    }, [isUpKeyPressed, data]);
+    }, [isUpKeyPressed, data, customCursor]);
 
     useEffect(() => {
         !customCursor &&
             data.length &&
             isDownKeyPressed &&
             setCursor(prevState => (prevState < data.length - 1 ? prevState + 1 : prevState));
-    }, [isDownKeyPressed, data]);
+    }, [isDownKeyPressed, data, customCursor]);
 
     const cursor = customCursor ?? cursorState;
 

--- a/packages/core/src/components/Table/Body/Row/Row.tsx
+++ b/packages/core/src/components/Table/Body/Row/Row.tsx
@@ -22,6 +22,7 @@ export const Row: FC<RowProps> = memo(props => {
             showShadowAfterFrozenElement,
             selectedRowIds,
             onRowSelection,
+            onRowNavigated,
             ...restProps
         } = props,
         {
@@ -111,6 +112,10 @@ export const Row: FC<RowProps> = memo(props => {
     useEffect(() => {
         isRowCollapsedFromKeyboard && setExpansionState(false);
     }, [isRowCollapsedFromKeyboard]);
+
+    useEffect(() => {
+        if (isNavigated) onRowNavigated && onRowNavigated(data);
+    }, [isNavigated]);
 
     // TODO: Check why useKeypress is not working in this case
     const handleRowClickFromKeyboard = useCallback(

--- a/packages/core/src/components/Table/Body/Row/Row.tsx
+++ b/packages/core/src/components/Table/Body/Row/Row.tsx
@@ -115,7 +115,7 @@ export const Row: FC<RowProps> = memo(props => {
 
     useEffect(() => {
         if (isNavigated) onRowNavigated && onRowNavigated(data);
-    }, [isNavigated]);
+    }, [isNavigated, onRowNavigated]);
 
     // TODO: Check why useKeypress is not working in this case
     const handleRowClickFromKeyboard = useCallback(

--- a/packages/core/src/components/Table/Body/Row/types.ts
+++ b/packages/core/src/components/Table/Body/Row/types.ts
@@ -19,4 +19,5 @@ export type RowProps = Omit<HTMLProps<HTMLTableRowElement>, 'style' | 'data'> & 
     isNavigated?: boolean;
     isRowExpandedFromKeyboard?: boolean;
     isRowCollapsedFromKeyboard?: boolean;
+    onRowNavigated?: (data: any) => void;
 };

--- a/packages/core/src/components/Table/Body/types.ts
+++ b/packages/core/src/components/Table/Body/types.ts
@@ -1,4 +1,6 @@
 export interface TableBodyProps {
+    rowCursor?: number | string;
+    onRowNavigated?: (data: { [key: string]: any }) => void;
     setUniqueIds: React.Dispatch<React.SetStateAction<any[]>>;
     selectedRowIds: Array<number | string>;
     onRowSelection: (id: number | string) => void;

--- a/packages/core/src/components/Table/Table.test.tsx
+++ b/packages/core/src/components/Table/Table.test.tsx
@@ -159,6 +159,39 @@ describe('Table component', () => {
 
             expect(onRowSelectionFn).toBeCalledTimes(1);
         });
+
+        it('should call onRowNavigated for the navigated row', () => {
+            const mockOnRowNavigated = jest.fn();
+            const { rerender } = render(<Table data={testData} columns={testColumns} rowCursor={1} onRowNavigated={mockOnRowNavigated} />);
+
+            expect(mockOnRowNavigated).toBeCalledWith({
+                age: '1',
+                color: 'green',
+                id: 2,
+                isPassed: true,
+                marks: {
+                    maths: 4,
+                    science: 7
+                },
+                name: 'Mary May',
+                rating: 4
+            });
+
+            rerender(<Table data={testData} columns={testColumns} rowCursor={2} onRowNavigated={mockOnRowNavigated} />);
+
+            expect(mockOnRowNavigated).toBeCalledWith({
+                age: '42',
+                color: 'green',
+                id: 3,
+                isPassed: true,
+                marks: {
+                    maths: 4,
+                    science: 7
+                },
+                name: 'Christine Lobowski',
+                rating: 4
+            });
+        });
     });
 
     describe('accordion', () => {

--- a/packages/core/src/components/Table/Table.tsx
+++ b/packages/core/src/components/Table/Table.tsx
@@ -36,6 +36,8 @@ export const Component: FC<TableProps> = memo(
                 withInfiniteScroll,
                 onPageChange,
                 maxHeight,
+                rowCursor,
+                onRowNavigated,
                 keyBindings,
                 ...restProps
             } = props,
@@ -148,6 +150,8 @@ export const Component: FC<TableProps> = memo(
                         />
                         <Body
                             {...{
+                                rowCursor,
+                                onRowNavigated,
                                 setUniqueIds,
                                 setSelectAllDisableState,
                                 selectedRowIds: isGroupedTable ? selectedGroupIds : selectedRowIds,

--- a/packages/core/src/components/Table/docs/Table.stories.mdx
+++ b/packages/core/src/components/Table/docs/Table.stories.mdx
@@ -386,6 +386,103 @@ You can view the key values [here](https://keycode.info/).
 />
 ```
 
+#### Custom keyboard navigation and controlled cursor
+
+You can implement your own controlled navigation by passing the `rowCursor` prop. You can then handle the behaviour of the cursor by passing a custom function.
+
+If you want to call a custom function everytime a row is being navigated, you can pass it to `onRowNavigated`.
+
+```tsx
+import { TableColumnConfig } from '@medly-components/core';
+
+export const TableComponent: React.FC = () => {
+    const [customCursor, setCustomCursor] = useState(1),
+        handleKeyboardNavigation = useCallback(
+            e => {
+                if (e.key === 'ArrowUp') setCustomCursor(prevState => (prevState > 0 ? prevState - 1 : prevState));
+                else if (e.key === 'ArrowDown') setCustomCursor(prevState => (prevState < data.length - 1 ? prevState + 1 : prevState));
+            },
+            [setCustomCursor]
+        ),
+        handleRowNavigated = useCallback(data => console.log(`The data for navigated row is: ${data}`)),
+        tableData = [
+            { id: 1, firstName: 'Mary', lastName: 'May', age: '19' },
+            { id: 2, firstName: 'Jacob', lastName: 'Thornton', age: '22' },
+            { id: 3, firstName: 'Chris', lastName: 'Evans', age: '44' }
+        ],
+        columns: TableColumnConfig[] = [
+            { title: 'First', field: 'firstName' },
+            { title: 'Last', field: 'lastName' }
+        ];
+
+    return (
+        <Table
+            rowCursor={customCursor}
+            onKeyDown={handleKeyboardNavigation}
+            onRowNavigated={handleRowNavigated}
+            data={tableData}
+            columns={columns}
+            isLoading={false}
+            size={'M'}
+        />
+    );
+};
+```
+
+<Preview withToolbar>
+    <Story name="Table with controlled keyboard navigation">
+        {() => {
+            const [selectedRowIds, setSelectedRowIds] = useState([]),
+                [customCursor, setCustomCursor] = useState(1),
+                [tableData, setTableData] = useState(data),
+                handleFilterData = useCallback(
+                    ({ sortField, sortOrder }) => setTableData(filterData(sortField, sortOrder, tableData)),
+                    [tableData]
+                ),
+                handleKeyboardNavigation = useCallback(
+                    e => {
+                        if (e.key === 'ArrowUp') setCustomCursor(prevState => (prevState > 0 ? prevState - 1 : prevState));
+                        else if (e.key === 'ArrowDown')
+                            setCustomCursor(prevState => (prevState < data.length - 1 ? prevState + 1 : prevState));
+                    },
+                    [setCustomCursor]
+                );
+            return (
+                <DummyWrapper>
+                    <DarkBackground showRowWithCardStyle={boolean('Show Row With Card Style', false)} />
+                    <Table
+                        rowCursor={customCursor}
+                        data={tableData}
+                        columns={columns}
+                        onSort={handleFilterData}
+                        onKeyDown={handleKeyboardNavigation}
+                        selectedRowIds={selectedRowIds}
+                        onRowSelection={setSelectedRowIds}
+                        onRowClick={action('Row Clicked')}
+                        onRowNavigated={action('Row Navigated')}
+                        isLoading={boolean('Loading', false)}
+                        isRowSelectable={boolean('Is row selectable', true)}
+                        isRowExpandable={boolean('Is row expandable', true)}
+                        rowSelectionDisableKey="disabled"
+                        rowClickDisableKey="disabled"
+                        size={select('Size', ['XS', 'S', 'M', 'L'], 'M')}
+                        showRowWithCardStyle={boolean('Show Row With Card Style', false)}
+                        expandedRowComponent={ExpandedRowComponent}
+                        actions={Actions}
+                        withMinimap={boolean('Enable minimap', false)}
+                        withPagination={boolean('Enable pagination', true)}
+                        totalItems={10}
+                        itemsPerPage={10}
+                        onPageChange={action('Page Changed')}
+                        onScrolledToBottom={action('Scrolled to bottom')}
+                        withRowSeparators={boolean('Enable row separators', true)}
+                    />
+                </DummyWrapper>
+            );
+        }}
+    </Story>
+</Preview>
+
 ## Actions
 
 To show action bar you must pass `actions` in the below format

--- a/packages/core/src/components/Table/types.ts
+++ b/packages/core/src/components/Table/types.ts
@@ -139,6 +139,10 @@ export interface TableProps extends Omit<HTMLProps<HTMLTableElement>, 'data' | '
     maxHeight?: string;
     /** Set keyBindings for keyboard navigation */
     keyBindings?: KeyBindings;
+    /** Keyboard navigated row's cursor location */
+    rowCursor?: number | string;
+    /** Function to be called when row is navigated using keyboard */
+    onRowNavigated?: (rowData: ObjectType) => void;
 }
 
 export interface StaticProps {


### PR DESCRIPTION
# PR Checklist

## Description
* Adds ability to control the keyboard navigated cursor externally by passing `rowCursor` props. This will allow user to call custom functions while navigating
* Adds `onRowNavigated` prop that accepts a function which will get fired when a row is navigated. It's signature is similar to `onRowClick`

### Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes and API changes)
- [ ] Build changes
- [ ] CI changes
- [ ] Document content changes
- [ ] Performance improvement
- [ ] Add missing tests
- [ ] Others (please describe)


## How has this been tested?

A custom `rowCursor` is passed and it is checked if `onRowNavigated` is called on subsequent re-renders with changed prop values

## Fixes #665 

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No


## Checklist

- [x] My code follows the style guidelines of this project

- [x] I have performed a self-review of my own code

- [ ] I have commented my code, particularly in hard-to-understand areas

- [x] I have made corresponding changes to the documentation

- [x] My changes generate no new warnings

- [x] I have added tests that prove my fix is effective or that my feature works

- [x] New and existing unit tests pass locally with my changes

- [ ] Any dependent changes have been merged and published in downstream modules
