### PR TITLE
fix: modal close issue on click on outside of modal

### DIFF
--- a/packages/core/src/components/Modal/Modal.tsx
+++ b/packages/core/src/components/Modal/Modal.tsx
@@ -43,7 +43,8 @@ const Component: FC<ModalProps> = memo(
                 onCloseModal && onCloseModal();
             }, [onCloseModal, manager]),
             handleBackgroundClick = useCallback(
-                (event: MouseEvent) => event.currentTarget === event.target && shouldCloseOnOutsideClick && handleCloseModal(),
+                (event: React.MouseEvent<HTMLDivElement>) =>
+                    event.currentTarget === event.target && shouldCloseOnOutsideClick && handleCloseModal(),
                 [shouldCloseOnOutsideClick, handleCloseModal]
             ),
             handleAnimationEnd = useCallback(() => {

--- a/packages/core/src/components/Modal/Modal.tsx
+++ b/packages/core/src/components/Modal/Modal.tsx
@@ -1,5 +1,5 @@
 import { useCombinedRefs, useKeyPress, useWindowSize, WithStyle } from '@medly-components/utils';
-import { FC, forwardRef, memo, useCallback, useEffect, useLayoutEffect, useReducer, useRef, useState } from 'react';
+import { FC, forwardRef, memo, MouseEvent, useCallback, useEffect, useLayoutEffect, useReducer, useRef, useState } from 'react';
 import Actions from './Actions';
 import CloseIcon from './CloseIcon';
 import Content from './Content';
@@ -43,7 +43,7 @@ const Component: FC<ModalProps> = memo(
                 onCloseModal && onCloseModal();
             }, [onCloseModal, manager]),
             handleBackgroundClick = useCallback(
-                (event: React.MouseEvent<HTMLDivElement>) =>
+                (event: MouseEvent<HTMLDivElement>) =>
                     event.currentTarget === event.target && shouldCloseOnOutsideClick && handleCloseModal(),
                 [shouldCloseOnOutsideClick, handleCloseModal]
             ),

--- a/packages/core/src/components/Modal/Modal.tsx
+++ b/packages/core/src/components/Modal/Modal.tsx
@@ -42,9 +42,10 @@ const Component: FC<ModalProps> = memo(
                 if (modalRef.current) manager.remove(modalRef.current);
                 onCloseModal && onCloseModal();
             }, [onCloseModal, manager]),
-            handleBackgroundClick = useCallback(() => {
-                shouldCloseOnOutsideClick && handleCloseModal();
-            }, [shouldCloseOnOutsideClick, handleCloseModal]),
+            handleBackgroundClick = useCallback(
+                (event: MouseEvent) => event.currentTarget === event.target && shouldCloseOnOutsideClick && handleCloseModal(),
+                [shouldCloseOnOutsideClick, handleCloseModal]
+            ),
             handleAnimationEnd = useCallback(() => {
                 if (!open) {
                     setShouldRender(false);

--- a/packages/core/src/components/Modal/Popup/Popup.tsx
+++ b/packages/core/src/components/Modal/Popup/Popup.tsx
@@ -1,15 +1,10 @@
 import { WithStyle } from '@medly-components/utils';
 import type { FC } from 'react';
-import { forwardRef, memo, Ref, useCallback } from 'react';
+import { forwardRef, memo, Ref } from 'react';
 import * as Styled from './Popup.styled';
 import { ModalPopupProps } from './types';
 
-const Component: FC<ModalPopupProps> = memo(
-    forwardRef((props, ref: Ref<HTMLDivElement>) => {
-        const stopPropagation = useCallback((e: React.MouseEvent) => e.stopPropagation(), []);
-        return <Styled.Popup ref={ref} onClick={stopPropagation} {...props} />;
-    })
-);
+const Component: FC<ModalPopupProps> = memo(forwardRef((props, ref: Ref<HTMLDivElement>) => <Styled.Popup ref={ref} {...props} />));
 
 Component.displayName = 'Popup';
 export const Popup: FC<ModalPopupProps> & WithStyle = Object.assign(Component, { Style: Styled.Popup });


### PR DESCRIPTION
affects: @medly-components/core

ISSUES CLOSED: #688

# PR Checklist

## Description
Handles the issue of modal being closed on click on outside of modal and also the issue of closing the singleSelect on clicking on outside of single select component.


### Type of change
<!-- Please check the one that applies to this PR using "x". -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes and API changes)
- [ ] Build changes
- [ ] CI changes
- [ ] Document content changes
- [ ] Performance improvement
- [ ] Add missing tests
- [ ] Others (please describe)


## Fixes  #688


## What is the current behaviour?
On Clicking outside of any SingleSelect component which is being used in Modal is not closing the dropdown.


## What is the new behaviour?
Now Clicking outside of any SingleSelect component which is being used in Modal is closing the dropdown.


## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

**Note:** (Replace This Text: If this PR contains a breaking change please describe the impact and migration path for existing application.)


## Additional context
(Replace This Text: Please describe any other related information or add screenshots of the PR.)


## Checklist
<!-- Please check the one that applies to this PR using "x". -->

- [x] My code follows the style guidelines of this project

- [x] I have performed a self-review of my own code

- [ ] I have commented my code, particularly in hard-to-understand areas

- [ ] I have made corresponding changes to the documentation

- [x] My changes generate no new warnings

- [ ] I have added tests that prove my fix is effective or that my feature works

- [x] New and existing unit tests pass locally with my changes

- [ ] Any dependent changes have been merged and published in downstream modules
