### PR TITLE
fix: Table component noResultRow prop vertical scroll issue

### DIFF
--- a/packages/core/src/components/Table/Body/Body.test.tsx
+++ b/packages/core/src/components/Table/Body/Body.test.tsx
@@ -1,0 +1,67 @@
+import { render, screen } from '@test-utils';
+import { RefObject } from 'react';
+import { defaultKeyBindings } from '../constants';
+import { TableComponentsCommonPropsContext } from '../context';
+import testColumns from '../docs/columns';
+import testData from '../docs/data';
+import Body from './Body';
+
+const tableRef = {
+    current: {
+        scrollWidth: 300,
+        offsetWidth: 200,
+        clientWidth: 200,
+        scrollLeft: 1,
+        addEventListener: jest.fn(),
+        removeEventListener: jest.fn(),
+        getBoundingClientRect: jest.fn().mockImplementation(() => ({
+            bottom: 100
+        })),
+        scroll: jest.fn()
+    }
+} as unknown as RefObject<HTMLTableElement>;
+
+const setUniqueIds = jest.fn(),
+    onRowSelection = jest.fn(),
+    setSelectAllDisableState = jest.fn(),
+    onGroupedRowSelection = jest.fn(),
+    defaultProps = {
+        setUniqueIds,
+        selectedRowIds: [1],
+        onRowSelection,
+        showShadowAfterFrozenElement: false,
+        setSelectAllDisableState,
+        onGroupedRowSelection
+    },
+    contextValue = {
+        columns: testColumns,
+        size: 'S' as 'XS' | 'S' | 'M' | 'L',
+        rowIdentifier: testColumns[0].field,
+        data: testData,
+        isGroupedTable: false,
+        tableRef,
+        hiddenDivRef: tableRef,
+        addColumnMaxSize: jest.fn(),
+        keyBindings: {
+            ...defaultKeyBindings
+        }
+    },
+    renderer = (props = defaultProps, context = contextValue) =>
+        render(
+            <TableComponentsCommonPropsContext.Provider value={context}>
+                <Body {...props} />
+            </TableComponentsCommonPropsContext.Provider>
+        );
+
+describe('Row', () => {
+    it('should render tbody properly with default props', () => {
+        const { container } = renderer();
+        expect(screen.getByText(testData[0].name)).toBeInTheDocument();
+        expect(container).toMatchSnapshot();
+    });
+
+    it('should render tbody properly with `No result` content', () => {
+        renderer(defaultProps, { ...contextValue, data: [] });
+        expect(screen.getByText('No result')).toBeInTheDocument();
+    });
+});

