### PR TITLE
feat: add support for keybinding to select row in Table component

### DIFF
--- a/packages/core/src/components/Table/Body/Cell/RowActionsCell/RowActionsCell.tsx
+++ b/packages/core/src/components/Table/Body/Cell/RowActionsCell/RowActionsCell.tsx
@@ -1,8 +1,8 @@
 import { ExpandMoreIcon } from '@medly-components/icons';
 import { WithStyle } from '@medly-components/utils';
-import type { FC } from 'react';
-import { memo, useCallback } from 'react';
+import { FC, KeyboardEvent, memo, useCallback, useContext } from 'react';
 import Checkbox from '../../../../Checkbox';
+import { TableComponentsCommonPropsContext } from '../../../context';
 import { LoadingDiv } from '../Styled';
 import { RowActionsCellStyled } from './RowActionsCell.styled';
 import { RowActionProps } from './types';
@@ -10,20 +10,29 @@ import { RowActionProps } from './types';
 const Component: FC<RowActionProps> = memo(props => {
     const stopPropagation = useCallback((e: React.MouseEvent) => e.stopPropagation(), []);
     const {
-        isLoading,
-        isRowExpanded,
-        isRowExpandable,
-        isRowSelectable,
-        isRowSelected,
-        isRowIndeterminate,
-        isRowSelectionDisabled,
-        onRowSelection,
-        onRowExpansionIconClick,
-        tableSize,
-        isGroupedTable,
-        showShadowAtRight,
-        isNavigated
-    } = props;
+            isLoading,
+            isRowExpanded,
+            isRowExpandable,
+            isRowSelectable,
+            isRowSelected,
+            isRowIndeterminate,
+            isRowSelectionDisabled,
+            onRowSelection,
+            onRowExpansionIconClick,
+            tableSize,
+            isGroupedTable,
+            showShadowAtRight,
+            isNavigated
+        } = props,
+        { keyBindings } = useContext(TableComponentsCommonPropsContext);
+
+    const handleKeyDown = useCallback(
+        (e: KeyboardEvent<HTMLInputElement>) => {
+            e.preventDefault();
+            if (e.key === keyBindings.selectRow) onRowSelection && onRowSelection(e);
+        },
+        [keyBindings.selectRow, onRowSelection]
+    );
 
     return (
         <RowActionsCellStyled
@@ -51,6 +60,7 @@ const Component: FC<RowActionProps> = memo(props => {
                             checked={isRowSelected}
                             onChange={onRowSelection}
                             onClick={stopPropagation}
+                            onKeyDown={handleKeyDown}
                         />
                     )}
                 </>

--- a/packages/core/src/components/Table/Body/Row/Row.tsx
+++ b/packages/core/src/components/Table/Body/Row/Row.tsx
@@ -120,7 +120,7 @@ export const Row: FC<RowProps> = memo(props => {
     // TODO: Check why useKeypress is not working in this case
     const handleRowClickFromKeyboard = useCallback(
         (e: KeyboardEvent<HTMLTableRowElement>) => {
-            e.key === keyBindings.rowClick! && isNavigated && handleRowClick && handleRowClick();
+            e.key === keyBindings.clickRow! && isNavigated && handleRowClick && handleRowClick();
         },
         [isNavigated, handleRowClick]
     );

--- a/packages/core/src/components/Table/Table.test.tsx
+++ b/packages/core/src/components/Table/Table.test.tsx
@@ -48,7 +48,7 @@ describe('Table component', () => {
                 onPageChange: mockOnPageChange
             };
 
-        it('should call onPageChange prop on click on any page', async () => {
+        it('should call onPageChange prop on click on any page', () => {
             const { container } = renderTable({ ...commonProps, defaultActivePage: 1 });
             expect(container).toMatchSnapshot();
             fireEvent.click(screen.getByText('30'));
@@ -86,7 +86,7 @@ describe('Table component', () => {
                 onRowClick: mockOnRowClick
             };
 
-        it('enter key should trigger onRowClick', async () => {
+        it('enter key should trigger onRowClick', () => {
             const { container } = renderTable({
                     ...commonProps
                 }),
@@ -111,7 +111,7 @@ describe('Table component', () => {
             });
         });
 
-        it('right arrow key should open the collapsible row', async () => {
+        it('right arrow key should open the collapsible row', () => {
             renderTable({
                 ...commonProps,
                 isRowExpandable: true,
@@ -126,7 +126,7 @@ describe('Table component', () => {
             expect(screen.getByText('Hello from Accordion')).toBeInTheDocument();
         });
 
-        it('left arrow key should close the collapsible row', async () => {
+        it('left arrow key should close the collapsible row', () => {
             renderTable({
                 ...commonProps,
                 isRowExpandable: true,
@@ -142,20 +142,38 @@ describe('Table component', () => {
             expect(screen.queryByText('Hello from Accordion')).not.toBeInTheDocument();
         });
 
-        it('space key should select the row', async () => {
+        it('space key should select the row', () => {
             const onRowSelectionFn = jest.fn();
             renderTable({
                 ...commonProps,
-                onRowSelection: onRowSelectionFn,
-                isRowSelectable: true
+                isRowSelectable: true,
+                onRowSelection: onRowSelectionFn
+            });
+
+            const table = screen.getByRole('table');
+            const tableRow = table.querySelectorAll('tr');
+            const checkbox = tableRow[1].querySelector('input[type="checkbox"]');
+
+            fireEvent.keyDown(checkbox!, { key: ' ', code: 32 });
+
+            expect(onRowSelectionFn).toBeCalledTimes(1);
+        });
+
+        it('custom selection key should select the row when passed as keybinding', () => {
+            const onRowSelectionFn = jest.fn();
+            renderTable({
+                ...commonProps,
+                isRowSelectable: true,
+                keyBindings: {
+                    selectRow: 'x'
+                },
+                onRowSelection: onRowSelectionFn
             });
             const table = screen.getByRole('table');
+            const tableRow = table.querySelectorAll('tr');
+            const checkbox = tableRow[2].querySelector('input[type="checkbox"]');
 
-            downArrowKeyPress(table);
-            downArrowKeyPress(table);
-            downArrowKeyPress(table);
-            downArrowKeyPress(table);
-            fireEvent.click(document.activeElement as HTMLInputElement);
+            fireEvent.keyDown(checkbox!, { key: 'x', code: 88 });
 
             expect(onRowSelectionFn).toBeCalledTimes(1);
         });

--- a/packages/core/src/components/Table/constants.ts
+++ b/packages/core/src/components/Table/constants.ts
@@ -13,5 +13,6 @@ export const defaultKeyBindings: KeyBindings = {
     down: 'ArrowDown',
     expandRow: 'ArrowRight',
     collapseRow: 'ArrowLeft',
-    rowClick: 'Enter'
+    clickRow: 'Enter',
+    selectRow: ' '
 };

--- a/packages/core/src/components/Table/docs/Table.stories.mdx
+++ b/packages/core/src/components/Table/docs/Table.stories.mdx
@@ -88,10 +88,7 @@ export const Dummy: React.FC = () => {
                         columns={columns}
                         onSort={handleFilterData}
                         selectedRowIds={selectedRowIds}
-                        onRowSelection={val => {
-                            setSelectedRowIds(val);
-                            console.log(val);
-                        }}
+                        onRowSelection={setSelectedRowIds}
                         onRowClick={action('Row Clicked')}
                         isLoading={boolean('Loading', false)}
                         isRowSelectable={boolean('Is row selectable', true)}

--- a/packages/core/src/components/Table/docs/Table.stories.mdx
+++ b/packages/core/src/components/Table/docs/Table.stories.mdx
@@ -88,7 +88,10 @@ export const Dummy: React.FC = () => {
                         columns={columns}
                         onSort={handleFilterData}
                         selectedRowIds={selectedRowIds}
-                        onRowSelection={setSelectedRowIds}
+                        onRowSelection={val => {
+                            setSelectedRowIds(val);
+                            console.log(val);
+                        }}
                         onRowClick={action('Row Clicked')}
                         isLoading={boolean('Loading', false)}
                         isRowSelectable={boolean('Is row selectable', true)}
@@ -370,7 +373,7 @@ To show Custom component, you need to pass props in the below format.
 ## Keyboard navigation
 
 To navigate the rows in a table, use the `Up Arrow` and `Down Arrow` keys. To select a row, use the `Space` key. To expand a row use the `Right Arrow` key, and to collapse a row use the `Left Arrow` key.
-These are the default browser key values that you can override (except the select `Space` key) by passing the keyBindings object to the `keyBindings` prop. Also, you must match the key values to the HTML spec.
+These are the default browser key values that you can override by passing the keyBindings object to the `keyBindings` prop. Also, you must match the key values to the HTML spec.
 You can view the key values [here](https://keycode.info/).
 
 ```tsx
@@ -381,7 +384,9 @@ You can view the key values [here](https://keycode.info/).
         up: 'ArrowUp', // Up arrow key
         down: 'ArrowDown', // Down arrow key
         expandRow: 'ArrowRight', // Right arrow key
-        collapseRow: 'ArrowLeft' // Left arrow key
+        collapseRow: 'ArrowLeft', // Left arrow key
+        clickRow: 'Enter', // Enter key
+        selectRow: ' ' // Space bar
     }}
 />
 ```

--- a/packages/core/src/components/Table/types.ts
+++ b/packages/core/src/components/Table/types.ts
@@ -20,7 +20,8 @@ export type KeyBindings = {
     down?: string;
     expandRow?: string;
     collapseRow?: string;
-    rowClick?: string;
+    clickRow?: string;
+    selectRow?: string;
 };
 
 export interface TableColumnConfig {


### PR DESCRIPTION
# PR Checklist

## Description
Adds support for `selectRow` keybinding to add custom keybinding for selecting a row

### Type of change
<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [x] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes and API changes)
- [ ] Build changes
- [ ] CI changes
- [x] Document content changes
- [ ] Performance improvement
- [x] Add missing tests
- [ ] Others (please describe)


## How has this been tested?
This has been manually tested in storybooks by passing the keybinding and testing the selection of row.
A unit test for testing the selection of row has also been added


## Fixes #672 

## What is the current behaviour?
User is not able to change the default keybinding for selecting a row


## What is the new behaviour?
User is able to change the default keybinding for selecting a row


## Does this PR introduce a breaking change?

- [x] Yes
- [ ] No

**Note:** 
In Table component's keybinding object, `rowClick` has been renamed to `clickRow` to match the naming convention of other variables. 

## Checklist
<!-- Please check the one that applies to this PR using "x". -->

- [x] My code follows the style guidelines of this project

- [x] I have performed a self-review of my own code

- [ ] I have commented my code, particularly in hard-to-understand areas

- [x] I have made corresponding changes to the documentation

- [x] My changes generate no new warnings

- [x] I have added tests that prove my fix is effective or that my feature works

- [x] New and existing unit tests pass locally with my changes

- [ ] Any dependent changes have been merged and published in downstream modules
