### PR TITLE
feat: add an option to hide input in datepicker component

### DIFF
--- a/packages/core/src/components/DatePicker/DatePicker.stories.mdx
+++ b/packages/core/src/components/DatePicker/DatePicker.stories.mdx
@@ -20,7 +20,7 @@ import { placements } from '../Popover/Popover.stories.tsx';
 
 # DatePicker Component
 
-The `DatePicker` is a controlled component that allows you to select a date through input text or using a calendar dialog. 
+The `DatePicker` is a controlled component that allows you to select a date through input text or using a calendar dialog.
 
 Handle the state as follows:
 
@@ -30,6 +30,7 @@ return <DatePicker label="Select Date" value={date} onChange={setDate} />;
 ```
 
 To use the calendar, you must:
+
 1. Ckick the calendar icon inside the DatePicker component to open the calendar.
 2. Click any date or click outside the DatePicker component to close the calendar.
 3. The provision to enter the date manually is given.
@@ -52,6 +53,7 @@ To use the calendar, you must:
                     label={text('Label', 'Date of Birth')}
                     variant={select('variant', variants, 'outlined')}
                     required={boolean('Required', false)}
+                    hideInput={boolean('Hide Input', false)}
                     showCalendarIcon={boolean('Show calendar icon', true)}
                     calendarIconPosition={select('Calendar icon position', calendarIconPositions, 'right')}
                 />

--- a/packages/core/src/components/DatePicker/DatePicker.styled.tsx
+++ b/packages/core/src/components/DatePicker/DatePicker.styled.tsx
@@ -3,7 +3,7 @@ import { InjectClassName, Omit, WithThemeProp } from '@medly-components/utils';
 import styled, { css } from 'styled-components';
 import Calendar from '../Calendar';
 import { getPosition } from '../Popover/Popup/styled/Popup.styled';
-import { InnerWrapper, OuterWrapper } from '../TextField/Styled';
+import { InnerWrapper, InputWrapper, OuterWrapper } from '../TextField/Styled';
 import { StyleProps } from './types';
 
 type State = 'default' | 'active' | 'error' | 'disabled';
@@ -36,6 +36,21 @@ export const DateIconWrapper = styled(InjectClassName)<Omit<StyleProps, 'placeme
     ${props => props.disabled && getStyleForIcon(props, 'disabled')};
 `;
 
+const hiddenInputStyle = css<StyleProps>`
+    margin: 0;
+    min-width: 0;
+    & > ${OuterWrapper} {
+        min-width: 0;
+        ${InnerWrapper} {
+            width: fit-content;
+            padding: ${({ size }) => (size === 'S' ? '0 0.4rem' : '0 0.8rem')};
+            & > ${InputWrapper} {
+                display: none;
+            }
+        }
+    }
+`;
+
 export const Wrapper = styled(OuterWrapper)<StyleProps>`
     & > ${OuterWrapper} {
         margin: 0;
@@ -48,7 +63,10 @@ export const Wrapper = styled(OuterWrapper)<StyleProps>`
         z-index: 4;
         position: absolute;
         ${getPosition}
-        top: ${({ size, placement }) =>
-            (placement === 'bottom' || placement === 'bottom-start' || placement === 'bottom-end') && (size === 'S' ? '4rem' : '5.6rem')};
+        top: ${({ size, placement, theme }) =>
+            (placement === 'bottom' || placement === 'bottom-start' || placement === 'bottom-end') &&
+            (size === 'S' ? theme.textField.height.S : theme.textField.height.M)};
     }