--- a/packages/core/src/components/Table/Body/Body.tsx
+++ b/packages/core/src/components/Table/Body/Body.tsx
@@ -56,20 +56,17 @@ const Body: FC<TableBodyProps> = memo(props => {
 
     return (
         <TBody>
-            {data.length === 0 &&
-                (noResultRow ? (
-                    noResultRow
-                ) : (
-                    <NoResultRow
-                        showRowWithCardStyle={showRowWithCardStyle}
-                        gridTemplateColumns={getGridTemplateColumns(columns)}
-                        withMinimap={withMinimap}
-                    >
-                        <NoResultCell width={tableVisibleWidth} tableSize={size}>
-                            {noResultRowText || 'No result'}
-                        </NoResultCell>
-                    </NoResultRow>
-                ))}
+            {data.length === 0 && (
+                <NoResultRow
+                    showRowWithCardStyle={showRowWithCardStyle}
+                    gridTemplateColumns={getGridTemplateColumns(columns)}
+                    withMinimap={withMinimap}
+                >
+                    <NoResultCell width={tableVisibleWidth} tableSize={size}>
+                        {noResultRow ? noResultRow : noResultRowText || 'No result'}
+                    </NoResultCell>
+                </NoResultRow>
+            )}
             {data.map((row, index) => {
                 const identifier = (groupBy ? row[groupBy] : row[rowIdentifier]) || index,
                     uniqueId = isNaN(Number(identifier)) ? index : identifier;

--- a/packages/core/src/components/Table/Body/__snapshots__/Body.test.tsx.snap
+++ b/packages/core/src/components/Table/Body/__snapshots__/Body.test.tsx.snap
@@ -1,0 +1,649 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`Row should render tbody properly with default props 1`] = `
+.c0 {
+  display: block;
+  min-width: -webkit-fit-content;
+  min-width: -moz-fit-content;
+  min-width: fit-content;
+}
+
+.c4 {
+  margin: 0;
+  color: inherit;
+  font-size: 1.4rem;
+  font-weight: 400;
+  -webkit-letter-spacing: 0rem;
+  -moz-letter-spacing: 0rem;
+  -ms-letter-spacing: 0rem;
+  letter-spacing: 0rem;
+  line-height: 2.2rem;
+  text-align: initial;
+  display: inline-block;
+}
+
+.c5 {
+  display: grid;
+  position: relative;
+  opacity: 1;
+  width: 100%;
+  height: 100%;
+  padding: 0;
+}
+
+.c2 {
+  width: 100%;
+  height: 100%;
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  overflow: hidden;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  opacity: 1;
+  padding: 0.8rem 1.6rem;
+  -webkit-box-pack: start;
+  -webkit-justify-content: flex-start;
+  -ms-flex-pack: start;
+  justify-content: flex-start;
+}
+
+.c2 .c3 {
+  text-overflow: ellipsis;
+  overflow: hidden;
+  white-space: nowrap;
+}
+
+.c6 {
+  width: 100%;
+  height: 100%;
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  overflow: hidden;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  opacity: 1;
+  padding: 0.8rem 1.6rem;
+  -webkit-box-pack: end;
+  -webkit-justify-content: flex-end;
+  -ms-flex-pack: end;
+  justify-content: flex-end;
+}
+
+.c6 .c3 {
+  text-overflow: ellipsis;
+  overflow: hidden;
+  white-space: nowrap;
+}
+
+.c1 {
+  display: grid;
+  position: relative;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  min-width: -webkit-fit-content;
+  min-width: -moz-fit-content;
+  min-width: fit-content;
+  outline: none;
+  cursor: inherit;
+}
+
+.c1.c1:hover {
+  z-index: 2;
+}
+
+.c1:nth-child(odd),
+.c1:nth-child(odd) > * {
+  background-color: #F7F8F9;
+  color: #13181D;
+}
+
+.c1:nth-child(even),
+.c1:nth-child(even) > * {
+  background-color: #ffffff;
+  color: #13181D;
+}
+
+.c7 {
+  display: grid;
+  position: relative;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  min-width: -webkit-fit-content;
+  min-width: -moz-fit-content;
+  min-width: fit-content;
+  outline: none;
+  cursor: inherit;
+}
+
+.c7.c7:hover {
+  z-index: 2;
+}
+
+.c7:nth-child(odd),
+.c7:nth-child(odd) > * {
+  background-color: #D7E3F6;
+  color: #13181D;
+}
+
+.c7:nth-child(even),
+.c7:nth-child(even) > * {
+  background-color: #D7E3F6;
+  color: #13181D;
+}
+
+<div>
+  <tbody
+    class="c0"
+  >
+    <tr
+      class="c1"
+      style="grid-template-columns: undefined minmax(0px, 0fr) undefined undefined undefined;"
+      tabindex="0"
+    >
+      <td
+        class="c2"
+      >
+        <span
+          class="c3 c4"
+          title="Albus Percival Wulfric Brian Dumbledore"
+        >
+          Albus Percival Wulfric Brian Dumbledore
+        </span>
+      </td>
+      <td
+        class="c5"
+        style="grid-template-columns: undefined undefined;"
+      >
+        <div
+          class="c6"
+        >
+          <span
+            class="c3 c4"
+            title="6"
+          >
+            6
+          </span>
+        </div>
+        <div
+          class="c6"
+        >
+          <span
+            class="c3 c4"
+            title="4"
+          >
+            4
+          </span>
+        </div>
+      </td>
+      <td
+        class="c6"
+      >
+        <span
+          class="c3 c4"
+          title="12"
+        >
+          12
+        </span>
+      </td>
+      <td
+        class="c2"
+      >
+        <span
+          class="c3 c4"
+          title="Yes"
+        >
+          Yes
+        </span>
+      </td>
+      <td
+        class="c6"
+      >
+        <span
+          class="c3 c4"
+          title="5"
+        >
+          5
+        </span>
+      </td>
+    </tr>
+    <tr
+      class="c7"
+      style="grid-template-columns: undefined minmax(0px, 0fr) undefined undefined undefined;"
+      tabindex="1"
+    >
+      <td
+        class="c2"
+      >
+        <span
+          class="c3 c4"
+          title="Mary May"
+        >
+          Mary May
+        </span>
+      </td>
+      <td
+        class="c5"
+        style="grid-template-columns: undefined undefined;"
+      >
+        <div
+          class="c6"
+        >
+          <span
+            class="c3 c4"
+            title="4"
+          >
+            4
+          </span>
+        </div>
+        <div
+          class="c6"
+        >
+          <span
+            class="c3 c4"
+            title="7"
+          >
+            7
+          </span>
+        </div>
+      </td>
+      <td
+        class="c6"
+      >
+        <span
+          class="c3 c4"
+          title="1"
+        >
+          1
+        </span>
+      </td>
+      <td
+        class="c2"
+      >
+        <span
+          class="c3 c4"
+          title="Yes"
+        >
+          Yes
+        </span>
+      </td>
+      <td
+        class="c6"
+      >
+        <span
+          class="c3 c4"
+          title="4"
+        >
+          4
+        </span>
+      </td>
+    </tr>
+    <tr
+      class="c1"
+      style="grid-template-columns: undefined minmax(0px, 0fr) undefined undefined undefined;"
+      tabindex="2"
+    >
+      <td
+        class="c2"
+      >
+        <span
+          class="c3 c4"
+          title="Christine Lobowski"
+        >
+          Christine Lobowski
+        </span>
+      </td>
+      <td
+        class="c5"
+        style="grid-template-columns: undefined undefined;"
+      >
+        <div
+          class="c6"
+        >
+          <span
+            class="c3 c4"
+            title="4"
+          >
+            4
+          </span>
+        </div>
+        <div
+          class="c6"
+        >
+          <span
+            class="c3 c4"
+            title="7"
+          >
+            7
+          </span>
+        </div>
+      </td>
+      <td
+        class="c6"
+      >
+        <span
+          class="c3 c4"
+          title="42"
+        >
+          42
+        </span>
+      </td>
+      <td
+        class="c2"
+      >
+        <span
+          class="c3 c4"
+          title="Yes"
+        >
+          Yes
+        </span>
+      </td>
+      <td
+        class="c6"
+      >
+        <span
+          class="c3 c4"
+          title="4"
+        >
+          4
+        </span>
+      </td>
+    </tr>
+    <tr
+      class="c1"
+      style="grid-template-columns: undefined minmax(0px, 0fr) undefined undefined undefined;"
+      tabindex="3"
+    >
+      <td
+        class="c2"
+      >
+        <span
+          class="c3 c4"
+          title="Brendon Philips"
+        >
+          Brendon Philips
+        </span>
+      </td>
+      <td
+        class="c5"
+        style="grid-template-columns: undefined undefined;"
+      >
+        <div
+          class="c6"
+        >
+          <span
+            class="c3 c4"
+            title="10"
+          >
+            10
+          </span>
+        </div>
+        <div
+          class="c6"
+        >
+          <span
+            class="c3 c4"
+            title="2"
+          >
+            2
+          </span>
+        </div>
+      </td>
+      <td
+        class="c6"
+      >
+        <span
+          class="c3 c4"
+          title="125"
+        >
+          125
+        </span>
+      </td>
+      <td
+        class="c2"
+      >
+        <span
+          class="c3 c4"
+          title="Yes"
+        >
+          Yes
+        </span>
+      </td>
+      <td
+        class="c6"
+      >
+        <span
+          class="c3 c4"
+          title="4.5"
+        >
+          4.5
+        </span>
+      </td>
+    </tr>
+    <tr
+      class="c1"
+      style="grid-template-columns: undefined minmax(0px, 0fr) undefined undefined undefined;"
+      tabindex="4"
+    >
+      <td
+        class="c2"
+      >
+        <span
+          class="c3 c4"
+          title="Margret Marmajuke"
+        >
+          Margret Marmajuke
+        </span>
+      </td>
+      <td
+        class="c5"
+        style="grid-template-columns: undefined undefined;"
+      >
+        <div
+          class="c6"
+        >
+          <span
+            class="c3 c4"
+            title="7"
+          >
+            7
+          </span>
+        </div>
+        <div
+          class="c6"
+        >
+          <span
+            class="c3 c4"
+            title="5"
+          >
+            5
+          </span>
+        </div>
+      </td>
+      <td
+        class="c6"
+      >
+        <span
+          class="c3 c4"
+          title="16"
+        >
+          16
+        </span>
+      </td>
+      <td
+        class="c2"
+      >
+        <span
+          class="c3 c4"
+          title="Yes"
+        >
+          Yes
+        </span>
+      </td>
+      <td
+        class="c6"
+      >
+        <span
+          class="c3 c4"
+          title="4"
+        >
+          4
+        </span>
+      </td>
+    </tr>
+    <tr
+      class="c1"
+      style="grid-template-columns: undefined minmax(0px, 0fr) undefined undefined undefined;"
+      tabindex="5"
+    >
+      <td
+        class="c2"
+      >
+        <span
+          class="c3 c4"
+          title="Van Ng"
+        >
+          Van Ng
+        </span>
+      </td>
+      <td
+        class="c5"
+        style="grid-template-columns: undefined undefined;"
+      >
+        <div
+          class="c6"
+        >
+          <span
+            class="c3 c4"
+            title="9"
+          >
+            9
+          </span>
+        </div>
+        <div
+          class="c6"
+        >
+          <span
+            class="c3 c4"
+            title="2"
+          >
+            2
+          </span>
+        </div>
+      </td>
+      <td
+        class="c6"
+      >
+        <span
+          class="c3 c4"
+          title="37"
+        >
+          37
+        </span>
+      </td>
+      <td
+        class="c2"
+      >
+        <span
+          class="c3 c4"
+          title="No"
+        >
+          No
+        </span>
+      </td>
+      <td
+        class="c6"
+      >
+        <span
+          class="c3 c4"
+          title="4"
+        >
+          4
+        </span>
+      </td>
+    </tr>
+    <tr
+      class="c1"
+      style="grid-template-columns: undefined minmax(0px, 0fr) undefined undefined undefined;"
+      tabindex="6"
+    >
+      <td
+        class="c2"
+      >
+        <span
+          class="c3 c4"
+          title="Duc Ng"
+        >
+          Duc Ng
+        </span>
+      </td>
+      <td
+        class="c5"
+        style="grid-template-columns: undefined undefined;"
+      >
+        <div
+          class="c6"
+        >
+          <span
+            class="c3 c4"
+            title="10"
+          >
+            10
+          </span>
+        </div>
+        <div
+          class="c6"
+        >
+          <span
+            class="c3 c4"
+            title="3"
+          >
+            3
+          </span>
+        </div>
+      </td>
+      <td
+        class="c6"
+      >
+        <span
+          class="c3 c4"
+          title="37"
+        >
+          37
+        </span>
+      </td>
+      <td
+        class="c2"
+      >
+        <span
+          class="c3 c4"
+          title="No"
+        >
+          No
+        </span>
+      </td>
+      <td
+        class="c6"
+      >
+        <span
+          class="c3 c4"
+          title="4"
+        >
+          4
+        </span>
+      </td>
+    </tr>
+  </tbody>
+</div>
+`;

--- a/packages/core/src/components/Table/Table.test.tsx
+++ b/packages/core/src/components/Table/Table.test.tsx
@@ -21,11 +21,7 @@ describe('Table component', () => {
     it('should render no result row', () => {
         renderTable({
             data: [],
-            noResultRow: (
-                <tr>
-                    <div>NO RESULT CUSTOM COMPONENT</div>
-                </tr>
-            )
+            noResultRow: <div>NO RESULT CUSTOM COMPONENT</div>
         });
         expect(screen.getByText('NO RESULT CUSTOM COMPONENT')).toBeInTheDocument();
     });

--- a/packages/core/src/components/Table/docs/Table.stories.mdx
+++ b/packages/core/src/components/Table/docs/Table.stories.mdx
@@ -354,15 +354,7 @@ You can replace `No Result` row with your Custom component. You need to pass the
 To show Custom component, you need to pass props in the below format.
 
 ```tsx
-<Table
-    data="Data Object"
-    columns="Columns Object"
-    noResultRow={
-        <tr>
-            <div>NO RESULT CUSTOM COMPONENT</div>
-        </tr>
-    }
-/>
+<Table data="Data Object" columns="Columns Object" noResultRow={<div>NO RESULT CUSTOM COMPONENT</div>} />
 ```
 
 **Note:** It is advisable to wrap your component in `<tr>` tag to avoid warnings.


### PR DESCRIPTION
# PR Checklist

## Description
fixed the vertical scroll issue on noResultRow prop. The vertical scroll was coming along with the horizontal scroll when we pass noResultRow prop to the table component and there is no data to display.

### Type of change
<!-- Please check the one that applies to this PR using "x". -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes and API changes)
- [ ] Build changes
- [ ] CI changes
- [x] Document content changes
- [ ] Performance improvement
- [x] Add missing tests
- [ ] Others (please describe)


## How has this been tested?
(Replace This Text: Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration.)

[ ] Test A

[ ] Test B


## Fixes #<issue_number>


## What is the current behaviour?
(Replace This Text: Please describe the current behaviour you are modifying, or link a relevant issue.)


## What is the new behaviour?
(Replace This Text: Please describe the expected new behaviour.)


## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

**Note:** (Replace This Text: If this PR contains a breaking change please describe the impact and migration path for existing application.)


## Additional context
(Replace This Text: Please describe any other related information or add screenshots of the PR.)


## Checklist
<!-- Please check the one that applies to this PR using "x". -->

- [x] My code follows the style guidelines of this project

- [x] I have performed a self-review of my own code

- [ ] I have commented my code, particularly in hard-to-understand areas

- [x] I have made corresponding changes to the documentation

- [x] My changes generate no new warnings

- [x] I have added tests that prove my fix is effective or that my feature works

- [x] New and existing unit tests pass locally with my changes

- [ ] Any dependent changes have been merged and published in downstream modules
