### PR TITLE
feat: add fullWidth feature in Tabs component

### DIFF
--- a/package.json
+++ b/package.json
@@ -107,7 +107,7 @@
         "@medly/eslint-config-react": "^0.3.1",
         "@medly/prettier-config": "^0.1.1",
         "@medly/rollup-config": "^0.8.2",
-        "@medly/stylelint-config": "^0.2.0",
+        "@medly/stylelint-config": "0.2.0",
         "@medly/typescript-config-react": "^1.4.0",
         "@nrwl/nx-cloud": "^15.0.2",
         "@storybook/addon-actions": "5.3.18",

--- a/packages/core/src/components/Tabs/Tab/Tab.styled.tsx
+++ b/packages/core/src/components/Tabs/Tab/Tab.styled.tsx
@@ -1,5 +1,5 @@
 import { SvgIcon } from '@medly-components/icons';
-import { centerAligned, getFontStyle } from '@medly-components/utils';
+import { breakpoints, centerAligned, getFontStyle, media } from '@medly-components/utils';
 import styled, { css } from 'styled-components';
 import Text from '../../Text';
 import { TabSize } from '../types';
@@ -120,6 +120,10 @@ const flatOutlinedStyle = css<StyledTabProps>`
         background-color: ${({ borderColor, active }) => (active ? borderColor.active : 'transparent')};
         border-radius: ${({ variant }) => variant === 'flat' && '0.5rem 0.5rem 0 0'};
     }
+
+    ${({ theme, fraction }) => media(breakpoints(theme.breakpoints).down('S'))`
+        flex: ${fraction || 1}
+    `}
 `;
 
 const flatBackgroundStyle = css`
@@ -142,7 +146,7 @@ export const TabWrapper = styled('button').attrs(({ theme }) => ({ ...theme.tabs
     border-style: solid;
     box-sizing: border-box;
     font-family: inherit;
-    flex: ${({ fraction, variant }) => variant !== 'solid' && fraction};
+    flex: ${({ fraction, fullWidth, variant }) => variant !== 'solid' && (fraction || (fullWidth ? '1' : 'initial'))};
     border-color: ${({ borderColor, variant }) => (variant === 'flat' || variant === 'outlined') && borderColor[variant]};
     border-width: ${({ variant }) => (variant === 'outlined' ? `0.1rem 0.1rem 0.1rem 0` : `0 0 0.1rem 0`)};
     transition: all 100ms ease-out;

--- a/packages/core/src/components/Tabs/Tab/__snapshots__/Tab.test.tsx.snap
+++ b/packages/core/src/components/Tabs/Tab/__snapshots__/Tab.test.tsx.snap
@@ -77,6 +77,9 @@ exports[`Tab should render active state properly 1`] = `
   border-style: solid;
   box-sizing: border-box;
   font-family: inherit;
+  -webkit-flex: initial;
+  -ms-flex: initial;
+  flex: initial;
   border-color: #b0bcc8;
   border-width: 0 0 0.1rem 0;
   -webkit-transition: all 100ms ease-out;
@@ -208,6 +211,14 @@ exports[`Tab should render active state properly 1`] = `
   align-items: center;
 }
 
+@media (max-width:767px) {
+  .c0 {
+    -webkit-flex: 1;
+    -ms-flex: 1;
+    flex: 1;
+  }
+}
+
 <div>
   <button
     aria-controls="panel-dummy"
@@ -334,6 +345,9 @@ exports[`Tab should render disabled state properly 1`] = `
   border-style: solid;
   box-sizing: border-box;
   font-family: inherit;
+  -webkit-flex: initial;
+  -ms-flex: initial;
+  flex: initial;
   border-color: #b0bcc8;
   border-width: 0 0 0.1rem 0;
   -webkit-transition: all 100ms ease-out;
@@ -487,6 +501,14 @@ exports[`Tab should render disabled state properly 1`] = `
   align-items: center;
 }
 
+@media (max-width:767px) {
+  .c0 {
+    -webkit-flex: 1;
+    -ms-flex: 1;
+    flex: 1;
+  }
+}
+
 <div>
   <button
     aria-controls="panel-dummy"
@@ -614,6 +636,9 @@ exports[`Tab should render properly with GREY tab background 1`] = `
   border-style: solid;
   box-sizing: border-box;
   font-family: inherit;