+
+    ${({ hideInput }) => hideInput && hiddenInputStyle};
 `;

--- a/packages/core/src/components/DatePicker/DatePicker.test.tsx
+++ b/packages/core/src/components/DatePicker/DatePicker.test.tsx
@@ -21,6 +21,13 @@ describe('DatePicker component', () => {
         expect(container).toMatchSnapshot();
     });
 
+    it('should render properly when hideInput prop is passed', () => {
+        const { container } = render(
+            <DatePicker hideInput label="Start Date" value={null} displayFormat="MM/dd/yyyy" onChange={jest.fn()} />
+        );
+        expect(container).toMatchSnapshot();
+    });
+
     it('should render properly when value is of string type', () => {
         const { container } = render(
                 <DatePicker

--- a/packages/core/src/components/DatePicker/DatePicker.tsx
+++ b/packages/core/src/components/DatePicker/DatePicker.tsx
@@ -31,6 +31,7 @@ const Component: FC<DatePickerProps> = memo(
                 calendarIconPosition,
                 defaultMonth,
                 defaultYear,
+                hideInput,
                 ...restProps
             } = props,
             id = props.id || props.label?.toLowerCase().replace(/\s/g, '') || 'medly-datepicker', // TODO:- Remove static ID concept to avoid dup ID
@@ -150,6 +151,7 @@ const Component: FC<DatePickerProps> = memo(
                 className={className}
                 variant={restProps.variant!}
                 placement={popoverPlacement!}
+                hideInput={hideInput}
             >
                 <TextField
                     errorText={errorText || builtInErrorMessage}

--- a/packages/core/src/components/DatePicker/__snapshots__/DatePicker.test.tsx.snap
+++ b/packages/core/src/components/DatePicker/__snapshots__/DatePicker.test.tsx.snap
@@ -13301,6 +13301,447 @@ exports[`DatePicker component popover placement should render properly with "top
 </div>
 `;
 
+exports[`DatePicker component should render properly when hideInput prop is passed 1`] = `
+.c12 {
+  overflow: visible;
+  font-size: 2.4rem;
+  -webkit-transition: all 100ms linear;
+  transition: all 100ms linear;
+  cursor: pointer;
+}
+
+.c12 * {
+  fill-opacity: 1;
+  -webkit-transition: all 100ms linear;
+  transition: all 100ms linear;
+  fill: #607890;
+}
+
+.c11 {
+  top: 50%;
+  left: 0;
+  cursor: text;
+  -webkit-user-select: none;
+  -moz-user-select: none;
+  -ms-user-select: none;
+  user-select: none;
+  position: absolute;
+  pointer-events: none;
+  -webkit-transition: all 150ms cubic-bezier(0.4,0,0.2,1);
+  transition: all 150ms cubic-bezier(0.4,0,0.2,1);
+  font-size: 1.6rem;
+  font-weight: 400;
+  -webkit-letter-spacing: 0rem;
+  -moz-letter-spacing: 0rem;
+  -ms-letter-spacing: 0rem;
+  letter-spacing: 0rem;
+  line-height: 2.6rem;
+  font-family: Open Sans,Helvetica Neue,Helvetica,Arial,sans-serif;
+  -webkit-transform-origin: 0 0;
+  -ms-transform-origin: 0 0;
+  transform-origin: 0 0;
+  touch-action: manipulation;
+  -webkit-transform: translateY(-50%);
+  -ms-transform: translateY(-50%);
+  transform: translateY(-50%);
+  opacity: 1;
+  z-index: 1;
+  width: 100%;
+  max-width: -webkit-min-content;
+  max-width: -moz-min-content;
+  max-width: min-content;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
+.c4 {
+  position: relative;
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  -webkit-flex-direction: row;
+  -ms-flex-direction: row;
+  flex-direction: row;
+  box-sizing: border-box;
+  height: 5.6rem;
+  padding: 0 1.6rem;
+  -webkit-transition: all 100ms ease-out;
+  transition: all 100ms ease-out;
+  cursor: text;
+  border-radius: 0.4rem 0.4rem 0 0;
+  background-color: #eff2f4;
+}
+
+.c4 .c10 {
+  color: #546A7F;
+}
+
+.c4 .sc-1ubn8hn-0,
+.c4 .sc-dynlvq-0 {
+  color: #546A7F;
+}
+
+.c4 .sc-1ubn8hn-0 *,
+.c4 .sc-dynlvq-0 * {
+  fill: #546A7F;
+}
+
+.c4 ~ .sc-avlt8d-0 {
+  color: #546A7F;
+}
+
+.c4::after {
+  content: '';
+  width: 100%;
+  height: 0;
+  position: absolute;
+  bottom: 0;
+  left: 0;
+  box-sizing: border-box;
+  border-top: 0.1rem solid #546A7F;
+  -webkit-transition: all 100ms ease-out;
+  transition: all 100ms ease-out;
+}
+
+.c4:hover::after,
+.c4:focus-within::after {
+  border-width: 0.2rem;
+}
+
+.c4 input {
+  box-shadow: 0 0 0 100000px #eff2f4 inset;
+}
+
+.c4:focus-within,
+.c4:focus-within:hover {
+  background-color: #EBF1FA;
+}
+
+.c4:focus-within::after,
+.c4:focus-within:hover::after {
+  border-color: #3872D2;
+  border-radius: 0;
+}
+
+.c4:focus-within .c10,
+.c4:focus-within:hover .c10 {
+  color: #3872D2;
+}
+
+.c4:focus-within .sc-1ubn8hn-0,
+.c4:focus-within:hover .sc-1ubn8hn-0,
+.c4:focus-within .sc-dynlvq-0,
+.c4:focus-within:hover .sc-dynlvq-0 {
+  color: #3872D2;
+}
+
+.c4:focus-within .sc-1ubn8hn-0 *,
+.c4:focus-within:hover .sc-1ubn8hn-0 *,
+.c4:focus-within .sc-dynlvq-0 *,
+.c4:focus-within:hover .sc-dynlvq-0 * {
+  fill: #3872D2;
+}
+
+.c4:focus-within input,
+.c4:focus-within:hover input {
+  box-shadow: 0 0 0 100000px #EBF1FA inset;
+}
+
+.c4:focus-within input::-webkit-input-placeholder,
+.c4:focus-within:hover input::-webkit-input-placeholder {
+  color: rgba(0,90,238,.2);
+}
+
+.c4:focus-within input::-moz-placeholder,
+.c4:focus-within:hover input::-moz-placeholder {
+  color: rgba(0,90,238,.2);
+}
+
+.c4:focus-within input:-ms-input-placeholder,
+.c4:focus-within:hover input:-ms-input-placeholder {
+  color: rgba(0,90,238,.2);
+}
+
+.c4:focus-within input::placeholder,
+.c4:focus-within:hover input::placeholder {
+  color: rgba(0,90,238,.2);
+}
+
+.c6 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  position: relative;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  background-color: transparent;
+  -webkit-flex: 1;
+  -ms-flex: 1;
+  flex: 1;
+  height: 100%;
+}
+
+.c9 {
+  position: absolute;
+  left: 0;
+  opacity: 0;
+  cursor: text;
+  -webkit-user-select: none;
+  -moz-user-select: none;
+  -ms-user-select: none;
+  user-select: none;
+  pointer-events: none;
+  color: rgba(0,90,238,.2);
+  bottom: 0.7rem;
+}
+
+.c2 {
+  position: relative;
+  -webkit-flex-direction: column;
+  -ms-flex-direction: column;
+  flex-direction: column;
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  width: 100%;
+  min-width: 20rem;
+  margin: 0.8rem 0;
+}
+
+.c7 {
+  color: #13181D;
+  width: 100%;
+  margin: 0;
+  padding: 0;
+  box-sizing: border-box;
+  -webkit-transition: all 100ms ease-out;
+  transition: all 100ms ease-out;
+  background-color: transparent;
+  border: none;
+  text-overflow: ellipsis;
+  resize: none;
+  z-index: 1;
+  -webkit-align-self: flex-end;
+  -ms-flex-item-align: end;
+  align-self: flex-end;
+  margin-bottom: 0.7rem;
+}
+
+.c7,
+.c7 ~ .c8 {
+  font-size: 1.6rem;
+  font-weight: 400;
+  -webkit-letter-spacing: 0rem;
+  -moz-letter-spacing: 0rem;
+  -ms-letter-spacing: 0rem;
+  letter-spacing: 0rem;
+  line-height: 2.6rem;
+  font-family: Open Sans,Helvetica Neue,Helvetica,Arial,sans-serif;
+}
+
+.c7.c7.c7:focus {
+  outline: none;
+  box-shadow: unset;
+}
+
+.c7.c7.c7:focus::-webkit-input-placeholder {
+  opacity: 1;
+}
+
+.c7.c7.c7:focus::-moz-placeholder {
+  opacity: 1;
+}
+
+.c7.c7.c7:focus:-ms-input-placeholder {
+  opacity: 1;
+}
+
+.c7.c7.c7:focus::placeholder {
+  opacity: 1;
+}
+
+.c7:disabled {
+  color: #435465;
+}
+
+.c7:disabled ~ .c10,
+.c7:disabled ~ .c8 {
+  cursor: not-allowed;
+}
+
+.c7::-webkit-input-placeholder {
+  opacity: 0;
+  -webkit-transition: all 100ms ease-out;
+  transition: all 100ms ease-out;
+}
+
+.c7::-moz-placeholder {
+  opacity: 0;
+  -webkit-transition: all 100ms ease-out;
+  transition: all 100ms ease-out;
+}
+
+.c7:-ms-input-placeholder {
+  opacity: 0;
+  -webkit-transition: all 100ms ease-out;
+  transition: all 100ms ease-out;
+}
+
+.c7::placeholder {
+  opacity: 0;
+  -webkit-transition: all 100ms ease-out;
+  transition: all 100ms ease-out;
+}
+
+.c7:not(:placeholder-shown) ~ .c10,
+.c7:focus ~ .c10 {
+  -webkit-transform: translateY(-87%) scale(0.75);
+  -ms-transform: translateY(-87%) scale(0.75);
+  transform: translateY(-87%) scale(0.75);
+}
+
+.c7:not(:placeholder-shown) ~ .c8 {
+  opacity: 1;
+}
+
+.c13 {
+  cursor: pointer;
+  border-radius: 50%;
+  padding: 0.8rem;
+}
+
+.c13 * {
+  fill: #607890;
+}
+
+.c13:hover {
+  background-color: #dfe4e9;
+}
+
+.c13:hover * {
+  fill: #303C48;
+}
+
+.c1 {
+  position: relative;
+  -webkit-flex-direction: column;
+  -ms-flex-direction: column;
+  flex-direction: column;
+  display: -webkit-inline-box;
+  display: -webkit-inline-flex;
+  display: -ms-inline-flexbox;
+  display: inline-flex;
+  width: -webkit-min-content;
+  width: -moz-min-content;
+  width: min-content;
+  min-width: 20rem;
+  margin: 0.8rem 0.8rem 0.8rem 0;
+  margin: 0;
+  min-width: 0;
+}
+
+.c1 > .c0 {
+  margin: 0;
+}
+
+.c1 > .c0 > .c3 {
+  padding-right: 0.8rem;
+}
+
+.c1 .sc-zv8j3p-0 {
+  z-index: 4;
+  position: absolute;
+  top: calc(100% + 0px);
+  left: 0%;
+  top: 5.6rem;
+}
+
+.c1 > .c0 {
+  min-width: 0;
+}
+
+.c1 > .c0 .c3 {
+  width: -webkit-fit-content;
+  width: -moz-fit-content;
+  width: fit-content;
+  padding: 0 0.8rem;
+}
+
+.c1 > .c0 .c3 > .c5 {
+  display: none;
+}
+
+<div>
+  <div
+    class="c0 c1"
+    id="startdate-datepicker-wrapper"
+  >
+    <div
+      class="c0 c2"
+      id="startdate-input-wrapper"
+    >
+      <div
+        class="c3 c4"
+      >
+        <div
+          class="c5 c6"
+        >
+          <input
+            aria-describedby="startdate-helper-text"
+            class="c7"
+            id="startdate-input"
+            pattern="\\\\d{2} \\\\/ \\\\d{2} \\\\/ \\\\d{4}"
+            placeholder="MM / DD / YYYY"
+            type="text"
+            value=""
+          />
+          <span
+            class="c8 c9"
+          >
+            MM / DD / YYYY
+          </span>
+          <label
+            class="c10 c11"
+            for="startdate-input"
+          >
+            Start Date
+          </label>
+        </div>
+        <svg
+          class="c12 c13"
+          fill="none"
+          height="1em"
+          id="startdate-calendar-icon"
+          title="startdate-calendar-icon"
+          viewBox="0 0 24 24"
+          width="1em"
+          xmlns="http://www.w3.org/2000/svg"
+        >
+          <path
+            clip-rule="evenodd"
+            d="M19 4h-1V3c0-.55-.45-1-1-1s-1 .45-1 1v1H8V3c0-.55-.45-1-1-1s-1 .45-1 1v1H5c-1.11 0-1.99.9-1.99 2L3 20a2 2 0 0 0 2 2h14c1.1 0 2-.9 2-2V6c0-1.1-.9-2-2-2zm0 15c0 .55-.45 1-1 1H6c-.55 0-1-.45-1-1V9h14v10zM9 13v-2H7v2h2zm2-2h2v2h-2v-2zm6 2v-2h-2v2h2z"
+            fill="#000"
+            fill-opacity=".54"
+            fill-rule="evenodd"
+          />
+        </svg>
+      </div>
+      
+    </div>
+  </div>
+</div>
+`;
+
 exports[`DatePicker component should render properly when value is of date type 1`] = `
 .c11 {
   overflow: visible;

--- a/packages/core/src/components/DatePicker/types.ts
+++ b/packages/core/src/components/DatePicker/types.ts
@@ -61,7 +61,7 @@ export interface DatePickerProps extends Omit<HTMLProps<HTMLInputElement>, 'valu
     defaultMonth?: number;
     /** Default year to show on calendar */
     defaultYear?: number;
-    /** Hide Input */
+    /** Set it true to hide the input */
     hideInput?: boolean;
 }
 

