### PR TITLE
chore: use nx affected command to speed up the ci build

### DIFF
--- a/.github/workflows/lint-test-build.yml
+++ b/.github/workflows/lint-test-build.yml
@@ -6,8 +6,8 @@ on:
             - 'master'
 
 concurrency:
-  group: ${{ github.workflow }}-${{ github.ref }}
-  cancel-in-progress: true
+    group: ${{ github.workflow }}-${{ github.ref }}
+    cancel-in-progress: true
 
 jobs:
     lint-test-build:
@@ -33,10 +33,10 @@ jobs:
               run: yarn
 
             - name: Lint
-              run: yarn lint --since=origin/master
+              run: yarn nx affected -t lint --parallel
 
             - name: Test
-              run: yarn test --since=origin/master
+              run: yarn nx affected -t test --parallel
 
             - name: Build
-              run: yarn build --since=origin/master
+              run: yarn nx affected -t build

--- a/.github/workflows/lint-test-build.yml
+++ b/.github/workflows/lint-test-build.yml
@@ -33,10 +33,10 @@ jobs:
               run: yarn
 
             - name: Lint
-              run: yarn nx affected -t lint --parallel
+              run: yarn lint --since=origin/master
 
             - name: Test
-              run: yarn nx affected -t test --parallel
+              run: yarn test --since=origin/master
 
             - name: Build
-              run: yarn nx affected -t build
+              run: yarn build --since=origin/master

--- a/packages/core/src/components/Text/Text.tsx
+++ b/packages/core/src/components/Text/Text.tsx
@@ -1,8 +1,8 @@
 import { WithStyle } from '@medly-components/utils';
+import type { FC } from 'react';
 import { forwardRef, memo, useMemo } from 'react';
 import { TextStyled } from './Text.styled';
 import { TextProps } from './types';
-import type { FC } from 'react';
 
 const Component: FC<TextProps> = memo(
     forwardRef(({ as, textVariant, textWeight, textAlign, children, ...restProps }, ref) => {
@@ -35,7 +35,7 @@ Component.defaultProps = {
     uppercase: false,
     fullWidth: false,
     textColor: 'inherit',
-    textAlign: 'initial'
+    textAlign: 'left'
 };
 Component.displayName = 'Text';
 export const Text: FC<TextProps> & WithStyle = Object.assign(Component, { Style: TextStyled });


### PR DESCRIPTION
# PR Checklist

## Description
use nx affected command to speed up the ci build and run command in all the affected packages.

### Type of change
<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes and API changes)
- [ ] Build changes
- [ ] CI changes
- [ ] Document content changes
- [x] Performance improvement
- [ ] Add missing tests
- [ ] Others (please describe)


## How has this been tested?
(Replace This Text: Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration.)

[ ] Test A

[ ] Test B


## Fixes #<issue_number>


## What is the current behaviour?
(Replace This Text: Please describe the current behaviour you are modifying, or link a relevant issue.)


## What is the new behaviour?
(Replace This Text: Please describe the expected new behaviour.)


## Does this PR introduce a breaking change?

- [ ] Yes
- [ ] No

**Note:** (Replace This Text: If this PR contains a breaking change please describe the impact and migration path for existing application.)


## Additional context
(Replace This Text: Please describe any other related information or add screenshots of the PR.)


## Checklist
<!-- Please check the one that applies to this PR using "x". -->

- [ ] My code follows the style guidelines of this project

- [ ] I have performed a self-review of my own code

- [ ] I have commented my code, particularly in hard-to-understand areas

- [ ] I have made corresponding changes to the documentation

- [ ] My changes generate no new warnings

- [ ] I have added tests that prove my fix is effective or that my feature works

- [ ] New and existing unit tests pass locally with my changes

- [ ] Any dependent changes have been merged and published in downstream modules