+  -webkit-flex: initial;
+  -ms-flex: initial;
+  flex: initial;
   border-color: #b0bcc8;
   border-width: 0 0 0.1rem 0;
   -webkit-transition: all 100ms ease-out;
@@ -771,6 +796,14 @@ exports[`Tab should render properly with GREY tab background 1`] = `
   align-items: center;
 }
 
+@media (max-width:767px) {
+  .c0 {
+    -webkit-flex: 1;
+    -ms-flex: 1;
+    flex: 1;
+  }
+}
+
 <div>
   <button
     aria-controls="panel-dummy"
@@ -905,6 +938,9 @@ exports[`Tab should render properly with L tab size 1`] = `
   border-style: solid;
   box-sizing: border-box;
   font-family: inherit;
+  -webkit-flex: initial;
+  -ms-flex: initial;
+  flex: initial;
   border-color: #b0bcc8;
   border-width: 0 0 0.1rem 0;
   -webkit-transition: all 100ms ease-out;
@@ -1056,6 +1092,14 @@ exports[`Tab should render properly with L tab size 1`] = `
   -webkit-box-align: center;
   -ms-flex-align: center;
   align-items: center;
+}
+
+@media (max-width:767px) {
+  .c0 {
+    -webkit-flex: 1;
+    -ms-flex: 1;
+    flex: 1;
+  }
 }
 
 <div>
@@ -1198,6 +1242,9 @@ exports[`Tab should render properly with L tab size 2`] = `
   border-style: solid;
   box-sizing: border-box;
   font-family: inherit;
+  -webkit-flex: initial;
+  -ms-flex: initial;
+  flex: initial;
   border-color: #b0bcc8;
   border-width: 0 0 0.1rem 0;
   -webkit-transition: all 100ms ease-out;
@@ -1351,6 +1398,14 @@ exports[`Tab should render properly with L tab size 2`] = `
   align-items: center;
 }
 
+@media (max-width:767px) {
+  .c0 {
+    -webkit-flex: 1;
+    -ms-flex: 1;
+    flex: 1;
+  }
+}
+
 <div>
   <button
     aria-controls="panel-dummy"
@@ -1486,6 +1541,9 @@ exports[`Tab should render properly with M tab size 1`] = `
   border-style: solid;
   box-sizing: border-box;
   font-family: inherit;
+  -webkit-flex: initial;
+  -ms-flex: initial;
+  flex: initial;
   border-color: #b0bcc8;
   border-width: 0 0 0.1rem 0;
   -webkit-transition: all 100ms ease-out;
@@ -1637,6 +1695,14 @@ exports[`Tab should render properly with M tab size 1`] = `
   -webkit-box-align: center;
   -ms-flex-align: center;
   align-items: center;
+}
+
+@media (max-width:767px) {
+  .c0 {
+    -webkit-flex: 1;
+    -ms-flex: 1;
+    flex: 1;
+  }
 }
 
 <div>
@@ -1768,6 +1834,9 @@ exports[`Tab should render properly with M tab size 2`] = `
   border-style: solid;
   box-sizing: border-box;
   font-family: inherit;
+  -webkit-flex: initial;
+  -ms-flex: initial;
+  flex: initial;
   border-color: #b0bcc8;
   border-width: 0 0 0.1rem 0;
   -webkit-transition: all 100ms ease-out;
@@ -1921,6 +1990,14 @@ exports[`Tab should render properly with M tab size 2`] = `
   align-items: center;
 }
 
+@media (max-width:767px) {
+  .c0 {
+    -webkit-flex: 1;
+    -ms-flex: 1;
+    flex: 1;
+  }
+}
+
 <div>
   <button
     aria-controls="panel-dummy"
@@ -2047,6 +2124,9 @@ exports[`Tab should render properly with S tab size 1`] = `
   border-style: solid;
   box-sizing: border-box;
   font-family: inherit;
+  -webkit-flex: initial;
+  -ms-flex: initial;
+  flex: initial;
   border-color: #b0bcc8;
   border-width: 0 0 0.1rem 0;
   -webkit-transition: all 100ms ease-out;
@@ -2198,6 +2278,14 @@ exports[`Tab should render properly with S tab size 1`] = `
   -webkit-box-align: center;
   -ms-flex-align: center;
   align-items: center;
+}
+
+@media (max-width:767px) {
+  .c0 {
+    -webkit-flex: 1;
+    -ms-flex: 1;
+    flex: 1;
+  }
 }
 
 <div>
@@ -2326,6 +2414,9 @@ exports[`Tab should render properly with S tab size 2`] = `
   border-style: solid;
   box-sizing: border-box;
   font-family: inherit;
