### PR TITLE
PSB | fix(core): remove clearing of value using ref

### DIFF
--- a/packages/core/src/components/FileInput/FileInput.tsx
+++ b/packages/core/src/components/FileInput/FileInput.tsx
@@ -29,9 +29,6 @@ const Component: FC<FileInputProps> = memo(
                 (event: any) => {
                     disabled && event.preventDefault();
                     onFocus && onFocus(event);
-                    if (inputRef.current) {
-                        inputRef.current.value = '';
-                    }
                 },
                 [disabled, onFocus]
             ),


### PR DESCRIPTION
affects: @medly-components/core

# PR Checklist

## Description
Removed manual value change using ref on label click.
if the file is already selected, and on file reselection process if we cancel it, it was clearing the file input value, but here the label is not getting cleared. Now if we try to take values from the form submission event, we get the file input value as empty.

### Type of change
<!-- Please check the one that applies to this PR using "x". -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes and API changes)
- [ ] Build changes
- [ ] CI changes
- [ ] Document content changes
- [ ] Performance improvement
- [ ] Add missing tests
- [ ] Others (please describe)


## How has this been tested?
(Replace This Text: Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration.)

[ ] Test A

[ ] Test B


## Fixes #<issue_number>


## What is the current behaviour?
on file reselection process if we cancel it, it's clearing the file input value but not the label. label shows the previously selected file. 

## What is the new behaviour?
on file reselection process if we cancel it, it will clear the file input value as well as a label like the default Html file input behaviour.


## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

**Note:** (Replace This Text: If this PR contains a breaking change please describe the impact and migration path for existing application.)


## Additional context
(Replace This Text: Please describe any other related information or add screenshots of the PR.)


## Checklist
<!-- Please check the one that applies to this PR using "x". -->

- [x] My code follows the style guidelines of this project

- [x] I have performed a self-review of my own code

- [ ] I have commented my code, particularly in hard-to-understand areas

- [ ] I have made corresponding changes to the documentation

- [x] My changes generate no new warnings

- [ ] I have added tests that prove my fix is effective or that my feature works

- [x] New and existing unit tests pass locally with my changes

- [ ] Any dependent changes have been merged and published in downstream modules
