### PR TITLE
fix(core): fix close icon bug, when initial value is provided.

### DIFF
--- a/packages/core/src/components/SearchBox/SearchBox.test.tsx
+++ b/packages/core/src/components/SearchBox/SearchBox.test.tsx
@@ -66,6 +66,12 @@ describe('SearchBox', () => {
             onInputChange: jest.fn()
         };
 
+        it('should render close icon when user provides initial value', () => {
+            const { inputEl } = renderComponent({ ...props, value: 'ABC' });
+            expect(inputEl.value).toHaveLength(3);
+            expect(screen.getByTitle('close icon')).toBeInTheDocument();
+        });
+
         it('should render close icon when user starts typing', () => {
             const { inputEl } = renderComponent(props);
             fireEvent.change(inputEl, { target: { value: 'R' } });

--- a/packages/core/src/components/SearchBox/SearchBox.tsx
+++ b/packages/core/src/components/SearchBox/SearchBox.tsx
@@ -39,7 +39,7 @@ const Component: FC<SearchBoxProps> = memo(
             [areOptionsVisible, setOptionsVisibilityState] = useState(false),
             [options, setOptions] = useState<Option[]>(defaultOptions || []),
             [isCustomSearchActive, setIsCustomSearchActive] = useState(false),
-            [showCloseIcon, setShowCloseIcon] = useState(false),
+            [showCloseIcon, setShowCloseIcon] = useState(!!restProps?.value?.toString().length),
             isEnterKeyPress = useKeyPress('Enter', true, optionsRef);
 
         useEffect(() => {
@@ -124,9 +124,9 @@ const Component: FC<SearchBoxProps> = memo(
                 }
                 onSearch && onSearch(inputRef.current?.value || '');
                 setOptionsVisibilityState(false);
+                setShowCloseIcon(inputRef.current?.value.length !== 0);
                 updateIsTyping(false);
             }
-            setShowCloseIcon(inputRef.current?.value.length !== 0);
         }, [isEnterKeyPress]);
 
         const hasCustomSearchFilter = !!customSearchFilter;

--- a/packages/core/src/components/SearchBox/SearchBox.tsx
+++ b/packages/core/src/components/SearchBox/SearchBox.tsx
@@ -124,9 +124,9 @@ const Component: FC<SearchBoxProps> = memo(
                 }
                 onSearch && onSearch(inputRef.current?.value || '');
                 setOptionsVisibilityState(false);
-                setShowCloseIcon(inputRef.current?.value.length !== 0);
                 updateIsTyping(false);
             }
+            setShowCloseIcon(inputRef.current?.value.length !== 0);
         }, [isEnterKeyPress]);
 
         const hasCustomSearchFilter = !!customSearchFilter;


### PR DESCRIPTION
affects: @medly-components/core

# PR Checklist

## Description
If user provided initial value to the component then it should render close icon.

### Type of change
<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes and API changes)
- [ ] Build changes
- [ ] CI changes
- [ ] Document content changes
- [ ] Performance improvement
- [ ] Add missing tests
- [ ] Others (please describe)


## How has this been tested?
(Replace This Text: Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration.)

[ ] Test A

[ ] Test B


## Fixes #<issue_number>


## What is the current behaviour?
(Replace This Text: Please describe the current behaviour you are modifying, or link a relevant issue.)


## What is the new behaviour?
(Replace This Text: Please describe the expected new behaviour.)


## Does this PR introduce a breaking change?

- [ ] Yes
- [ ] No

**Note:** (Replace This Text: If this PR contains a breaking change please describe the impact and migration path for existing application.)


## Additional context
(Replace This Text: Please describe any other related information or add screenshots of the PR.)


## Checklist
<!-- Please check the one that applies to this PR using "x". -->

- [ ] My code follows the style guidelines of this project

- [ ] I have performed a self-review of my own code

- [ ] I have commented my code, particularly in hard-to-understand areas

- [ ] I have made corresponding changes to the documentation

- [ ] My changes generate no new warnings

- [ ] I have added tests that prove my fix is effective or that my feature works

- [ ] New and existing unit tests pass locally with my changes

- [ ] Any dependent changes have been merged and published in downstream modules
