### PR TITLE
chore(packages): add command to remove symlink for packages

### DIFF
--- a/package.json
+++ b/package.json
@@ -36,6 +36,7 @@
         "clean": "lerna clean && rimraf node_modules",
         "commit": "git-cz",
         "init:commitizen": "commitizen init cz-lerna-changelog --yarn --dev --exact --force",
+        "unlink:packages": "lerna exec -- yarn unlink",
         "link:packages": "lerna link && lerna exec -- yarn link",
         "lint:css": "stylelint 'packages/**/src/**/*.tsx'",
         "lint:ts": "eslint 'packages/**/src/**/*.{ts,tsx}'",


### PR DESCRIPTION
# PR Checklist

## Description
Add a command to remove symlink created using `yarn link:packages` command

### Type of change
<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes and API changes)
- [ ] Build changes
- [ ] CI changes
- [ ] Document content changes
- [ ] Performance improvement
- [ ] Add missing tests
- [x] Others (please describe)

Add a command to automate unlinking of packages

## How has this been tested?
manually

## What is the current behaviour?
User have to manually navigate to the respected packages and then unlink them

## What is the new behaviour?
`yarn unlink:packages` will remove all the symlinks for the nested packages

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No
