### PR TITLE
fix(core): on blur event not removing focus properly able to open drop down using arrow key

### DIFF
--- a/packages/core/src/components/SingleSelect/SingleSelect.test.tsx
+++ b/packages/core/src/components/SingleSelect/SingleSelect.test.tsx
@@ -411,6 +411,15 @@ describe('SingleSelect component', () => {
                 fireEvent.keyDown(inputEl, { key: 'ArrowDown', code: 40 }); // will not shows the options
                 expect(screen.queryByRole('list')).not.toBeInTheDocument();
             });
+
+            it('should not show options on blur event', async () => {
+                render(<SingleSelect options={options} />);
+                const inputEl = screen.getByRole('textbox') as HTMLInputElement;
+                fireEvent.focus(inputEl);
+                fireEvent.blur(inputEl);
+                fireEvent.keyDown(inputEl, { key: 'ArrowDown', code: 40 }); // will not shows the options
+                expect(screen.queryByRole('list')).not.toBeInTheDocument();
+            });
         });
 
         describe('up arrow', () => {

--- a/packages/core/src/components/SingleSelect/SingleSelect.tsx
+++ b/packages/core/src/components/SingleSelect/SingleSelect.tsx
@@ -116,6 +116,13 @@ const Component: FC<SingleSelectProps> = memo(
                 },
                 [onFocus]
             ),
+            handleBlur = useCallback(
+                (event: React.FocusEvent<HTMLInputElement>) => {
+                    isFocused.current = false;
+                    onBlur?.(event);
+                },
+                [onBlur]
+            ),
             inputValidator = useCallback(() => '', []),
             handleKeyPress = useCallback((event: React.KeyboardEvent) => !isSearchable && event.preventDefault(), [isSearchable]);
 
@@ -151,7 +158,7 @@ const Component: FC<SingleSelectProps> = memo(
             helperText: inputProps.helperText,
             errorText: inputProps.errorText || builtInErrorMessage,
             onFocus: handleFocus,
-            onBlur,
+            onBlur: handleBlur,
             onKeyPress: handleKeyPress,
             disabled,
             showDecorators,


### PR DESCRIPTION
affects: @medly-components/core

ISSUES CLOSED: #728

# PR Checklist

## Description
triggering blur event not removing the Single Select focus, still able to open the drop-down using down arrow key.

### Type of change
<!-- Please check the one that applies to this PR using "x". -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes and API changes)
- [ ] Build changes
- [ ] CI changes
- [ ] Document content changes
- [ ] Performance improvement
- [ ] Add missing tests
- [ ] Others (please describe)


## How has this been tested?
(Replace This Text: Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration.)

[ ] Test A

[ ] Test B


## Fixes #728 


## What is the current behaviour?
able open drop-down using the down arrow key after the blur event triggered using ref


## What is the new behaviour?
will remove the focus on the blur event, and will not open dropdown.


## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

## Checklist
<!-- Please check the one that applies to this PR using "x". -->

- [x] My code follows the style guidelines of this project

- [x] I have performed a self-review of my own code

- [ ] I have commented my code, particularly in hard-to-understand areas

- [ ] I have made corresponding changes to the documentation

- [ ] My changes generate no new warnings

- [x] I have added tests that prove my fix is effective or that my feature works

- [x] New and existing unit tests pass locally with my changes

- [ ] Any dependent changes have been merged and published in downstream modules
