### PR TITLE
fix(core): fixed single select outside click focus issue

### DIFF
--- a/packages/core/src/components/SingleSelect/SingleSelect.tsx
+++ b/packages/core/src/components/SingleSelect/SingleSelect.tsx
@@ -104,6 +104,7 @@ const Component: FC<SingleSelectProps> = memo(
             ),
             handleOuterClick = useCallback(() => {
                 if (areOptionsVisible) {
+                    isFocused.current = false;
                     hideOptions();
                     validate();
                     updateToDefaultOptions();


### PR DESCRIPTION
affects: @medly-components/core

ISSUES CLOSED: #718

# PR Checklist

## Description
This PR resolves the focus issue on a single select field which is mentioned in the #718 issue ticket.

### Type of change
<!-- Please check the one that applies to this PR using "x". -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes and API changes)
- [ ] Build changes
- [ ] CI changes
- [ ] Document content changes
- [ ] Performance improvement
- [ ] Add missing tests
- [ ] Others (please describe)


## How has this been tested?
(Replace This Text: Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration.)

[ ] Test A

[ ] Test B


## Fixes #<issue_number>


## What is the current behaviour?
the focus was not getting removed on the outside click, it was opening an options popup when we press the down arrow key


## What is the new behaviour?
Removed focus on the outside click, It will not open the option popup when we click outside and press the down arrow key.


## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

**Note:** (Replace This Text: If this PR contains a breaking change please describe the impact and migration path for existing application.)


## Additional context
(Replace This Text: Please describe any other related information or add screenshots of the PR.)


## Checklist
<!-- Please check the one that applies to this PR using "x". -->

- [x] My code follows the style guidelines of this project

- [x] I have performed a self-review of my own code

- [ ] I have commented my code, particularly in hard-to-understand areas

- [ ] I have made corresponding changes to the documentation

- [x] My changes generate no new warnings

- [ ] I have added tests that prove my fix is effective or that my feature works

- [x] New and existing unit tests pass locally with my changes

- [ ] Any dependent changes have been merged and published in downstream modules
