### PR TITLE
fix: stop passing placeholder to wrapper component in multiselect component

### DIFF
--- a/packages/core/src/components/MultiSelect/MultiSelect.tsx
+++ b/packages/core/src/components/MultiSelect/MultiSelect.tsx
@@ -33,6 +33,7 @@ const Component: FC<MultiSelectProps> = memo(
                 prefix,
                 isCreatable = false,
                 noResultComponent,
+                placeholder: initialPlaceholder,
                 ...restProps
             } = props,
             selectId = useMemo(() => id || label?.toLocaleLowerCase().replace(' ', '') || 'medly-multiSelect', [id, label]);
@@ -45,7 +46,7 @@ const Component: FC<MultiSelectProps> = memo(
             [areOptionsVisible, setOptionsVisibilityState] = useState(false),
             [selectedOptions, setSelectedOptions] = useState(getDefaultSelectedOptions(defaultOptions, values!)),
             [inputValue, setInputValue] = useState(getInputValue(selectedOptions)),
-            [placeholder, setPlaceholder] = useState(values!.length > 0 ? `${values!.length} options selected` : props.placeholder),
+            [placeholder, setPlaceholder] = useState(values!.length > 0 ? `${values!.length} options selected` : initialPlaceholder),
             [cursor, setCursor] = useState(-1),
             [isParentCursorEnabled, setIsParentCursorEnabled] = useState(true),
             isSelectKeyPressed = useKeyPress(' ', false, wrapperRef),
@@ -147,7 +148,7 @@ const Component: FC<MultiSelectProps> = memo(
         useEffect(() => {
             if (areOptionsVisible) {
                 inputRef.current && inputRef.current.focus();
-                setPlaceholder(selectedOptions.length > 0 ? `${selectedOptions.length} options selected` : props.placeholder);
+                setPlaceholder(selectedOptions.length > 0 ? `${selectedOptions.length} options selected` : initialPlaceholder);
             } else {
                 setInputValue(getInputValue(selectedOptions));
                 setOptions(defaultOptions);

--- a/packages/core/src/components/MultiSelect/__snapshots__/MultiSelect.test.tsx.snap
+++ b/packages/core/src/components/MultiSelect/__snapshots__/MultiSelect.test.tsx.snap
@@ -427,7 +427,6 @@ exports[`MultiSelect component should render correctly with all the props given 
     class="c0"
     disabled=""
     id="pharmacy-wrapper"
-    placeholder="Please Select"
   >
     <div
       class="c1 c2"
@@ -879,7 +878,6 @@ exports[`MultiSelect component should render correctly with default props 1`] = 
   <div
     class="c0"
     id="medly-multiSelect-wrapper"
-    placeholder="Please Select . . ."
     value="Dummy1,Dummy2"
   >
     <div
@@ -1895,7 +1893,6 @@ exports[`MultiSelect component should render properly with M size 1`] = `
   <div
     class="c0"
     id="pharmacy-wrapper"
-    placeholder="Please Select . . ."
   >
     <div
       class="c1 c2"
@@ -3270,7 +3267,6 @@ exports[`MultiSelect component should render properly with S size 1`] = `
   <div
     class="c0"
     id="pharmacy-wrapper"
-    placeholder="Please Select . . ."
   >
     <div
       class="c1 c2"

--- a/packages/forms/src/components/Form/__snapshots__/Form.test.tsx.snap
+++ b/packages/forms/src/components/Form/__snapshots__/Form.test.tsx.snap
@@ -2253,7 +2253,6 @@ exports[`Form should render properly with initial state 1`] = `
         class="c54"
         id="graduation-wrapper"
         name="graduation"
-        placeholder="Please Select . . ."
       >
         <div
           class="c2 c41"
@@ -4498,7 +4497,6 @@ exports[`Form should render properly without initial state 1`] = `
         class="c54"
         id="graduation-wrapper"
         name="graduation"
-        placeholder="Please Select . . ."
       >
         <div
           class="c5 c41"


### PR DESCRIPTION
affects: @medly-components/core, @medly-components/forms

# PR Checklist

## Description
Stop passing `placeholder` prop to `Wrapper` component in `MultiSelect` component.

### Type of change
<!-- Please check the one that applies to this PR using "x". -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes and API changes)
- [ ] Build changes
- [ ] CI changes
- [ ] Document content changes
- [ ] Performance improvement
- [ ] Add missing tests
- [ ] Others (please describe)


## How has this been tested?
(Replace This Text: Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration.)

[ ] Test A

[ ] Test B


## Fixes #<issue_number>


## What is the current behaviour?
Placeholder prop is by mistakenly passed to Wrapper component.


## What is the new behaviour?
Placeholder prop is now not being passed to Wrapper component.


## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

**Note:** (Replace This Text: If this PR contains a breaking change please describe the impact and migration path for existing application.)


## Additional context
(Replace This Text: Please describe any other related information or add screenshots of the PR.)


## Checklist
<!-- Please check the one that applies to this PR using "x". -->

- [x] My code follows the style guidelines of this project

- [x] I have performed a self-review of my own code

- [ ] I have commented my code, particularly in hard-to-understand areas

- [ ] I have made corresponding changes to the documentation

- [ ] My changes generate no new warnings

- [ ] I have added tests that prove my fix is effective or that my feature works

- [x] New and existing unit tests pass locally with my changes

- [ ] Any dependent changes have been merged and published in downstream modules
