### PR TITLE
refactor: use `Logo` prop types for `MedlySidenavHeader` prop types

### DIFF
--- a/packages/layout/src/components/SideNav/MedlySidenavHeader/MedlySidenavHeader.test.tsx
+++ b/packages/layout/src/components/SideNav/MedlySidenavHeader/MedlySidenavHeader.test.tsx
@@ -35,7 +35,7 @@ describe('Medly sidenav header', () => {
             <SidenavContext.Provider
                 value={{ activeItem: 'dummy', isHovered: true, isExpanded: true, activeItemChangeHandler: () => null }}
             >
-                <MedlySidenavHeader companyLogo={DummyLogo} companyName={DummyName} />
+                <MedlySidenavHeader companyLogo={<DummyLogo />} companyName={<DummyName />} />
             </SidenavContext.Provider>
         );
         expect(screen.getByText('My Logo')).toBeInTheDocument();

--- a/packages/layout/src/components/SideNav/MedlySidenavHeader/MedlySidenavHeader.tsx
+++ b/packages/layout/src/components/SideNav/MedlySidenavHeader/MedlySidenavHeader.tsx
@@ -1,15 +1,15 @@
 import { Logo } from '@medly-components/core';
 import { WithStyle } from '@medly-components/utils';
-import { memo, FC, useContext } from 'react';
+import { FC, memo, useContext } from 'react';
 import SideNavContext from '../SideNav.context';
 import * as Styled from './MedlySidenavHeader.styled';
 import { Props } from './types';
 
-const Component: FC<Props> = memo(({ companyLogo: CompanyLogo, companyName: CompanyName }) => {
+const Component: FC<Props> = memo(({ companyLogo, companyName }) => {
     const { isHovered, isExpanded } = useContext(SideNavContext);
     return (
         <Styled.SidenavHeader as="div" isHovered={isHovered} isExpanded={isExpanded}>
-            <Logo name={CompanyName && <CompanyName />} logo={CompanyLogo && <CompanyLogo />} />
+            <Logo name={companyName} logo={companyLogo} />
         </Styled.SidenavHeader>
     );
 });

--- a/packages/layout/src/components/SideNav/MedlySidenavHeader/types.ts
+++ b/packages/layout/src/components/SideNav/MedlySidenavHeader/types.ts
@@ -1,8 +1,8 @@
-import { SvgIconProps } from '@medly-components/icons';
+import { LogoProps } from '@medly-components/core';
 
 export interface Props {
-    companyLogo?: React.FunctionComponent<SvgIconProps>;
-    companyName?: React.FunctionComponent<SvgIconProps>;
+    companyLogo?: LogoProps['logo'];
+    companyName?: LogoProps['name'];
 }
 
 export interface HeaderStyledProps {


### PR DESCRIPTION
affects: @medly-components/layout

# PR Checklist

## Description
use `Logo` prop types for `MedlySidenavHeader` prop types

### Type of change
<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, local variables)
- [x] Refactoring (no functional changes and API changes)
- [ ] Build changes
- [ ] CI changes
- [ ] Document content changes
- [ ] Performance improvement
- [ ] Add missing tests
- [ ] Others (please describe)

## What is the current behaviour?
The types are different for `MedlySidenavHeader` which is eventually being passed to the `Logo` component


## What is the new behaviour?
use `Logo` prop types for `MedlySidenavHeader` prop types


## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No


## Checklist
<!-- Please check the one that applies to this PR using "x". -->

- [x] My code follows the style guidelines of this project

- [x] I have performed a self-review of my own code

- [ ] I have commented my code, particularly in hard-to-understand areas

- [ ] I have made corresponding changes to the documentation

- [x] My changes generate no new warnings

- [ ] I have added tests that prove my fix is effective or that my feature works

- [x] New and existing unit tests pass locally with my changes

- [ ] Any dependent changes have been merged and published in downstream modules
