### PR TITLE
feat: add Style property to Breadcrumb Back component

### DIFF
--- a/packages/core/src/components/Breadcrumb/Back/Back.styled.tsx
+++ b/packages/core/src/components/Breadcrumb/Back/Back.styled.tsx
@@ -4,6 +4,7 @@ import { BreadcrumbItemStyled } from '../Item/Item.styled';
 
 export const BreadcrumbBackStyled = styled(BreadcrumbItemStyled)`
     & > ${SvgIcon} {
+        margin-right: 0.4rem;
         * {
             fill: ${({ theme }) => theme.breadcrumb.textColor.default};
         }

--- a/packages/core/src/components/Breadcrumb/Back/Back.tsx
+++ b/packages/core/src/components/Breadcrumb/Back/Back.tsx
@@ -1,17 +1,20 @@
 import { ChevronLeftIcon } from '@medly-components/icons';
-import { HTMLProps } from '@medly-components/utils';
-import { memo, forwardRef } from 'react';
+import { HTMLProps, WithStyle } from '@medly-components/utils';
+import type { FC } from 'react';
+import { forwardRef, memo } from 'react';
 import Text from '../../Text';
 import { BreadcrumbBackStyled } from './Back.styled';
-import type { FC } from 'react';
 
-export const BreadcrumbBack: FC<HTMLProps<HTMLLIElement>> = memo(
+export const Component: FC<HTMLProps<HTMLLIElement>> = memo(
     forwardRef((props, ref) => (
         <BreadcrumbBackStyled ref={ref} {...props}>
-            <ChevronLeftIcon size="S" />
+            <ChevronLeftIcon />
             <Text>Back</Text>
         </BreadcrumbBackStyled>
     ))
 );
+Component.displayName = 'BreadcrumbBack';
 
-BreadcrumbBack.displayName = 'BreadcrumbBack';
+export const BreadcrumbBack: typeof Component & WithStyle = Object.assign(Component, {
+    Style: BreadcrumbBackStyled
+});

--- a/packages/core/src/components/Breadcrumb/Breadcrumb.stories.mdx
+++ b/packages/core/src/components/Breadcrumb/Breadcrumb.stories.mdx
@@ -4,11 +4,21 @@ import * as stories from './Breadcrumb.stories';
 import { action } from '@storybook/addon-actions';
 import Text from '../Text';
 
-<Meta title="Core" component={Breadcrumb} />
+<Meta
+    title="Core"
+    component={Breadcrumb}
+    parameters={{
+        jest: ['Breadcrumb.test.tsx'],
+        design: {
+            type: 'figma',
+            url: 'https://www.figma.com/file/vA4EQdxl0d0ETtYpw2uSjW/Medly-Pattern-Library---B2B-%2F-Internal?node-id=10182%3A9510&t=YrDOrJ1xBbs3GUTh-1'
+        }
+    }}
+/>
 
 # Breadcrumb
 
-A `Breadcrumb` is a list of links that help you visualize the location of the page within an application or website by showing the hierarchical structure.  
+A `Breadcrumb` is a list of links that help you visualize the location of the page within an application or website by showing the hierarchical structure.
 
 <Preview withToolbar>
     <Story name="Breadcrumb">
@@ -22,7 +32,7 @@ A `Breadcrumb` is a list of links that help you visualize the location of the pa
     </Story>
 </Preview>
 
-To perform on click action on any item, pass the `onClick` prop, and to disable any item, pass the `disabled` prop. 
+To perform on click action on any item, pass the `onClick` prop, and to disable any item, pass the `disabled` prop.
 Additionally, to use the back button, call `<Breadcrumb.Back />`.
 
 <Preview withToolbar>

--- a/packages/core/src/components/Breadcrumb/Breadcrumb.tsx
+++ b/packages/core/src/components/Breadcrumb/Breadcrumb.tsx
@@ -1,12 +1,12 @@
 import { ChevronRightIcon } from '@medly-components/icons';
 import { WithStyle } from '@medly-components/utils';
+import type { FC } from 'react';
 import { Children } from 'react';
 import addSeparator from './addSeparator';
 import BreadcrumbBack from './Back';
 import { BreadcrumbStyled } from './Breadcrumb.styled';
 import BreadcrumbItem from './Item';
 import { BreadcrumbProps, BreadcrumbStaticProps } from './types';
-import type { FC } from 'react';
 
 const Component: FC<BreadcrumbProps> = props => {
     const { separator, children, ...restProps } = props,
@@ -17,7 +17,7 @@ const Component: FC<BreadcrumbProps> = props => {
 };
 
 Component.displayName = 'Breadcrumb';
-Component.defaultProps = { separator: <ChevronRightIcon size="S" aria-hidden="true" /> };
+Component.defaultProps = { separator: <ChevronRightIcon aria-hidden="true" /> };
 export const Breadcrumb: FC<BreadcrumbProps> & WithStyle & BreadcrumbStaticProps = Object.assign(Component, {
     Item: BreadcrumbItem,
     Back: BreadcrumbBack,

--- a/packages/core/src/components/Breadcrumb/__snapshots__/Breadcrumb.test.tsx.snap
+++ b/packages/core/src/components/Breadcrumb/__snapshots__/Breadcrumb.test.tsx.snap
@@ -3,7 +3,7 @@
 exports[`Breadcrumb component should render properly with "/" separator 1`] = `
 .c3 {
   overflow: visible;
-  font-size: 2rem;
+  font-size: 2.4rem;
   -webkit-transition: all 100ms linear;
   transition: all 100ms linear;
   cursor: inherit;
@@ -125,6 +125,10 @@ exports[`Breadcrumb component should render properly with "/" separator 1`] = `
 
 .c1:hover .c4 {
   color: #3061B3;
+}
+
+.c1 > .c2 {
+  margin-right: 0.4rem;
 }
 
 .c1 > .c2 * {
@@ -221,13 +225,28 @@ exports[`Breadcrumb component should render properly with "/" separator 1`] = `
 exports[`Breadcrumb component should render properly with {"$typeof": Symbol(react.element), "_owner": null, "_store": [Object], "key": "dummy", "props": [Object], "ref": null, "type": [Object]} separator 1`] = `
 .c3 {
   overflow: visible;
-  font-size: 2rem;
+  font-size: 2.4rem;
   -webkit-transition: all 100ms linear;
   transition: all 100ms linear;
   cursor: inherit;
 }
 
 .c3 * {
+  fill-opacity: 1;
+  -webkit-transition: all 100ms linear;
+  transition: all 100ms linear;
+  fill: #607890;
+}
+
+.c6 {
+  overflow: visible;
+  font-size: 2rem;
+  -webkit-transition: all 100ms linear;
+  transition: all 100ms linear;
+  cursor: inherit;
+}
+
+.c6 * {
   fill-opacity: 1;
   -webkit-transition: all 100ms linear;
   transition: all 100ms linear;
@@ -248,38 +267,6 @@ exports[`Breadcrumb component should render properly with {"$typeof": Symbol(rea
   display: inline-block;
 }
 
-.c6 {
-  height: 100%;
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
-  -webkit-align-items: center;
-  -webkit-box-align: center;
-  -ms-flex-align: center;
-  align-items: center;
-}
-
-.c6 .c4 {
-  -webkit-user-select: none;
-  -moz-user-select: none;
-  -ms-user-select: none;
-  user-select: none;
-  color: #3872D2;
-  font-size: 1.4rem;
-  font-weight: 600;
-  -webkit-letter-spacing: 0rem;
-  -moz-letter-spacing: 0rem;
-  -ms-letter-spacing: 0rem;
-  letter-spacing: 0rem;
-  line-height: 2.2rem;
-  font-family: Open Sans,Helvetica Neue,Helvetica,Arial,sans-serif;
-}
-
-.c6:hover .c4 {
-  color: #3061B3;
-}
-
 .c7 {
   height: 100%;
   display: -webkit-box;
@@ -290,7 +277,6 @@ exports[`Breadcrumb component should render properly with {"$typeof": Symbol(rea
   -webkit-box-align: center;
   -ms-flex-align: center;
   align-items: center;
-  cursor: pointer;
 }
 
 .c7 .c4 {
@@ -310,6 +296,39 @@ exports[`Breadcrumb component should render properly with {"$typeof": Symbol(rea
 }
 
 .c7:hover .c4 {
+  color: #3061B3;
+}
+
+.c8 {
+  height: 100%;
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  cursor: pointer;
+}
+
+.c8 .c4 {
+  -webkit-user-select: none;
+  -moz-user-select: none;
+  -ms-user-select: none;
+  user-select: none;
+  color: #3872D2;
+  font-size: 1.4rem;
+  font-weight: 600;
+  -webkit-letter-spacing: 0rem;
+  -moz-letter-spacing: 0rem;
+  -ms-letter-spacing: 0rem;
+  letter-spacing: 0rem;
+  line-height: 2.2rem;
+  font-family: Open Sans,Helvetica Neue,Helvetica,Arial,sans-serif;
+}
+
+.c8:hover .c4 {
   color: #3061B3;
 }
 
@@ -343,6 +362,10 @@ exports[`Breadcrumb component should render properly with {"$typeof": Symbol(rea
 
 .c1:hover .c4 {
   color: #3061B3;
+}
+
+.c1 > .c2 {
+  margin-right: 0.4rem;
 }
 
 .c1 > .c2 * {
@@ -403,30 +426,7 @@ exports[`Breadcrumb component should render properly with {"$typeof": Symbol(rea
       </span>
     </li>
     <svg
-      class="c2 c3"
-      fill="none"
-      height="1em"
-      viewBox="0 0 24 24"
-      width="1em"
-      xmlns="http://www.w3.org/2000/svg"
-    >
-      <path
-        d="M9 6.71a.996.996 0 0 0 0 1.41L12.88 12 9 15.88a.996.996 0 1 0 1.41 1.41L15 12.7a.996.996 0 0 0 0-1.41L10.41 6.7c-.38-.38-1.02-.38-1.41.01z"
-        fill="#000"
-        fill-opacity=".54"
-      />
-    </svg>
-    <li
-      class="c6"
-    >
-      <span
-        class="c4 c5"
-      >
-        Covered Entities
-      </span>
-    </li>
-    <svg
-      class="c2 c3"
+      class="c2 c6"
       fill="none"
       height="1em"
       viewBox="0 0 24 24"
@@ -441,6 +441,29 @@ exports[`Breadcrumb component should render properly with {"$typeof": Symbol(rea
     </svg>
     <li
       class="c7"
+    >
+      <span
+        class="c4 c5"
+      >
+        Covered Entities
+      </span>
+    </li>
+    <svg
+      class="c2 c6"
+      fill="none"
+      height="1em"
+      viewBox="0 0 24 24"
+      width="1em"
+      xmlns="http://www.w3.org/2000/svg"
+    >
+      <path
+        d="M9 6.71a.996.996 0 0 0 0 1.41L12.88 12 9 15.88a.996.996 0 1 0 1.41 1.41L15 12.7a.996.996 0 0 0 0-1.41L10.41 6.7c-.38-.38-1.02-.38-1.41.01z"
+        fill="#000"
+        fill-opacity=".54"
+      />
+    </svg>
+    <li
+      class="c8"
     >
       <span
         class="c4 c5"

--- a/packages/core/src/components/Breadcrumb/types.ts
+++ b/packages/core/src/components/Breadcrumb/types.ts
@@ -1,5 +1,7 @@
 import { HTMLProps } from '@medly-components/utils';
-import type { FC, ReactNode } from 'react';
+import type { ReactNode } from 'react';
+import { BreadcrumbBack } from './Back/Back';
+import { BreadcrumbItem } from './Item/Item';
 
 export type BreadcrumbProps = Omit<HTMLProps<HTMLOListElement>, 'type'> & {
     /** You can pass any separator which you can use between the links */
@@ -7,6 +9,6 @@ export type BreadcrumbProps = Omit<HTMLProps<HTMLOListElement>, 'type'> & {
 };
 
 export type BreadcrumbStaticProps = {
-    Item: FC<HTMLProps<HTMLLIElement>>;
-    Back: FC<HTMLProps<HTMLLIElement>>;
+    Item: typeof BreadcrumbItem;
+    Back: typeof BreadcrumbBack;
 };


### PR DESCRIPTION
affects: @medly-components/core

# PR Checklist

## Description
Add Style property to Breadcrumb Back component and make the icon size `M` as per the design.

### Type of change
<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes and API changes)
- [ ] Build changes
- [ ] CI changes
- [ ] Document content changes
- [ ] Performance improvement
- [ ] Add missing tests
- [ ] Others (please describe)

## What is the current behaviour?
There is no `Style` property available for BreadcrumbBack component, and the icon size was also not correct as per the design.


## What is the new behaviour?
T`Style` property is now available for BreadcrumbBack component, and the icon size is `M` as per the design.


## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

**Note:** (Replace This Text: If this PR contains a breaking change please describe the impact and migration path for existing application.)


## Additional context
(Replace This Text: Please describe any other related information or add screenshots of the PR.)


## Checklist
<!-- Please check the one that applies to this PR using "x". -->

- [x] My code follows the style guidelines of this project

- [x] I have performed a self-review of my own code

- [ ] I have commented my code, particularly in hard-to-understand areas

- [ ] I have made corresponding changes to the documentation

- [x] My changes generate no new warnings

- [ ] I have added tests that prove my fix is effective or that my feature works

- [x] New and existing unit tests pass locally with my changes

- [ ] Any dependent changes have been merged and published in downstream modules
