### PR TITLE
fix: fix closing any popup like calendar in drawer component

### DIFF
--- a/packages/core/src/components/Drawer/Drawer.tsx
+++ b/packages/core/src/components/Drawer/Drawer.tsx
@@ -1,4 +1,5 @@
 import { useKeyPress, WithStyle } from '@medly-components/utils';
+import type { FC, MouseEvent } from 'react';
 import { forwardRef, memo, useCallback, useEffect, useReducer, useState } from 'react';
 import { reducer } from '../Modal/scrollStateReducer';
 import Content from './Content';
@@ -7,7 +8,6 @@ import { DrawerBackground, DrawerStyled } from './Drawer.styled';
 import Footer from './Footer';
 import Header from './Header';
 import { DrawerProps, DrawerStaticProps } from './types';
-import type { FC } from 'react';
 
 const Component: FC<DrawerProps> = memo(
     forwardRef(({ id, onClose, open, width, children, withOverlay, position, ...props }, ref) => {
@@ -15,7 +15,10 @@ const Component: FC<DrawerProps> = memo(
             [shouldRender, setRenderState] = useState(open),
             [scrollState, dispatch] = useReducer(reducer, { scrolledToTop: true, scrolledToBottom: false, scrollPosition: 0 });
 
-        const stopPropagation = useCallback((e: React.MouseEvent) => e.stopPropagation(), []),
+        const handleBackgroundClick = useCallback(
+                (event: MouseEvent<HTMLDivElement>) => event.currentTarget === event.target && onClose && onClose(),
+                [onClose]
+            ),
             handleAnimationEnd = useCallback(() => !open && setRenderState(false), [open]);
 
         useEffect(() => {
@@ -27,15 +30,15 @@ const Component: FC<DrawerProps> = memo(
         }, [open]);
 
         return shouldRender ? (
-            <DrawerBackground onClick={onClose} ref={ref} open={open} {...props} id={`${id}-overlay`} withOverlay={withOverlay}>
-                <DrawerStyled
-                    id={id!}
-                    position={position!}
-                    onClick={stopPropagation}
-                    width={width!}
-                    open={open}
-                    onAnimationEnd={handleAnimationEnd}
-                >
+            <DrawerBackground
+                ref={ref}
+                open={open}
+                {...props}
+                id={`${id}-overlay`}
+                withOverlay={withOverlay}
+                onClick={handleBackgroundClick}
+            >
+                <DrawerStyled id={id!} position={position!} width={width!} open={open} onAnimationEnd={handleAnimationEnd}>
                     <DrawerContext.Provider value={{ id: id!, scrollState, dispatch, onClose }}>{children}</DrawerContext.Provider>
                 </DrawerStyled>
             </DrawerBackground>

--- a/packages/core/src/components/Drawer/types.ts
+++ b/packages/core/src/components/Drawer/types.ts
@@ -1,7 +1,7 @@
 import { HTMLProps, WithStyle } from '@medly-components/utils';
+import type { Dispatch, FC } from 'react';
 import { ScrollActionTypes } from '../Modal/scrollStateReducer/types';
 import { DrawerFooterProps } from './Footer/types';
-import type { FC, Dispatch } from 'react';
 
 export interface DrawerProps extends HTMLProps<HTMLDivElement> {
     open?: boolean;


### PR DESCRIPTION
affects: @medly-components/core

# PR Checklist

## Description
Any popup like `Calendar` or `SingleSelct` popup is not closing on clicking outside of popup but inside `Drawer` component. Because the eventPropagation was stopped in `Drawer` component and beacuse of that those popup are not closing.

### Type of change
<!-- Please check the one that applies to this PR using "x". -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes and API changes)
- [ ] Build changes
- [ ] CI changes
- [ ] Document content changes
- [ ] Performance improvement
- [ ] Add missing tests
- [ ] Others (please describe)


## How has this been tested?
(Replace This Text: Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration.)

[ ] Test A

[ ] Test B


## Fixes #<issue_number>


## What is the current behaviour?
Any popup like `Calendar` or `SingleSelct` popup is not closing on clicking outside of popup but inside `Drawer` component. 


## What is the new behaviour?
Now popup like `Calendar` or `SingleSelct` popup is closing on clicking outside of popup but inside `Drawer` component. 


## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

**Note:** (Replace This Text: If this PR contains a breaking change please describe the impact and migration path for existing application.)


## Additional context
(Replace This Text: Please describe any other related information or add screenshots of the PR.)


## Checklist
<!-- Please check the one that applies to this PR using "x". -->

- [x] My code follows the style guidelines of this project

- [x] I have performed a self-review of my own code

- [ ] I have commented my code, particularly in hard-to-understand areas

- [ ] I have made corresponding changes to the documentation

- [x] My changes generate no new warnings

- [ ] I have added tests that prove my fix is effective or that my feature works

- [x] New and existing unit tests pass locally with my changes

- [ ] Any dependent changes have been merged and published in downstream modules
