### PR TITLE
feat(core): updated core modal border radius and padding

### DIFF
--- a/packages/core/src/components/Modal/Header/Header.styled.tsx
+++ b/packages/core/src/components/Modal/Header/Header.styled.tsx
@@ -12,11 +12,12 @@ const getPosition = ({ scrollState }: Props) => {
 
     return css`
         position: ${isWithinThreshold ? 'relative' : 'fixed'};
-        padding: ${({ theme }) => `${isWithinThreshold ? theme.spacing.L2 : theme.spacing.S4} ${theme.spacing.S4} ${theme.spacing.S4}`};
+        padding: ${({ theme }) =>
+            `${isWithinThreshold ? theme.spacing.L2 : theme.spacing.S4} ${theme.spacing.L2} ${theme.spacing.S4} ${theme.spacing.S4}`};
 
         ${({ theme }) => media(breakpoints(theme.breakpoints).up('M'))`
             position: relative;
-            padding: ${theme.spacing.M2} ${theme.spacing.M2} ${theme.spacing.S4};
+            padding: ${theme.spacing.M2} ${theme.spacing.L2} ${theme.spacing.S4} ${theme.spacing.M2};
         `}
 
         ${({ theme }) => `
@@ -48,8 +49,8 @@ export const Header = styled('div')<Props>`
     box-sizing: border-box;
     background-color: ${({ theme }) => theme.modal.backgroundColor};
     width: 100%;
-    border-top-left-radius: 1.6rem;
-    border-top-right-radius: 1.6rem;
+    border-top-left-radius: 1.2rem;
+    border-top-right-radius: 1.2rem;
     z-index: 10;
     color: ${({ theme }) => theme.modal.headerColor};
     ${getPosition}

--- a/packages/core/src/components/Modal/Header/__snapshots__/Header.test.tsx.snap
+++ b/packages/core/src/components/Modal/Header/__snapshots__/Header.test.tsx.snap
@@ -18,19 +18,19 @@ exports[`Modal component header should render properly at small screen size 1`] 
   box-sizing: border-box;
   background-color: #ffffff;
   width: 100%;
-  border-top-left-radius: 1.6rem;
-  border-top-right-radius: 1.6rem;
+  border-top-left-radius: 1.2rem;
+  border-top-right-radius: 1.2rem;
   z-index: 10;
   color: #13181D;
   position: fixed;
-  padding: 1.6rem 1.6rem 1.6rem;
+  padding: 1.6rem 5.6rem 1.6rem 1.6rem;
   box-shadow: 0 1.8rem 1.6rem -1.6rem rgba(176,188,200,0.6);
 }
 
 @media (min-width:768px) {
   .c0 {
     position: relative;
-    padding: 3.2rem 3.2rem 1.6rem;
+    padding: 3.2rem 5.6rem 1.6rem 3.2rem;
   }
 }
 

--- a/packages/core/src/components/Modal/Modal.tsx
+++ b/packages/core/src/components/Modal/Modal.tsx
@@ -77,8 +77,7 @@ const Component: FC<ModalProps> = memo(
             if (shouldRender && modalRef.current) manager.add(modalRef.current);
         }, [shouldRender, manager]);
 
-        const contentRef = useRef<HTMLDivElement>(null);
-        const handleScroll = useScrollState({ ref: contentRef, scrollState, dispatch });
+        const handleScroll = useScrollState({ ref: innerContainerRef, scrollState, dispatch });
 
         return shouldRender ? (
             <ModalBackgroundStyled {...{ ...restProps, id, open, isSmallScreen }} onClick={handleBackgroundClick}>

--- a/packages/core/src/components/Modal/Popup/Popup.styled.tsx
+++ b/packages/core/src/components/Modal/Popup/Popup.styled.tsx
@@ -47,8 +47,8 @@ export const Popup = styled('div')<ModalPopupProps>`
     min-height: ${({ minHeight }) => minHeight || '25.6rem'};
     box-shadow: 0 0.4rem 3.2 ${({ theme }) => theme.modal.shadowColor};
     box-sizing: border-box;
-    border-top-left-radius: 1.6rem;
-    border-top-right-radius: 1.6rem;
+    border-top-left-radius: 1.2rem;
+    border-top-right-radius: 1.2rem;
     overflow: ${({ overflowVisible }) => !overflowVisible && `hidden`};
 
     ${({ theme, open }) => media(breakpoints(theme.breakpoints).down('S'))`

--- a/packages/core/src/components/Modal/Popup/__snapshots__/Popup.test.tsx.snap
+++ b/packages/core/src/components/Modal/Popup/__snapshots__/Popup.test.tsx.snap
@@ -14,8 +14,8 @@ exports[`Modal Popup component at small screen size should render properly when 
   min-height: 200px;
   box-shadow: 0 0.4rem 3.2 rgba(67,84,101,0.5);
   box-sizing: border-box;
-  border-top-left-radius: 1.6rem;
-  border-top-right-radius: 1.6rem;
+  border-top-left-radius: 1.2rem;
+  border-top-right-radius: 1.2rem;
   overflow: hidden;
 }
 
@@ -74,8 +74,8 @@ exports[`Modal Popup component at small screen size should render properly when 
   min-height: 200px;
   box-shadow: 0 0.4rem 3.2 rgba(67,84,101,0.5);
   box-sizing: border-box;
-  border-top-left-radius: 1.6rem;
-  border-top-right-radius: 1.6rem;
+  border-top-left-radius: 1.2rem;
+  border-top-right-radius: 1.2rem;
   overflow: hidden;
 }
 

--- a/packages/core/src/components/Modal/__snapshots__/Modal.test.tsx.snap
+++ b/packages/core/src/components/Modal/__snapshots__/Modal.test.tsx.snap
@@ -180,12 +180,12 @@ exports[`Modal component should render properly when it is open 1`] = `
   box-sizing: border-box;
   background-color: #ffffff;
   width: 100%;
-  border-top-left-radius: 1.6rem;
-  border-top-right-radius: 1.6rem;
+  border-top-left-radius: 1.2rem;
+  border-top-right-radius: 1.2rem;
   z-index: 10;
   color: #13181D;
   position: relative;
-  padding: 5.6rem 1.6rem 1.6rem;
+  padding: 5.6rem 5.6rem 1.6rem 1.6rem;
 }
 
 .c0 {
@@ -254,8 +254,8 @@ exports[`Modal component should render properly when it is open 1`] = `
   min-height: 200px;
   box-shadow: 0 0.4rem 3.2 rgba(67,84,101,0.5);
   box-sizing: border-box;
-  border-top-left-radius: 1.6rem;
-  border-top-right-radius: 1.6rem;
+  border-top-left-radius: 1.2rem;
+  border-top-right-radius: 1.2rem;
   overflow: hidden;
 }
 
@@ -305,7 +305,7 @@ exports[`Modal component should render properly when it is open 1`] = `
 @media (min-width:768px) {
   .c5 {
     position: relative;
-    padding: 3.2rem 3.2rem 1.6rem;
+    padding: 3.2rem 5.6rem 1.6rem 3.2rem;
   }
 }
 


### PR DESCRIPTION
affects: @medly-components/core

Updated core modal border radius and padding to avoid overlap of title and close button.
There was a mix of values for border radius, some places using `1.6rem` and others `1.2rem` and we decided 1.2 is the correct value.

I attached screenshots for the header's padding values, we're now making sure that the close button won't overlap the text.

Before
![before](https://user-images.githubusercontent.com/56295/182145492-ebb41a2a-0855-47fd-bd98-1d77076c254d.png)

After
![after](https://user-images.githubusercontent.com/56295/182145503-5e821e92-a499-47f8-92fe-c427c088b261.png)

