### PR TITLE
feat: add isLoading and custom loader support in search box

### DIFF
--- a/packages/core/src/components/SearchBox/SearchBox.stories.mdx
+++ b/packages/core/src/components/SearchBox/SearchBox.stories.mdx
@@ -28,6 +28,7 @@ A `SearchBox` or search bar component is a text field which takes your input and
                     minWidth={text('Min Width', '25.6rem')}
                     maxWidth={text('Max Width', '100%')}
                     fullWidth={boolean('Full Width', false)}
+                    isLoading={boolean('isLoading', false)}
                 />
             );
         }}
@@ -51,15 +52,26 @@ To customize your search filter, you must pass react component to the `customSea
                     minWidth={text('Min Width', '25.6rem')}
                     customSearchFilter={<PlaceholderComponent />}
                     fullWidth={boolean('Full Width', true)}
+                    isLoading={boolean('isLoading', false)}
                 />
             );
         }}
     </Story>
 </Preview>
 
+## Loading state
+
+You can pass boolean value to `isLoading` prop to show loader.
+
+<Preview>
+    <Story name="withLoader">
+        <SearchBox size="M" placeholder="Search" isLoading />
+    </Story>
+</Preview>
+
 ## Sizes
 
-Two sizes are available: S | M | 
+Two sizes are available: S | M |
 
 <Preview>
     <SearchBox size="S" placeholder="Small search text box" />

--- a/packages/core/src/components/SearchBox/SearchBox.stories.mdx
+++ b/packages/core/src/components/SearchBox/SearchBox.stories.mdx
@@ -1,6 +1,7 @@
 import { useState, useEffect } from 'react';
 import { Preview, Story, Meta, Props } from '@storybook/addon-docs/blocks';
 import { optionsArray, size, ThemeInterface, PlaceholderComponent } from './SearchBox.stories.tsx';
+import { DotsLoader } from '@medly-components/loaders';
 import * as stories from './SearchBox.stories';
 import { text, select, boolean } from '@storybook/addon-knobs';
 import { SearchBox } from './SearchBox';
@@ -63,9 +64,23 @@ To customize your search filter, you must pass react component to the `customSea
 
 You can pass boolean value to `isLoading` prop to show loader.
 
+#### Default loader
+
+By default circle loader is shown.
+
 <Preview>
     <Story name="withLoader">
         <SearchBox size="M" placeholder="Search" isLoading />
+    </Story>
+</Preview>
+
+#### Custom loader
+
+You can also pass custom React component to `loader` prop to show custom loader.
+
+<Preview>
+    <Story name="withCustomLoader">
+        <SearchBox size="M" placeholder="Search" loader={<DotsLoader />} isLoading />
     </Story>
 </Preview>
 

--- a/packages/core/src/components/SearchBox/SearchBox.test.tsx
+++ b/packages/core/src/components/SearchBox/SearchBox.test.tsx
@@ -141,6 +141,12 @@ describe('SearchBox', () => {
             render(<SearchBox isLoading />);
             expect(screen.queryByTitle('search icon')).not.toBeInTheDocument();
         });
+
+        it('should show custom loader when passed', () => {
+            const CustomLoader = () => <span>Loading</span>;
+            render(<SearchBox loader={<CustomLoader />} isLoading />);
+            expect(screen.getByText('Loading')).toBeInTheDocument();
+        });
     });
 
     describe('options', () => {

--- a/packages/core/src/components/SearchBox/SearchBox.test.tsx
+++ b/packages/core/src/components/SearchBox/SearchBox.test.tsx
@@ -104,8 +104,9 @@ describe('SearchBox', () => {
                 expect(closeIcon).toBeInTheDocument();
                 fireEvent.keyDown(container, { key: 'Enter', code: 13 });
                 expect(inputEl.value).toHaveLength(8);
-                expect(screen.queryByTitle('close icon')).toBeInTheDocument();
+                expect(screen.getByTitle('close icon')).toBeInTheDocument();
             });
+
             it('should show the close icon after clicking the search icon', () => {
                 const { inputEl } = renderComponent(props);
                 fireEvent.change(inputEl, { target: { value: 'Brooklyn' } });
@@ -113,7 +114,7 @@ describe('SearchBox', () => {
                 expect(closeIcon).toBeInTheDocument();
                 fireEvent.click(screen.getByTitle('search icon'));
                 expect(inputEl.value).toHaveLength(8);
-                expect(screen.queryByTitle('close icon')).toBeInTheDocument();
+                expect(screen.getByTitle('close icon')).toBeInTheDocument();
             });
         });
     });
@@ -127,6 +128,18 @@ describe('SearchBox', () => {
         it('should render expand icon when showExpandIcon prop is true', () => {
             renderComponent(props);
             expect(screen.getByTitle('expand icon')).toBeInTheDocument();
+        });
+    });
+
+    describe('loading state', () => {
+        it('should show loader when isLoading is true', () => {
+            render(<SearchBox isLoading />);
+            expect(screen.getByTestId('circle-loader')).toBeInTheDocument();
+        });
+
+        it('should not show search icon when isLoading is true', () => {
+            render(<SearchBox isLoading />);
+            expect(screen.queryByTitle('search icon')).not.toBeInTheDocument();
         });
     });
 

--- a/packages/core/src/components/SearchBox/SearchBox.tsx
+++ b/packages/core/src/components/SearchBox/SearchBox.tsx
@@ -28,6 +28,7 @@ const Component: FC<SearchBoxProps> = memo(
             minWidth,
             maxWidth,
             isLoading,
+            loader: customLoader,
             ...restProps
         } = props;
         const wrapperRef = useRef<any>(null),
