### PR TITLE
fix: set overflow visible when accordion is visible

### DIFF
--- a/packages/core/src/components/Accordion/Content/Content.styled.tsx
+++ b/packages/core/src/components/Accordion/Content/Content.styled.tsx
@@ -1,7 +1,7 @@
 import styled from 'styled-components';
 
 export const Wrapper = styled('div')<{ isActive: boolean }>`
-    overflow: hidden;
+    overflow: ${({ isActive }) => !isActive && 'hidden'};
     transition: all 200ms ${({ isActive }) => (isActive ? 'ease-in' : 'ease-out')};
     max-height: ${({ isActive }) => !isActive && 0};
     opacity: ${({ isActive }) => (isActive ? 1 : 0)};


### PR DESCRIPTION
affects: @medly-components/core

# PR Checklist

## Description
Set overflow visible to `Accordion.Content` component when accordion is visible so that if that renders any popup that can be visible

### Type of change
<!-- Please check the one that applies to this PR using "x". -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes and API changes)
- [ ] Build changes
- [ ] CI changes
- [ ] Document content changes
- [ ] Performance improvement
- [ ] Add missing tests
- [ ] Others (please describe)


## How has this been tested?
(Replace This Text: Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration.)

[ ] Test A

[ ] Test B


## Fixes #<issue_number>


## What is the current behaviour?
`Accordion.Content` is by default overflow hidden and because of that any pop up like datepicker is not visible


## What is the new behaviour?
Overflow is set to visible for `Accordion.Content` component when accordion is visible so that any pop up inside the content can be visible

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

**Note:** (Replace This Text: If this PR contains a breaking change please describe the impact and migration path for existing application.)


## Additional context
(Replace This Text: Please describe any other related information or add screenshots of the PR.)


## Checklist
<!-- Please check the one that applies to this PR using "x". -->

- [ ] My code follows the style guidelines of this project

- [ ] I have performed a self-review of my own code

- [ ] I have commented my code, particularly in hard-to-understand areas

- [ ] I have made corresponding changes to the documentation

- [ ] My changes generate no new warnings

- [ ] I have added tests that prove my fix is effective or that my feature works

- [ ] New and existing unit tests pass locally with my changes

- [ ] Any dependent changes have been merged and published in downstream modules
