### PR TITLE
fix(core): DatePicker is not reseting the text field value when the `prop` value is `null`

### DIFF
--- a/packages/core/src/components/DatePicker/DatePicker.tsx
+++ b/packages/core/src/components/DatePicker/DatePicker.tsx
@@ -48,7 +48,11 @@ const Component: FC<DatePickerProps> = memo(
             isErrorPresent = useMemo(() => !!errorText || !!builtInErrorMessage, [errorText, builtInErrorMessage]);
 
         useEffect(() => {
-            date && setTextValue(format(date, displayFormat!).replace(new RegExp('\\/|\\-', 'g'), ' $& '));
+            if (date === null) {
+                setTextValue('');
+            } else if (date) {
+                setTextValue(format(date, displayFormat!).replace(new RegExp('\\/|\\-', 'g'), ' $& '));
+            }
         }, [date, displayFormat]);
         const onTextChange = useCallback(
                 (event: React.ChangeEvent<HTMLInputElement>) => {


### PR DESCRIPTION
affects: @medly-components/core

The issues is easy to replicate when you hydrate a from with a \`null\` value prop for the
`DatePicker`,notice how the text keeps the old value.




# PR Checklist

## Description
The component `DatePicker` is when getting the prop value set to `null`, due to boolean evaluation of the following expresion
```
   date && setTextValue(format(date, displayFormat).replace(new RegExp('\\/|\\-', 'g'), ' $& '));
```
Will not execute the `setTextValue` function, keeping the old value for the `TextField`.

Example
 t1. <Datepicker value ='01/01/2022`>  --> on screen 01/01/2022
 t2 <Datepicker value ={null}>  --> on screen 01/01/2022


### Type of change
<!-- Please check the one that applies to this PR using "x". -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes and API changes)
- [ ] Build changes
- [ ] CI changes
- [ ] Document content changes
- [ ] Performance improvement
- [ ] Add missing tests
- [ ] Others (please describe)


## How has this been tested?


https://user-images.githubusercontent.com/101274033/179564709-02a19abf-9db4-4e91-92fc-1a6e86a0c22f.mov



## Fixes #<issue_number>


## What is the current behaviour?
More details in here
https://medlypharmacy.atlassian.net/browse/CHILL-707


## What is the new behaviour?
It will clear the `TextField` if value === `null`.


## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

**Note:** (Replace This Text: If this PR contains a breaking change please describe the impact and migration path for existing application.)


## Additional context
NONE.


## Checklist
<!-- Please check the one that applies to this PR using "x". -->

- [x] My code follows the style guidelines of this project

- [x] I have performed a self-review of my own code

- [ ] I have commented my code, particularly in hard-to-understand areas

- [ ] I have made corresponding changes to the documentation

- [x] My changes generate no new warnings

- [x] I have added tests that prove my fix is effective or that my feature works

- [ ] New and existing unit tests pass locally with my changes

- [ ] Any dependent changes have been merged and published in downstream modules
