### PR TITLE
fix: should not close modal on clicking on modal 

### DIFF
--- a/packages/core/src/components/Modal/Modal.test.tsx
+++ b/packages/core/src/components/Modal/Modal.test.tsx
@@ -88,6 +88,14 @@ describe('Modal component', () => {
         expect(mockOnCloseModal).toBeCalled();
     });
 
+    it('should not call onCloseModal on click on modal', () => {
+        const mockOnCloseModal = jest.fn();
+        const { container } = modalRenderer({ open: true, onCloseModal: mockOnCloseModal, shouldCloseOnOutsideClick: true });
+        fireEvent.click(container.querySelector('#medly-modal-popup') as HTMLDivElement);
+        expect(mockOnCloseModal).not.toBeCalled();
+        expect(container.querySelector('#medly-modal-popup')).toBeInTheDocument();
+    });
+
     it('should be able to render any JSX element in header', () => {
         const mockOnCloseModal = jest.fn();
         const { container } = render(

--- a/packages/core/src/components/Modal/Modal.tsx
+++ b/packages/core/src/components/Modal/Modal.tsx
@@ -44,7 +44,7 @@ const Component: FC<ModalProps> = memo(
             }, [onCloseModal, manager]),
             handleBackgroundClick = useCallback(() => {
                 shouldCloseOnOutsideClick && handleCloseModal();
-            }, [shouldCloseOnOutsideClick, onCloseModal]),
+            }, [shouldCloseOnOutsideClick, handleCloseModal]),
             handleAnimationEnd = useCallback(() => {
                 if (!open) {
                     setShouldRender(false);

--- a/packages/core/src/components/Modal/Popup/Popup.tsx
+++ b/packages/core/src/components/Modal/Popup/Popup.tsx
@@ -1,10 +1,15 @@
 import { WithStyle } from '@medly-components/utils';
 import type { FC } from 'react';
-import { forwardRef, memo, Ref } from 'react';
+import { forwardRef, memo, Ref, useCallback } from 'react';
 import * as Styled from './Popup.styled';
 import { ModalPopupProps } from './types';
 
-const Component: FC<ModalPopupProps> = memo(forwardRef((props, ref: Ref<HTMLDivElement>) => <Styled.Popup ref={ref} {...props} />));
+const Component: FC<ModalPopupProps> = memo(
+    forwardRef((props, ref: Ref<HTMLDivElement>) => {
+        const stopPropagation = useCallback((e: React.MouseEvent) => e.stopPropagation(), []);
+        return <Styled.Popup ref={ref} onClick={stopPropagation} {...props} />;
+    })
+);
 
 Component.displayName = 'Popup';
 export const Popup: FC<ModalPopupProps> & WithStyle = Object.assign(Component, { Style: Styled.Popup });


### PR DESCRIPTION
# PR Checklist

## Description
Reverts a stopPropagation from Popup component that was removed earlier

### Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes and API changes)
- [ ] Build changes
- [ ] CI changes
- [ ] Document content changes
- [ ] Performance improvement
- [ ] Add missing tests
- [ ] Others (please describe)


## How has this been tested?
This has been tested manually and a test has also been added to verify the same


## Fixes #682


## What is the current behaviour?
When `shouldClickOnOutsideClick` is passed, the modal closes even on clicking on the modal


## What is the new behaviour?
When `shouldClickOnOutsideClick` is passed, the modal does not close on clicking on the modal


## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

**Note:** (Replace This Text: If this PR contains a breaking change please describe the impact and migration path for existing application.)


## Additional context
(Replace This Text: Please describe any other related information or add screenshots of the PR.)


## Checklist
<!-- Please check the one that applies to this PR using "x". -->

- [x] My code follows the style guidelines of this project

- [x] I have performed a self-review of my own code

- [ ] I have commented my code, particularly in hard-to-understand areas

- [ ] I have made corresponding changes to the documentation

- [ ] My changes generate no new warnings

- [ ] I have added tests that prove my fix is effective or that my feature works

- [ ] New and existing unit tests pass locally with my changes

- [ ] Any dependent changes have been merged and published in downstream modules