--- a/packages/core/src/components/DatePicker/types.ts
+++ b/packages/core/src/components/DatePicker/types.ts
@@ -61,9 +61,11 @@ export interface DatePickerProps extends Omit<HTMLProps<HTMLInputElement>, 'valu
     defaultMonth?: number;
     /** Default year to show on calendar */
     defaultYear?: number;
+    /** Hide Input */
+    hideInput?: boolean;
 }
 
-export interface StyleProps extends Pick<DatePickerProps, 'variant' | 'fullWidth' | 'disabled' | 'minWidth' | 'size'> {
+export interface StyleProps extends Pick<DatePickerProps, 'variant' | 'fullWidth' | 'disabled' | 'minWidth' | 'size' | 'hideInput'> {
     isErrorPresent?: boolean;
     isActive?: boolean;
     placement: Placement;


### PR DESCRIPTION
affects: @medly-components/core

# PR Checklist

## Description
Add an option to hide input in datepicker component via passing the prop `hideInput`. This feature will help us to render the datepicker like below 
<img width="740" alt="image" src="https://user-images.githubusercontent.com/3636885/232042014-9db93584-89cb-44e2-9907-cfde248648f2.png">


### Type of change
<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes and API changes)
- [ ] Build changes
- [ ] CI changes
- [ ] Document content changes
- [ ] Performance improvement
- [ ] Add missing tests
- [ ] Others (please describe)


## How has this been tested?
Added the unit to test the component with `hideInput` prop being passed.

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

**Note:** (Replace This Text: If this PR contains a breaking change please describe the impact and migration path for existing application.)


## Additional context
(Replace This Text: Please describe any other related information or add screenshots of the PR.)


## Checklist
<!-- Please check the one that applies to this PR using "x". -->

- [x] My code follows the style guidelines of this project

- [x] I have performed a self-review of my own code

- [x] I have commented my code, particularly in hard-to-understand areas

- [x] I have made corresponding changes to the documentation

- [x] My changes generate no new warnings

- [x] I have added tests that prove my fix is effective or that my feature works

- [x] New and existing unit tests pass locally with my changes

- [x] Any dependent changes have been merged and published in downstream modules