+  -webkit-flex: initial;
+  -ms-flex: initial;
+  flex: initial;
   border-color: #b0bcc8;
   border-width: 0 0 0.1rem 0;
   -webkit-transition: all 100ms ease-out;
@@ -2477,6 +2568,14 @@ exports[`Tab should render properly with S tab size 2`] = `
   -webkit-box-align: center;
   -ms-flex-align: center;
   align-items: center;
+}
+
+@media (max-width:767px) {
+  .c0 {
+    -webkit-flex: 1;
+    -ms-flex: 1;
+    flex: 1;
+  }
 }
 
 <div>
@@ -2605,6 +2704,9 @@ exports[`Tab should render properly with WHITE tab background 1`] = `
   border-style: solid;
   box-sizing: border-box;
   font-family: inherit;
+  -webkit-flex: initial;
+  -ms-flex: initial;
+  flex: initial;
   border-color: #b0bcc8;
   border-width: 0 0 0.1rem 0;
   -webkit-transition: all 100ms ease-out;
@@ -2756,6 +2858,14 @@ exports[`Tab should render properly with WHITE tab background 1`] = `
   -webkit-box-align: center;
   -ms-flex-align: center;
   align-items: center;
+}
+
+@media (max-width:767px) {
+  .c0 {
+    -webkit-flex: 1;
+    -ms-flex: 1;
+    flex: 1;
+  }
 }
 
 <div>
@@ -2884,6 +2994,9 @@ exports[`Tab should render properly with flat tab variant 1`] = `
   border-style: solid;
   box-sizing: border-box;
   font-family: inherit;
+  -webkit-flex: initial;
+  -ms-flex: initial;
+  flex: initial;
   border-color: #b0bcc8;
   border-width: 0 0 0.1rem 0;
   -webkit-transition: all 100ms ease-out;
@@ -3037,6 +3150,14 @@ exports[`Tab should render properly with flat tab variant 1`] = `
   align-items: center;
 }
 
+@media (max-width:767px) {
+  .c0 {
+    -webkit-flex: 1;
+    -ms-flex: 1;
+    flex: 1;
+  }
+}
+
 <div>
   <button
     aria-controls="panel-dummy"
@@ -3163,6 +3284,9 @@ exports[`Tab should render properly with outlined tab variant 1`] = `
   border-style: solid;
   box-sizing: border-box;
   font-family: inherit;
+  -webkit-flex: initial;
+  -ms-flex: initial;
+  flex: initial;
   border-color: #C7D0D8;
   border-width: 0.1rem 0.1rem 0.1rem 0;
   -webkit-transition: all 100ms ease-out;
@@ -3309,6 +3433,14 @@ exports[`Tab should render properly with outlined tab variant 1`] = `
   -webkit-box-align: center;
   -ms-flex-align: center;
   align-items: center;
+}
+
+@media (max-width:767px) {
+  .c0 {
+    -webkit-flex: 1;
+    -ms-flex: 1;
+    flex: 1;
+  }
 }
 
 <div>

--- a/packages/core/src/components/Tabs/Tab/types.ts
+++ b/packages/core/src/components/Tabs/Tab/types.ts
@@ -38,4 +38,6 @@ export interface TabProps extends HTMLProps<HTMLButtonElement> {
     fraction?: number;
     /** Disabled label text (only visible for the `solid` Tabs variant) */
     disabledLabel?: string;
+    /** This prop will be past down by Tabs component so that TabList can be rendered with full width  */
+    fullWidth?: string;
 }

--- a/packages/core/src/components/Tabs/TabList/TabList.tsx
+++ b/packages/core/src/components/Tabs/TabList/TabList.tsx
@@ -7,7 +7,7 @@ import * as Styled from './TabList.styled';
 import { TabListProps } from './types';
 
 const Component: FC<TabListProps> = memo(props => {
-    const { active, onChange, ...restProps } = props,
+    const { active, onChange, fullWidth, ...restProps } = props,
         leftPress = useKeyPress('ArrowLeft'),
         rightPress = useKeyPress('ArrowRight'),
         homePress = useKeyPress('Home'),
@@ -58,6 +58,7 @@ const Component: FC<TabListProps> = memo(props => {
                             onClick={handleChange(id)}
                             totalTabs={totalTabs}
                             variant={variant}
+                            fullWidth={fullWidth}
                             {...child.props}
                         />
                     );

--- a/packages/core/src/components/Tabs/TabList/__snapshots__/TabList.test.tsx.snap
+++ b/packages/core/src/components/Tabs/TabList/__snapshots__/TabList.test.tsx.snap
@@ -53,6 +53,9 @@ exports[`TabList should render properly 1`] = `
   border-style: solid;
   box-sizing: border-box;
   font-family: inherit;
