### PR TITLE
fix(core): pass default HTML input attributes to input elements in DateRangePicker

### DIFF
--- a/packages/core/src/components/DateRangePicker/DateRangePicker.tsx
+++ b/packages/core/src/components/DateRangePicker/DateRangePicker.tsx
@@ -131,6 +131,7 @@ export const DateRangePicker: FC<DateRangeProps> = memo(props => {
                 onCustomRangeIconClick={onCustomRangeIconClick}
                 showChevronIcon={customDateRangeOptions!.length > 0}
                 outerClickValidator={outerClickValidator}
+                {...restProps}
             />
             {isActive &&
                 (activePopover === PopoverTypes.CALENDAR ? (

--- a/packages/core/src/components/DateRangePicker/DateRangeTextFields/DateRangeTextFields.tsx
+++ b/packages/core/src/components/DateRangePicker/DateRangeTextFields/DateRangeTextFields.tsx
@@ -1,4 +1,5 @@
 import { ChevronDownIcon, DateRangeIcon } from '@medly-components/icons';
+import type { FC } from 'react';
 import { memo, useEffect } from 'react';
 import { DateIconWrapper as IconWrapper } from '../../DatePicker/DatePicker.styled';
 import datePickerPattern from '../../DatePicker/datePickerPattern';
@@ -10,7 +11,6 @@ import { Wrapper } from './DateRangeTextFields.styled';
 import InputSeparator from './InputSeparator';
 import { Props } from './types';
 import { useDateRangeTextFieldsHandlers } from './useDateRangeTextFieldsHandlers';
-import type { FC } from 'react';
 
 export const DateRangeTextFields: FC<Props> = memo(props => {
     const {
@@ -32,7 +32,8 @@ export const DateRangeTextFields: FC<Props> = memo(props => {
             showChevronIcon,
             activePopover,
             onCustomRangeIconClick,
-            outerClickValidator
+            outerClickValidator,
+            ...restProps
         } = props,
         {
             mask,
@@ -61,7 +62,8 @@ export const DateRangeTextFields: FC<Props> = memo(props => {
             placeholder: mask,
             onChange: handleTextChange,
             errorText: errorText || builtInErrorMessage,
-            pattern: datePickerPattern[displayFormat]
+            pattern: datePickerPattern[displayFormat],
+            ...restProps
         },
         iconProps = {
             variant,


### PR DESCRIPTION
affects: @medly-components/core

ISSUES CLOSED: #723

# PR Checklist

## Description
This PR fixes the issue #723 

### Type of change
<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes and API changes)
- [ ] Build changes
- [ ] CI changes
- [ ] Document content changes
- [ ] Performance improvement
- [ ] Add missing tests
- [ ] Others (please describe)

## Fixes #723 

## What is the current behaviour?
Default input attributes were not being passed to input elements


## What is the new behaviour?
Default input attributes are being passed to input elements


## Does this PR introduce a breaking change?

- [ ] Yes
- [ ] No



## Checklist
<!-- Please check the one that applies to this PR using "x". -->

- [ ] My code follows the style guidelines of this project

- [ ] I have performed a self-review of my own code

- [ ] I have commented my code, particularly in hard-to-understand areas

- [ ] I have made corresponding changes to the documentation

- [ ] My changes generate no new warnings

- [ ] I have added tests that prove my fix is effective or that my feature works

- [ ] New and existing unit tests pass locally with my changes

- [ ] Any dependent changes have been merged and published in downstream modules
