### PR TITLE
fix: escape key closes all modal instead of top modal

### DIFF
--- a/packages/core/src/components/Modal/Modal.stories.mdx
+++ b/packages/core/src/components/Modal/Modal.stories.mdx
@@ -44,11 +44,13 @@ The shadow effect apears on the Header & Actions section if you scroll through t
 
 ### Keyboard Support
 
-The Modal component supports keyboard navigation when in focus. 
+The Modal component supports keyboard navigation when in focus.
 
 | Key | Function        |
 | --- | --------------- |
 | Esc | Close the modal |
+
+You can disable the closing of modal on Escape key press by passing `disableEscapeKeyDown` prop.
 
 <Preview withToolbar>
     <Story name="Modal">{stories.Basic()}</Story>

--- a/packages/core/src/components/Modal/Modal.test.tsx
+++ b/packages/core/src/components/Modal/Modal.test.tsx
@@ -3,9 +3,16 @@ import { Modal } from './Modal';
 import { ModalBackgroundStyled } from './Modal.styled';
 import { ModalBackgroundProps, ModalProps } from './types';
 
-const modalRenderer = ({ open = false, onCloseModal = jest.fn(), minWidth, minHeight, shouldCloseOnOutsideClick = false }: ModalProps) =>
+const modalRenderer = ({
+    open = false,
+    onCloseModal = jest.fn(),
+    minWidth,
+    minHeight,
+    shouldCloseOnOutsideClick = false,
+    disableEscapeKeyDown = false
+}: ModalProps) =>
     render(
-        <Modal {...{ open, onCloseModal, minHeight, minWidth, shouldCloseOnOutsideClick }}>
+        <Modal {...{ open, onCloseModal, minHeight, minWidth, shouldCloseOnOutsideClick, disableEscapeKeyDown }}>
             <Modal.Header>
                 <p>Demo Header</p>
             </Modal.Header>
@@ -56,6 +63,14 @@ describe('Modal component', () => {
         modalRenderer({ open: true, onCloseModal: mockOnCloseModal });
         fireEvent.click(screen.getByTitle('medly-modal-close-icon'));
         expect(mockOnCloseModal).toBeCalled();
+    });
+
+    it('should not call onCloseModal on pressing escape key when disableEscapeKeyDown prop is passed', () => {
+        const mockOnCloseModal = jest.fn(),
+            { container } = modalRenderer({ open: true, onCloseModal: mockOnCloseModal, disableEscapeKeyDown: true }),
+            popup = container.querySelector('#medly-modal-popup') as HTMLDivElement;
+        fireEvent.keyDown(popup, { key: 'Escape', code: 27 });
+        expect(mockOnCloseModal).not.toBeCalled();
     });
 
     it('should call onCloseModal on pressing escape key', () => {

--- a/packages/core/src/components/Modal/Modal.tsx
+++ b/packages/core/src/components/Modal/Modal.tsx
@@ -40,7 +40,7 @@ const Component: FC<ModalProps> = memo(
         const handleCloseModal = useCallback(() => {
                 if (modalRef.current) manager.remove(modalRef.current);
                 onCloseModal && onCloseModal();
-            }, [onCloseModal]),
+            }, [onCloseModal, manager]),
             handleBackgroundClick = useCallback(() => {
                 shouldCloseOnOutsideClick && handleCloseModal();
             }, [shouldCloseOnOutsideClick, onCloseModal]),
@@ -63,7 +63,7 @@ const Component: FC<ModalProps> = memo(
 
         useEffect(() => {
             !disableEscapeKeyDown && open && isEscPressed && modalRef.current && manager.isTopModal(modalRef.current) && handleCloseModal();
-        }, [open, isEscPressed]);
+        }, [open, isEscPressed, disableEscapeKeyDown, handleCloseModal, manager]);
 
         useLayoutEffect(() => {
             open && setActiveElement(document.activeElement as HTMLElement);
@@ -72,7 +72,7 @@ const Component: FC<ModalProps> = memo(
         useEffect(() => {
             !shouldRender && activeElement?.focus();
             if (shouldRender && modalRef.current) manager.add(modalRef.current);
-        }, [shouldRender]);
+        }, [shouldRender, manager]);
 
         return shouldRender ? (
             <ModalBackgroundStyled {...{ ...restProps, id, open, isSmallScreen }} onClick={handleBackgroundClick}>

--- a/packages/core/src/components/Modal/Modal.tsx
+++ b/packages/core/src/components/Modal/Modal.tsx
@@ -6,13 +6,26 @@ import Content from './Content';
 import Header from './Header';
 import { ModalContext } from './Modal.context';
 import { InnerContainerStyled, ModalBackgroundStyled } from './Modal.styled';
+import ModalManager from './ModalManager';
 import Popup from './Popup';
 import { reducer } from './scrollStateReducer/scrollStateReducer';
 import { ModalProps, ModalStaticProps } from './types';
 
+const manager = new ModalManager();
+
 const Component: FC<ModalProps> = memo(
     forwardRef((props, ref) => {
-        const { open, onCloseModal, overflowVisible, children, minWidth, shouldCloseOnOutsideClick, minHeight, ...restProps } = props,
+        const {
+                open,
+                onCloseModal,
+                overflowVisible,
+                children,
+                minWidth,
+                shouldCloseOnOutsideClick,
+                minHeight,
+                disableEscapeKeyDown,
+                ...restProps
+            } = props,
             id = restProps.id || 'medly-modal',
             modalRef = useCombinedRefs<HTMLDivElement>(ref, useRef(null)),
             isEscPressed = useKeyPress('Escape', false, modalRef),
@@ -24,8 +37,12 @@ const Component: FC<ModalProps> = memo(
             { width: windowWidth } = useWindowSize(),
             isSmallScreen = windowWidth < 768;
 
-        const handleBackgroundClick = useCallback(() => {
-                shouldCloseOnOutsideClick && onCloseModal && onCloseModal();
+        const handleCloseModal = useCallback(() => {
+                if (modalRef.current) manager.remove(modalRef.current);
+                onCloseModal && onCloseModal();
+            }, [onCloseModal]),
+            handleBackgroundClick = useCallback(() => {
+                shouldCloseOnOutsideClick && handleCloseModal();
             }, [shouldCloseOnOutsideClick, onCloseModal]),
             handleAnimationEnd = useCallback(() => {
                 if (!open) {
@@ -45,7 +62,7 @@ const Component: FC<ModalProps> = memo(
         }, [open]);
 
         useEffect(() => {
-            open && isEscPressed && onCloseModal && onCloseModal();
+            !disableEscapeKeyDown && open && isEscPressed && modalRef.current && manager.isTopModal(modalRef.current) && handleCloseModal();
         }, [open, isEscPressed]);
 
         useLayoutEffect(() => {
@@ -54,6 +71,7 @@ const Component: FC<ModalProps> = memo(
 
         useEffect(() => {
             !shouldRender && activeElement?.focus();
+            if (shouldRender && modalRef.current) manager.add(modalRef.current);
         }, [shouldRender]);
 
         return shouldRender ? (
@@ -64,7 +82,7 @@ const Component: FC<ModalProps> = memo(
                     onAnimationEnd={handleAnimationEnd}
                     {...{ minWidth, minHeight, open, overflowVisible }}
                 >
-                    <CloseIcon id={`${id}-close-button`} title={`${id}-close-icon`} size="M" variant="solid" onClick={onCloseModal} />
+                    <CloseIcon id={`${id}-close-button`} title={`${id}-close-icon`} size="M" variant="solid" onClick={handleCloseModal} />
                     <InnerContainerStyled
                         id={`${id}-inner-container`}
                         ref={innerContainerRef}
@@ -85,7 +103,8 @@ const Component: FC<ModalProps> = memo(
 
 Component.defaultProps = {
     open: false,
-    shouldCloseOnOutsideClick: false
+    shouldCloseOnOutsideClick: false,
+    disableEscapeKeyDown: false
 };
 Component.displayName = 'Modal';
 export const Modal: FC<ModalProps> & WithStyle & ModalStaticProps = Object.assign(Component, {

--- a/packages/core/src/components/Modal/ModalManager/ModalManager.test.tsx
+++ b/packages/core/src/components/Modal/ModalManager/ModalManager.test.tsx
@@ -1,0 +1,90 @@
+import { cleanup } from '@test-utils';
+import ModalManager from './ModalManager';
+
+function createModalElement(text: string) {
+    const el = document.createElement('div');
+    el.appendChild(document.createTextNode(text));
+    return el;
+}
+
+const Modal1 = createModalElement('Modal 1');
+const Modal2 = createModalElement('Modal 2');
+const Modal3 = createModalElement('Modal 2');
+
+describe('Modal component', () => {
+    afterEach(cleanup);
+
+    const modalManager = new ModalManager();
+
+    it('should add modals to modal list', () => {
+        const idx1 = modalManager.add(Modal1);
+        expect(idx1).toBe(0);
+
+        const idx2 = modalManager.add(Modal2);
+        expect(idx2).toBe(1);
+
+        const idx3 = modalManager.add(Modal3);
+        expect(idx3).toBe(2);
+    });
+
+    it('should remove modals to modal list', () => {
+        const idx1 = modalManager.remove(Modal3);
+        expect(idx1).toBe(2);
+
+        const idx2 = modalManager.remove(Modal2);
+        expect(idx2).toBe(1);
+
+        const idx3 = modalManager.remove(Modal1);
+        expect(idx3).toBe(0);
+    });
+
+    it('should return the index of modal if it already exists', () => {
+        const idx = modalManager.add(Modal1);
+        expect(idx).toBe(0);
+
+        const idx2 = modalManager.add(Modal2);
+        expect(idx2).toBe(1);
+
+        const idxTemp1 = modalManager.add(Modal1);
+        expect(idxTemp1).toBe(0);
+
+        const idxTemp2 = modalManager.add(Modal2);
+        expect(idxTemp2).toBe(1);
+
+        // Cleanup
+        modalManager.remove(Modal1);
+        modalManager.remove(Modal2);
+    });
+
+    it('should return -1 if there is an attempt to remove a modal that does not exist', () => {
+        const idx = modalManager.remove(Modal1);
+        expect(idx).toBe(-1);
+    });
+
+    it('should return correct top modal in stacking context', () => {
+        modalManager.add(Modal1);
+        expect(modalManager.isTopModal(Modal1)).toBe(true);
+        expect(modalManager.isTopModal(Modal2)).toBe(false);
+        expect(modalManager.isTopModal(Modal3)).toBe(false);
+
+        modalManager.add(Modal2);
+        expect(modalManager.isTopModal(Modal1)).toBe(false);
+        expect(modalManager.isTopModal(Modal2)).toBe(true);
+        expect(modalManager.isTopModal(Modal3)).toBe(false);
+
+        modalManager.add(Modal3);
+        expect(modalManager.isTopModal(Modal1)).toBe(false);
+        expect(modalManager.isTopModal(Modal2)).toBe(false);
+        expect(modalManager.isTopModal(Modal3)).toBe(true);
+
+        modalManager.remove(Modal1);
+        expect(modalManager.isTopModal(Modal1)).toBe(false);
+        expect(modalManager.isTopModal(Modal2)).toBe(false);
+        expect(modalManager.isTopModal(Modal3)).toBe(true);
+
+        modalManager.remove(Modal3);
+        expect(modalManager.isTopModal(Modal1)).toBe(false);
+        expect(modalManager.isTopModal(Modal2)).toBe(true);
+        expect(modalManager.isTopModal(Modal3)).toBe(false);
+    });
+});

--- a/packages/core/src/components/Modal/ModalManager/ModalManager.ts
+++ b/packages/core/src/components/Modal/ModalManager/ModalManager.ts
@@ -1,0 +1,31 @@
+import { Modal } from './types';
+
+export default class ModalManager {
+    private modals: Modal[];
+
+    constructor() {
+        this.modals = [];
+    }
+
+    add(modal: Modal): number {
+        let modalIndex = this.modals.indexOf(modal);
+        if (modalIndex !== -1) return modalIndex;
+
+        modalIndex = this.modals.length;
+        this.modals.push(modal);
+        return modalIndex;
+    }
+
+    remove(modal: Modal): number {
+        const modalIndex = this.modals.indexOf(modal);
+
+        if (modalIndex === -1) return modalIndex;
+
+        this.modals.splice(modalIndex, 1);
+        return modalIndex;
+    }
+
+    isTopModal(modal: Modal): boolean {
+        return this.modals.length > 0 && this.modals[this.modals.length - 1] === modal;
+    }
+}

--- a/packages/core/src/components/Modal/ModalManager/index.ts
+++ b/packages/core/src/components/Modal/ModalManager/index.ts
@@ -1,0 +1,1 @@
+export { default } from './ModalManager';

--- a/packages/core/src/components/Modal/ModalManager/types.ts
+++ b/packages/core/src/components/Modal/ModalManager/types.ts
@@ -1,0 +1,1 @@
+export type Modal = HTMLDivElement;

--- a/packages/core/src/components/Modal/types.ts
+++ b/packages/core/src/components/Modal/types.ts
@@ -17,6 +17,8 @@ export interface ModalProps extends HTMLProps<HTMLDivElement> {
     minHeight?: string;
     /** Set it true to close the modal when clicked outside the modal */
     shouldCloseOnOutsideClick?: boolean;
+    /** Set it true to disable closing of modal on Escape key press */
+    disableEscapeKeyDown?: boolean;
 }
 
 export interface ModalBackgroundProps {


### PR DESCRIPTION
# PR Checklist

## Description
* Adds modal manager to manage stacking context of multiple modals which fixes closing of multiple modals on Escape key (#669).
* Adds `disableEscapeKeyDown` prop in case developer wants to disable this behaviour all together and implement their version of Escape key behaviour.

### Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, local variables)
- [x] Refactoring (no functional changes and API changes)
- [ ] Build changes
- [ ] CI changes
- [ ] Document content changes
- [ ] Performance improvement
- [ ] Add missing tests
- [ ] Others (please describe)


## How has this been tested?
* Multiple modals are added to the document and then their closing behaviour is checked.
* Modal manager is tested by adding and removing of div elements and verifying their indices

## Fixes #669 


## What is the current behaviour?
Escape key closes all open modals in the document


## What is the new behaviour?
Escape key only closes the top open modal in the document


## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

## Checklist

- [x] My code follows the style guidelines of this project

- [x] I have performed a self-review of my own code

- [ ] I have commented my code, particularly in hard-to-understand areas

- [x] I have made corresponding changes to the documentation

- [x] My changes generate no new warnings

- [x] I have added tests that prove my fix is effective or that my feature works

- [x] New and existing unit tests pass locally with my changes

- [ ] Any dependent changes have been merged and published in downstream modules