+  -webkit-flex: initial;
+  -ms-flex: initial;
+  flex: initial;
   border-color: #b0bcc8;
   border-width: 0 0 0.1rem 0;
   -webkit-transition: all 100ms ease-out;
@@ -187,6 +190,9 @@ exports[`TabList should render properly 1`] = `
   border-style: solid;
   box-sizing: border-box;
   font-family: inherit;
+  -webkit-flex: initial;
+  -ms-flex: initial;
+  flex: initial;
   border-color: #b0bcc8;
   border-width: 0 0 0.1rem 0;
   -webkit-transition: all 100ms ease-out;
@@ -362,6 +368,22 @@ exports[`TabList should render properly 1`] = `
   justify-content: flex-start;
   overflow-x: auto;
   background-color: transparent;
+}
+
+@media (max-width:767px) {
+  .c1 {
+    -webkit-flex: 1;
+    -ms-flex: 1;
+    flex: 1;
+  }
+}
+
+@media (max-width:767px) {
+  .c7 {
+    -webkit-flex: 1;
+    -ms-flex: 1;
+    flex: 1;
+  }
 }
 
 <div>

--- a/packages/core/src/components/Tabs/TabList/types.ts
+++ b/packages/core/src/components/Tabs/TabList/types.ts
@@ -3,6 +3,7 @@ import { TabSize, Variant } from '../types';
 
 export interface TabListProps extends HTMLProps<HTMLDivElement> {
     active: any;
+    fullWidth?: boolean;
     onChange: (id: any) => void;
 }
 
