### PR TITLE
revert: sidenav and drawer height issue on mobile devices

### DIFF
--- a/packages/core/src/components/Drawer/Drawer.styled.tsx
+++ b/packages/core/src/components/Drawer/Drawer.styled.tsx
@@ -34,7 +34,6 @@ export const DrawerStyled = styled('aside')<DrawerStyledProps>`
     display: flex;
     flex-direction: column;
     height: 100vh;
-    height: fill-available;
     background-color: ${({ theme }) => theme.colors.white};
     width: ${props => props.width};
     position: fixed;

--- a/packages/core/src/components/Drawer/__snapshots__/Drawer.test.tsx.snap
+++ b/packages/core/src/components/Drawer/__snapshots__/Drawer.test.tsx.snap
@@ -30,9 +30,6 @@ exports[`Drawer component should render properly with left positioned 1`] = `
   -ms-flex-direction: column;
   flex-direction: column;
   height: 100vh;
-  height: -webkit-fill-available;
-  height: -moz-available;
-  height: fill-available;
   background-color: #ffffff;
   width: 40rem;
   position: fixed;
@@ -200,9 +197,6 @@ exports[`Drawer component should render properly with right positioned 1`] = `
   -ms-flex-direction: column;
   flex-direction: column;
   height: 100vh;
-  height: -webkit-fill-available;
-  height: -moz-available;
-  height: fill-available;
   background-color: #ffffff;
   width: 40rem;
   position: fixed;

--- a/packages/layout/src/components/Header/Nav/Nav.styled.tsx
+++ b/packages/layout/src/components/Header/Nav/Nav.styled.tsx
@@ -8,7 +8,6 @@ export const BGOverlay = styled.div<{ isOpen: boolean }>`
     left: 0;
     width: 100vw;
     height: 100vh;
-    height: fill-available;
     background: ${({ theme }) => theme.colors.black};
     opacity: ${({ isOpen }) => (isOpen ? 0.5 : 0)};
     z-index: ${({ isOpen }) => (isOpen ? 1000 : -100)};
@@ -22,7 +21,6 @@ export const BGOverlay = styled.div<{ isOpen: boolean }>`
 export const Container = styled.div<{ isOpen: boolean }>`
     position: absolute;
     height: 100vh;
-    height: fill-available;
     width: 320px;
     top: 0;
     left: ${props => (props.isOpen ? 0 : '-320px')};

--- a/packages/layout/src/components/SideNav/__snapshots__/SideNav.test.tsx.snap
+++ b/packages/layout/src/components/SideNav/__snapshots__/SideNav.test.tsx.snap
@@ -259,9 +259,6 @@ exports[`SideNav should render properly with shadow 1`] = `
 
 .c0 {
   height: 100vh;
-  height: -webkit-fill-available;
-  height: -moz-available;
-  height: fill-available;
   background-color: #dfe4e9;
   width: 0;
   position: fixed;
@@ -772,9 +769,6 @@ exports[`SideNav should render properly without shadow 1`] = `
 
 .c0 {
   height: 100vh;
-  height: -webkit-fill-available;
-  height: -moz-available;
-  height: fill-available;
   background-color: #dfe4e9;
   width: 0;
   position: fixed;

--- a/packages/layout/src/components/SidePanel/SidePanel.styled.tsx
+++ b/packages/layout/src/components/SidePanel/SidePanel.styled.tsx
@@ -12,7 +12,6 @@ const rightPositioned = () => css`
 
 export const SidePanelStyled = styled('aside')<SidePanelStyledProps>`
     height: 100vh;
-    height: fill-available;
     background-color: ${({ theme }) => theme.sidePanel.bgColor};
     width: 0;
     position: fixed;

--- a/packages/layout/src/components/SidePanel/__snapshots__/SidePanel.test.tsx.snap
+++ b/packages/layout/src/components/SidePanel/__snapshots__/SidePanel.test.tsx.snap
@@ -3,9 +3,6 @@
 exports[`SidePanel component should render with left positioned by default 1`] = `
 .c0 {
   height: 100vh;
-  height: -webkit-fill-available;
-  height: -moz-available;
-  height: fill-available;
   background-color: #dfe4e9;
   width: 0;
   position: fixed;
@@ -26,9 +23,6 @@ exports[`SidePanel component should render with left positioned by default 1`] =
 exports[`SidePanel component should render with right positioned when position prop given as right 1`] = `
 .c0 {
   height: 100vh;
-  height: -webkit-fill-available;
-  height: -moz-available;
-  height: fill-available;
   background-color: #dfe4e9;
   width: 0;
   position: fixed;


### PR DESCRIPTION
affects: @medly-components/core, @medly-components/layout

# PR Checklist

## Description
Fixes the issue that causes transparent sidenav in Header component.
This is a revert of https://github.com/medly/medly-components//commit/eea5e621534f1eb88cca2e1eb0ab66e447a9e40d after the new webkit browser update

### Type of change
<!-- Please check the one that applies to this PR using "x". -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes and API changes)
- [ ] Build changes
- [ ] CI changes
- [ ] Document content changes
- [ ] Performance improvement
- [ ] Add missing tests
- [ ] Others (please describe)


## How has this been tested?
(Replace This Text: Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration.)

[ ] Test A

[ ] Test B


## Fixes #<issue_number>


## What is the current behaviour?
(Replace This Text: Please describe the current behaviour you are modifying, or link a relevant issue.)


## What is the new behaviour?
(Replace This Text: Please describe the expected new behaviour.)


## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

**Note:** (Replace This Text: If this PR contains a breaking change please describe the impact and migration path for existing application.)


## Additional context
(Replace This Text: Please describe any other related information or add screenshots of the PR.)


## Checklist
<!-- Please check the one that applies to this PR using "x". -->

- [ ] My code follows the style guidelines of this project

- [ ] I have performed a self-review of my own code

- [ ] I have commented my code, particularly in hard-to-understand areas

- [ ] I have made corresponding changes to the documentation

- [ ] My changes generate no new warnings

- [ ] I have added tests that prove my fix is effective or that my feature works

- [ ] New and existing unit tests pass locally with my changes

- [ ] Any dependent changes have been merged and published in downstream modules
