### PR TITLE
feat(core): fixed SearchBox search trigger issue on option selection using enter

### DIFF
--- a/packages/core/src/components/SearchBox/SearchBox.test.tsx
+++ b/packages/core/src/components/SearchBox/SearchBox.test.tsx
@@ -216,8 +216,9 @@ describe('SearchBox', () => {
         });
 
         describe('with option selected', () => {
-            const onOptionSelectedMock = jest.fn();
-            const withOptionCB = { ...props, onOptionSelected: onOptionSelectedMock };
+            const onOptionSelectedMock = jest.fn(),
+                onSearch = jest.fn(),
+                withOptionCB = { ...props, onOptionSelected: onOptionSelectedMock, onSearch };
 
             it('should call on OptionSelected when option is clicked', () => {
                 const { inputEl } = renderComponent(withOptionCB);
@@ -231,6 +232,15 @@ describe('SearchBox', () => {
                 fireEvent.focus(inputEl);
                 fireEvent.keyDown(container, { key: 'ArrowDown', code: 40 });
                 fireEvent.keyDown(container, { key: 'Enter', code: 13 });
+                expect(inputEl).toHaveValue('Dummy 1');
+            });
+
+            it('should not call onSearch on option selection using enter', () => {
+                const { container, inputEl } = renderComponent(withOptionCB);
+                fireEvent.focus(inputEl);
+                fireEvent.keyDown(container, { key: 'ArrowDown', code: 40 });
+                fireEvent.keyDown(container, { key: 'Enter', code: 13 });
+                expect(onSearch).not.toBeCalled();
                 expect(inputEl).toHaveValue('Dummy 1');
             });
         });

--- a/packages/core/src/components/SearchBox/SearchBox.tsx
+++ b/packages/core/src/components/SearchBox/SearchBox.tsx
@@ -1,6 +1,6 @@
 import { CloseIcon, ExpandIcon, SearchIcon } from '@medly-components/icons';
 import { CircleLoader } from '@medly-components/loaders';
-import { useCombinedRefs, useKeyPress, useOuterClickNotifier, WithStyle } from '@medly-components/utils';
+import { WithStyle, useCombinedRefs, useKeyPress, useOuterClickNotifier } from '@medly-components/utils';
 import type { FC } from 'react';
 import { forwardRef, memo, useCallback, useEffect, useRef, useState } from 'react';
 import Options from '../SingleSelect/Options';
@@ -68,13 +68,13 @@ const Component: FC<SearchBoxProps> = memo(
                 setOptionsVisibilityState(false);
                 setShowCloseIcon(false);
                 updateIsTyping(false);
-                onClear && onClear();
+                onClear?.();
             }, []),
             handleChange = useCallback((event: React.ChangeEvent<HTMLInputElement>) => {
                 const { value } = event.target;
                 updateIsTyping(value.length !== 0);
                 setShowCloseIcon(value.length !== 0);
-                onInputChange && onInputChange(value);
+                onInputChange?.(value);
             }, []),
             handleOptionClick = useCallback(
                 (option: Option) => {
@@ -83,7 +83,7 @@ const Component: FC<SearchBoxProps> = memo(
                         inputRef.current.focus();
                     }
                     setOptionsVisibilityState(false);
-                    onOptionSelected && onOptionSelected(option);
+                    onOptionSelected?.(option);
                 },
                 [onOptionSelected]
             ),
@@ -98,7 +98,7 @@ const Component: FC<SearchBoxProps> = memo(
             handleBlur = useCallback(() => {
                 isFocused.current = false;
             }, []),
-            handleSearchIconClick = useCallback(() => onSearch && onSearch(inputRef.current?.value || ''), [onSearch]);
+            handleSearchIconClick = useCallback(() => onSearch?.(inputRef.current?.value || ''), [onSearch]);
 
         useKeyboardNavigation({
             isFocused,
@@ -119,10 +119,10 @@ const Component: FC<SearchBoxProps> = memo(
                 const currentSelectedOption = options.find(option => option.hovered === true);
                 if (inputRef.current && currentSelectedOption) {
                     inputRef.current.value = currentSelectedOption.label;
-                    onOptionSelected && onOptionSelected(currentSelectedOption);
+                    onOptionSelected?.(currentSelectedOption);
                     inputRef.current.blur();
                 }
-                onSearch && onSearch(inputRef.current?.value || '');
+                !currentSelectedOption && onSearch?.(inputRef.current?.value || '');
                 setOptionsVisibilityState(false);
                 setShowCloseIcon(inputRef.current?.value.length !== 0);
                 updateIsTyping(false);


### PR DESCRIPTION
affects: @medly-components/core

ISSUES CLOSED: #725

# PR Checklist

## Description
 fixed the SearchBox search trigger issue on option selection using the up-down arrow keys and enter key press.


### Type of change
<!-- Please check the one that applies to this PR using "x". -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes and API changes)
- [ ] Build changes
- [ ] CI changes
- [ ] Document content changes
- [ ] Performance improvement
- [ ] Add missing tests
- [ ] Others (please describe)


## How has this been tested?
(Replace This Text: Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration.)

[ ] Test A

[ ] Test B


## Fixes #725 


## What is the current behaviour?
when we select an option using the up-down arrow keys and press enter, it triggers the search event again.


## What is the new behaviour?
when we select an option using the up-down arrow keys and press enter, it will not trigger the search event.


## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

**Note:** (Replace This Text: If this PR contains a breaking change please describe the impact and migration path for existing application.)


## Checklist
<!-- Please check the one that applies to this PR using "x". -->

- [x] My code follows the style guidelines of this project

- [x] I have performed a self-review of my own code

- [ ] I have commented my code, particularly in hard-to-understand areas

- [ ] I have made corresponding changes to the documentation

- [ ] My changes generate no new warnings

- [x] I have added tests that prove my fix is effective or that my feature works

- [x] New and existing unit tests pass locally with my changes

- [ ] Any dependent changes have been merged and published in downstream modules