@@ -10,6 +11,7 @@ export type StyledTabListProps = HTMLProps<HTMLDivElement> &
     WithThemeProp & {
         tabSize: TabSize;
         variant: Variant;
+        fullWidth?: boolean;
     };
 
 export type StyledSliderProps = Omit<StyledTabListProps, 'variant'> & {

--- a/packages/core/src/components/Tabs/TabPanel/TabPanel.styled.tsx
+++ b/packages/core/src/components/Tabs/TabPanel/TabPanel.styled.tsx
@@ -5,7 +5,7 @@ export const TabPanel = styled('div')<StyledProps>`
     &:focus {
         outline: none;
     }
-    padding: 10px;
+    padding: 1rem;
     height: 100%;
     width: 100%;
     display: ${({ isActive }) => (!isActive ? 'none' : 'block')};

--- a/packages/core/src/components/Tabs/TabPanel/__snapshots__/TabPanel.test.tsx.snap
+++ b/packages/core/src/components/Tabs/TabPanel/__snapshots__/TabPanel.test.tsx.snap
@@ -2,7 +2,7 @@
 
 exports[`TabPanel should render only active tab content 1`] = `
 .c0 {
-  padding: 10px;
+  padding: 1rem;
   height: 100%;
   width: 100%;
   display: block;

--- a/packages/core/src/components/Tabs/Tabs.stories.mdx
+++ b/packages/core/src/components/Tabs/Tabs.stories.mdx
@@ -47,10 +47,11 @@ Use `Tabs.Tab` to add tab in `Tabs` component.
             <Tabs
                 defaultActive="tab1"
                 aria-label="Basic Tabs"
-                tabSize={select('Tab Size', sizes, 'S')}
-                tabBackground={select('Tab Background', tabBg, 'WHITE')}
                 forceRender={boolean('Force Render', false)}
+                fullWidth={boolean('Full Width', false)}
+                tabSize={select('Tab Size', sizes, 'S')}
                 variant={select('Variant', ['flat', 'outlined', 'solid'], 'flat')}
+                tabBackground={select('Tab Background', tabBg, 'WHITE')}
             >
                 <Tabs.Tab id="tab1" label="Add" helperText="Details" count={0}>
                     Content for the add panel
@@ -77,9 +78,11 @@ We provide the `icon` prop as well.
             <Tabs
                 defaultActive="tab1"
                 aria-label="WithIcon Tabs"
+                forceRender={boolean('Force Render', false)}
+                fullWidth={boolean('Full Width', false)}
                 tabSize={select('Tab Size', sizes, 'S')}
                 tabBackground={select('Tab Background', tabBg, 'WHITE')}
-                forceRender={boolean('Force Render', false)}
+                variant={select('Variant', ['flat', 'outlined', 'solid'], 'flat')}
             >
                 <Tabs.Tab id="tab1" label="Add" helperText="Details" count={68} icon={DashboardIcon}>
                     Content for the add panel
@@ -185,7 +188,7 @@ Three Tab variants are available viz; flat, outlined, and solid.
 
 Three Tab szes are available: `S` | `M` | `L`.
 
-## 1. `S` 
+## 1. `S`
 
 <Preview withToolbar>
     <Tabs defaultActive="tab11" aria-label="Open style tabs" tabSize="S">
@@ -201,7 +204,7 @@ Three Tab szes are available: `S` | `M` | `L`.
     </Tabs>
 </Preview>
 
-## 2. `M` 
+## 2. `M`
 
 <Preview withToolbar>
     <Tabs defaultActive="tab11" aria-label="Open style tabs" tabSize="M">
@@ -217,7 +220,7 @@ Three Tab szes are available: `S` | `M` | `L`.
     </Tabs>
 </Preview>
 
-## 3. `L` 
+## 3. `L`
 
 <Preview withToolbar>
     <Tabs defaultActive="tab11" aria-label="Open style tabs" tabSize="L">
@@ -239,7 +242,6 @@ Three Tab szes are available: `S` | `M` | `L`.
 
 2. **Controlled**: When using the controlled `Tabs` component you must provide the `active` and `onChange` prop.
 
-
 ## Keyboard support
 
 This component supports keyboard navigation when in focus.
@@ -253,7 +255,7 @@ This component supports keyboard navigation when in focus.
 
 ## Props
 
-This component offers the `tabs` and `tab`  props mentioned in the table below:
+This component offers the `tabs` and `tab` props mentioned in the table below:
 
 ## 1. Tabs Props
 

--- a/packages/core/src/components/Tabs/Tabs.test.tsx
+++ b/packages/core/src/components/Tabs/Tabs.test.tsx
@@ -48,6 +48,20 @@ describe('Tabs', () => {
         expect(container).toBeEmptyDOMElement();
     });
 
+    it('should render properly with fullWidth', () => {
+        const { container } = render(
+            <Tabs fullWidth>
+                <Tab id="tab2" label="Delete">
+                    Content for the delete panel
+                </Tab>
+                <Tab id="tab2" label="Delete">
+                    Content for the delete panel
+                </Tab>
+            </Tabs>
+        );
+        expect(container).toMatchSnapshot();
+    });
+
     it('should not render anything if there is no children', () => {
         const { container } = render(<Tabs />);
         expect(container).toBeEmptyDOMElement();

--- a/packages/core/src/components/Tabs/Tabs.tsx
+++ b/packages/core/src/components/Tabs/Tabs.tsx
@@ -10,7 +10,19 @@ import { StaticProps, TabsProps } from './types';
 
 const Component: FC<TabsProps> = memo(
     forwardRef((props, ref) => {
-        const { hidePanel, defaultActive, active, onChange, children, tabSize, tabBackground, forceRender, variant, ...restProps } = props,
+        const {
+                hidePanel,
+                defaultActive,
+                active,
+                onChange,
+                children,
+                tabSize,
+                tabBackground,
+                forceRender,
+                variant,
+                fullWidth,
+                ...restProps
+            } = props,
             tabsId = props.id || 'medly-tabs',
             tabIds = useMemo(
                 () =>
@@ -41,7 +53,7 @@ const Component: FC<TabsProps> = memo(
         return (
             <Styled.Tabs id={tabsId} ref={ref} {...restProps}>
                 <TabsContext.Provider value={tabsContext}>
-                    <TabList id={`${tabsId}-list`} active={activeTab} onChange={handleTabChange}>
+                    <TabList id={`${tabsId}-list`} active={activeTab} onChange={handleTabChange} fullWidth={fullWidth}>
                         {children}
                     </TabList>
                     {!hidePanel && (

--- a/packages/core/src/components/Tabs/__snapshots__/Tabs.test.tsx.snap
+++ b/packages/core/src/components/Tabs/__snapshots__/Tabs.test.tsx.snap
@@ -62,6 +62,9 @@ exports[`Tabs should render properly with flat tab variant 1`] = `
   border-style: solid;
   box-sizing: border-box;
   font-family: inherit;
+  -webkit-flex: initial;
+  -ms-flex: initial;
+  flex: initial;
   border-color: #b0bcc8;
   border-width: 0 0 0.1rem 0;
   -webkit-transition: all 100ms ease-out;
@@ -196,6 +199,9 @@ exports[`Tabs should render properly with flat tab variant 1`] = `
   border-style: solid;
   box-sizing: border-box;
   font-family: inherit;
+  -webkit-flex: initial;
+  -ms-flex: initial;
+  flex: initial;
   border-color: #b0bcc8;
   border-width: 0 0 0.1rem 0;
   -webkit-transition: all 100ms ease-out;
@@ -374,7 +380,7 @@ exports[`Tabs should render properly with flat tab variant 1`] = `
 }
 
 .c10 {
-  padding: 10px;
+  padding: 1rem;
   height: 100%;
   width: 100%;
   display: block;
@@ -382,6 +388,22 @@ exports[`Tabs should render properly with flat tab variant 1`] = `
 
 .c10:focus {
   outline: none;
+}
+
+@media (max-width:767px) {
+  .c1 {
+    -webkit-flex: 1;
+    -ms-flex: 1;
+    flex: 1;
+  }
+}
+
+@media (max-width:767px) {
+  .c9 {
+    -webkit-flex: 1;
+    -ms-flex: 1;
+    flex: 1;
+  }
 }
 
 <div>
@@ -489,6 +511,318 @@ exports[`Tabs should render properly with flat tab variant 1`] = `
 </div>
 `;
 
+exports[`Tabs should render properly with fullWidth 1`] = `
+.c4 {
+  margin: 0;
+  color: inherit;
+  font-size: 1.4rem;
+  font-weight: 400;
+  -webkit-letter-spacing: 0rem;
+  -moz-letter-spacing: 0rem;
+  -ms-letter-spacing: 0rem;
+  letter-spacing: 0rem;
+  line-height: 2.2rem;
+  text-align: initial;
+  display: inline-block;
+}
+
+.c6 {
+  font-size: 1.4rem;
+  font-weight: 600;
+  -webkit-letter-spacing: 0rem;
+  -moz-letter-spacing: 0rem;
+  -ms-letter-spacing: 0rem;
+  letter-spacing: 0rem;
+  line-height: 2.2rem;
+  font-family: Open Sans,Helvetica Neue,Helvetica,Arial,sans-serif;
+}
+
+.c1 {
+  padding: 1.6rem;
+  -webkit-user-select: none;
+  -moz-user-select: none;
+  -ms-user-select: none;
+  user-select: none;
+  -webkit-text-decoration: none;
+  text-decoration: none;
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  -webkit-box-pack: start;
+  -webkit-justify-content: flex-start;
+  -ms-flex-pack: start;
+  justify-content: flex-start;
+  -webkit-flex-flow: row wrap;
+  -ms-flex-flow: row wrap;
+  flex-flow: row wrap;
+  position: relative;
+  border-style: solid;
+  box-sizing: border-box;
+  font-family: inherit;
+  -webkit-flex: 1;
+  -ms-flex: 1;
+  flex: 1;
+  border-color: #b0bcc8;
+  border-width: 0 0 0.1rem 0;
+  -webkit-transition: all 100ms ease-out;
+  transition: all 100ms ease-out;
+  background-color: #EBF1FA;
+  background-color: #ffffff;
+  background-color: transparent;
+}
+
+.c1 * {
+  -webkit-transition: all 100ms ease-out;
+  transition: all 100ms ease-out;
+}
+
+.c1:focus {
+  outline: none;
+}
+
+.c1:disabled {
+  cursor: not-allowed;
+  background-color: #ffffff;
+}
+
+.c1:disabled::after {
+  background-color: transparent;
+}
+
+.c1:disabled .c5 {
+  color: #b0bcc8;
+}
+
+.c1:disabled .sc-1kcg570-3 {
+  color: #b0bcc8;
+}
+
+.c1:disabled .sc-1kcg570-0 {
+  background-color: #b0bcc8;
+}
+
+.c1:disabled .sc-1pf3x8a-0 {
+  font-size: 2.4rem;
+  padding: 0;
+  background-color: transparent;
+}
+
+.c1:disabled .sc-1pf3x8a-0 * {
+  fill: #b0bcc8;
+}
+
+.c1:not(:disabled):hover {
+  cursor: pointer;
+}
+
+.c1 .sc-1pf3x8a-0 {
+  margin-right: 1.6rem;
+}
+
+.c1 .c5 {
+  color: #3872D2;
+}
+
+.c1 .sc-1kcg570-3 {
+  color: #607890;
+}
+
+.c1 .sc-1kcg570-0 {
+  background-color: #3872D2;
+}
+
+.c1 .sc-1pf3x8a-0 {
+  font-size: 2.4rem;
+  padding: 0;
+  background-color: transparent;
+}
+
+.c1 .sc-1pf3x8a-0 * {
+  fill: #3872D2;
+}
+
+.c1 .sc-1pf3x8a-0 * {
+  fill: #3872D2;
+}
+
+.c1:first-child {
+  border-top-left-radius: 0.8rem;
+}
+
+.c1:last-child {
+  border-top-right-radius: 0.8rem;
+}
+
+.c1::after {
+  content: '';
+  position: absolute;
+  display: block;
+  height: 0.4rem;
+  bottom: -0.1rem;
+  left: 0;
+  width: 100%;
+  background-color: #3872D2;
+  border-radius: 0.5rem 0.5rem 0 0;
+}
+
+.c1:disabled {
+  background-color: transparent;
+}
+
+.c2 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-flex-direction: column;
+  -ms-flex-direction: column;
+  flex-direction: column;
+}
+
+.c3 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-flex-direction: row;
+  -ms-flex-direction: row;
+  flex-direction: row;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+}
+
+.c0 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-box-pack: center;
+  -webkit-justify-content: center;
+  -ms-flex-pack: center;
+  justify-content: center;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  -webkit-flex-direction: row;
+  -ms-flex-direction: row;
+  flex-direction: row;
+  -webkit-box-pack: start;
+  -webkit-justify-content: flex-start;
+  -ms-flex-pack: start;
+  justify-content: flex-start;
+  overflow-x: auto;
+  background-color: transparent;
+}
+
+.c7 {
+  padding: 1rem;
+  height: 100%;
+  width: 100%;
+  display: block;
+}
+
+.c7:focus {
+  outline: none;
+}
+
+@media (max-width:767px) {
+  .c1 {
+    -webkit-flex: 1;
+    -ms-flex: 1;
+    flex: 1;
+  }
+}
+
+<div>
+  <div
+    class=""
+    id="medly-tabs"
+  >
+    <div
+      class="c0"
+      id="medly-tabs-list"
+    >
+      <button
+        aria-controls="panel-tab2"
+        aria-selected="true"
+        class="c1"
+        id="tab2"
+        label="[object Object]"
+        role="tab"
+        tabindex="0"
+        type="button"
+      >
+        <div
+          class="c2"
+        >
+          <div
+            class="c3"
+          >
+            <span
+              class="c4 c5 c6"
+              id="tab2-label"
+            >
+              Delete
+            </span>
+          </div>
+        </div>
+      </button>
+      <button
+        aria-controls="panel-tab2"
+        aria-selected="true"
+        class="c1"
+        id="tab2"
+        label="[object Object]"
+        role="tab"
+        tabindex="0"
+        type="button"
+      >
+        <div
+          class="c2"
+        >
+          <div
+            class="c3"
+          >
+            <span
+              class="c4 c5 c6"
+              id="tab2-label"
+            >
+              Delete
+            </span>
+          </div>
+        </div>
+      </button>
+    </div>
+    <div
+      aria-labelledby="tab2"
+      class="c7"
+      id="medly-tabs-panel-tab2"
+      role="tabpanel"
+      tabindex="0"
+    >
+      Content for the delete panel
+    </div>
+    <div
+      aria-labelledby="tab2"
+      class="c7"
+      id="medly-tabs-panel-tab2"
+      role="tabpanel"
+      tabindex="0"
+    >
+      Content for the delete panel
+    </div>
+  </div>
+</div>
+`;
+
 exports[`Tabs should render properly with outlined tab variant 1`] = `
 .c4 {
   margin: 0;
@@ -551,6 +885,9 @@ exports[`Tabs should render properly with outlined tab variant 1`] = `
   border-style: solid;
   box-sizing: border-box;
   font-family: inherit;
+  -webkit-flex: initial;
+  -ms-flex: initial;
+  flex: initial;
   border-color: #C7D0D8;
   border-width: 0.1rem 0.1rem 0.1rem 0;
   -webkit-transition: all 100ms ease-out;
@@ -680,6 +1017,9 @@ exports[`Tabs should render properly with outlined tab variant 1`] = `
   border-style: solid;
   box-sizing: border-box;
   font-family: inherit;
+  -webkit-flex: initial;
+  -ms-flex: initial;
+  flex: initial;
   border-color: #C7D0D8;
   border-width: 0.1rem 0.1rem 0.1rem 0;
   -webkit-transition: all 100ms ease-out;
@@ -853,7 +1193,7 @@ exports[`Tabs should render properly with outlined tab variant 1`] = `
 }
 
 .c10 {
-  padding: 10px;
+  padding: 1rem;
   height: 100%;
   width: 100%;
   display: block;
@@ -861,6 +1201,22 @@ exports[`Tabs should render properly with outlined tab variant 1`] = `
 
 .c10:focus {
   outline: none;
+}
+
+@media (max-width:767px) {
+  .c1 {
+    -webkit-flex: 1;
+    -ms-flex: 1;
+    flex: 1;
+  }
+}
+
+@media (max-width:767px) {
+  .c9 {
+    -webkit-flex: 1;
+    -ms-flex: 1;
+    flex: 1;
+  }
 }
 
 <div>
@@ -1377,7 +1733,7 @@ exports[`Tabs should render properly with solid tab variant 1`] = `
 }
 
 .c12 {
-  padding: 10px;
+  padding: 1rem;
   height: 100%;
   width: 100%;
   display: block;

--- a/packages/core/src/components/Tabs/types.ts
+++ b/packages/core/src/components/Tabs/types.ts
@@ -29,6 +29,8 @@ export interface TabsProps extends HTMLProps<HTMLDivElement> {
     hidePanel?: boolean;
     /** Tabs design */
     variant?: Variant;
+    /** Set it true to render tab list in full width */
+    fullWidth?: boolean;
 }
 
 export interface StaticProps {

--- a/yarn.lock
+++ b/yarn.lock
@@ -3826,7 +3826,7 @@
     tslib "^2.2.0"
     typescript "4.2.4"
 
-"@medly/stylelint-config@^0.2.0":
+"@medly/stylelint-config@0.2.0":
   version "0.2.0"
   resolved "https://registry.yarnpkg.com/@medly/stylelint-config/-/stylelint-config-0.2.0.tgz#5f1e8ce2cdc0a4577d723d79bb467bae7c3460cf"
   integrity sha512-QtBweDNoDRUkyRiWS7MNxgF8AffBvqK2kSDmQR0lycUzRbBB9PjpiH134avYC20+6fAeTAW/QEE23PFRsMRmpQ==


### PR DESCRIPTION
affects: @medly-components/core

# PR Checklist

## Description
Add `fullWidth`  prop to `Tabs` component so that TabList can take parents full width

### Type of change
<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes and API changes)
- [ ] Build changes
- [ ] CI changes
- [ ] Document content changes
- [ ] Performance improvement
- [ ] Add missing tests
- [ ] Others (please describe)

## What is the current behaviour?
There is no way to make TabsList full width
<img width="1359" alt="image" src="https://user-images.githubusercontent.com/3636885/215290442-833bfb35-f074-4777-a537-9832781c0d5c.png">



## What is the new behaviour?
After passing `fullWidth`  prop to `Tabs` component `TabList` will take parents full width
<img width="1360" alt="image" src="https://user-images.githubusercontent.com/3636885/215290453-c3ff86be-f509-4edc-8486-d5901ca9b382.png">


## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

**Note:** (Replace This Text: If this PR contains a breaking change please describe the impact and migration path for existing application.)


## Additional context
(Replace This Text: Please describe any other related information or add screenshots of the PR.)


## Checklist
<!-- Please check the one that applies to this PR using "x". -->

- [x] My code follows the style guidelines of this project

- [x] I have performed a self-review of my own code

- [x] I have commented my code, particularly in hard-to-understand areas

- [x] I have made corresponding changes to the documentation

- [x] My changes generate no new warnings

- [x] I have added tests that prove my fix is effective or that my feature works

- [x] New and existing unit tests pass locally with my changes

- [x] Any dependent changes have been merged and published in downstream modules