@@ -161,7 +162,11 @@ const Component: FC<SearchBoxProps> = memo(
                 )}
                 <SearchIconWrapper areOptionsVisible={areOptionsVisible} isTyping={isTyping} size={size!}>
                     {isLoading ? (
-                        <CircleLoader data-testid="circle-loader" size="XXS" />
+                        customLoader ? (
+                            customLoader
+                        ) : (
+                            <CircleLoader data-testid="circle-loader" size="XXS" />
+                        )
                     ) : (
                         <SearchIcon title="search icon" size={size} onClick={handleSearchIconClick} />
                     )}

--- a/packages/core/src/components/SearchBox/SearchBox.tsx
+++ b/packages/core/src/components/SearchBox/SearchBox.tsx
@@ -1,4 +1,5 @@
 import { CloseIcon, ExpandIcon, SearchIcon } from '@medly-components/icons';
+import { CircleLoader } from '@medly-components/loaders';
 import { useCombinedRefs, useKeyPress, useOuterClickNotifier, WithStyle } from '@medly-components/utils';
 import type { FC } from 'react';
 import { forwardRef, memo, useCallback, useEffect, useRef, useState } from 'react';
@@ -26,6 +27,7 @@ const Component: FC<SearchBoxProps> = memo(
             fullWidth,
             minWidth,
             maxWidth,
+            isLoading,
             ...restProps
         } = props;
         const wrapperRef = useRef<any>(null),
@@ -158,7 +160,11 @@ const Component: FC<SearchBoxProps> = memo(
                     </ExpandIconWrapper>
                 )}
                 <SearchIconWrapper areOptionsVisible={areOptionsVisible} isTyping={isTyping} size={size!}>
-                    <SearchIcon title="search icon" size={size} onClick={handleSearchIconClick} />
+                    {isLoading ? (
+                        <CircleLoader size="XXS" />
+                    ) : (
+                        <SearchIcon title="search icon" size={size} onClick={handleSearchIconClick} />
+                    )}
                 </SearchIconWrapper>
                 {areOptionsVisible && options && (
                     <Options

--- a/packages/core/src/components/SearchBox/SearchBox.tsx
+++ b/packages/core/src/components/SearchBox/SearchBox.tsx
@@ -161,7 +161,7 @@ const Component: FC<SearchBoxProps> = memo(
                 )}
                 <SearchIconWrapper areOptionsVisible={areOptionsVisible} isTyping={isTyping} size={size!}>
                     {isLoading ? (
-                        <CircleLoader size="XXS" />
+                        <CircleLoader data-testid="circle-loader" size="XXS" />
                     ) : (
                         <SearchIcon title="search icon" size={size} onClick={handleSearchIconClick} />
                     )}

--- a/packages/core/src/components/SearchBox/types.ts
+++ b/packages/core/src/components/SearchBox/types.ts
@@ -21,6 +21,8 @@ export interface SearchBoxProps extends Omit<HTMLProps<HTMLInputElement>, 'size'
     options?: Option[];
     /** React component for additional filtering */
     customSearchFilter?: ReactElement<any>;
+    /** Show loader while the flag is true */
+    isLoading?: boolean;
     /** Does the component take up all available width */
     fullWidth?: boolean;
     /** Min width in rem/% (1rem = 10px)*/

--- a/packages/core/src/components/SearchBox/types.ts
+++ b/packages/core/src/components/SearchBox/types.ts
@@ -1,6 +1,6 @@
 import { Size } from '@medly-components/theme';
 import { HTMLProps } from '@medly-components/utils';
-import { ReactElement } from 'react';
+import { ReactElement, ReactNode } from 'react';
 
 export type Option = {
     label: string;
@@ -23,6 +23,8 @@ export interface SearchBoxProps extends Omit<HTMLProps<HTMLInputElement>, 'size'
     customSearchFilter?: ReactElement<any>;
     /** Show loader while the flag is true */
     isLoading?: boolean;
+    /** Pass any React component as a loader */
+    loader?: ReactNode;
     /** Does the component take up all available width */
     fullWidth?: boolean;
     /** Min width in rem/% (1rem = 10px)*/


### PR DESCRIPTION
# PR Checklist

## Description
* Introduction of `isLoading` prop to show loading state of the search
* Adds support for custom loader in search component

### Type of change
<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes and API changes)
- [ ] Build changes
- [ ] CI changes
- [ ] Document content changes
- [ ] Performance improvement
- [ ] Add missing tests
- [ ] Others (please describe)


## How has this been tested?
Tests have been added which test for loading state


## Fixes #677 


## What is the current behaviour?
No loading state supported by search component


## What is the new behaviour?
Introduction of isLoading prop


## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No



## Additional context

![Screenshot 2022-06-28 at 4 09 47 PM](https://user-images.githubusercontent.com/29458374/176159540-ef8c43b1-1ce3-40f2-92af-9dd0b211d5f1.png)


## Checklist
<!-- Please check the one that applies to this PR using "x". -->

- [x] My code follows the style guidelines of this project

- [x] I have performed a self-review of my own code

- [ ] I have commented my code, particularly in hard-to-understand areas

- [x] I have made corresponding changes to the documentation

- [x] My changes generate no new warnings

- [x] I have added tests that prove my fix is effective or that my feature works

- [x] New and existing unit tests pass locally with my changes

- [ ] Any dependent changes have been merged and published in downstream modules
